### PR TITLE
is_probably_readable() ゲートを除去し parse() の結果を常に使用する

### DIFF
--- a/src/fetch/extractor.rs
+++ b/src/fetch/extractor.rs
@@ -20,8 +20,6 @@ pub(super) fn extract_article(html: &str, url: Option<&str>) -> ExtractedArticle
         }
     };
 
-    let readable = readability.is_probably_readable();
-
     match readability.parse() {
         Ok(article) => {
             let title = if article.title.is_empty() {
@@ -30,22 +28,12 @@ pub(super) fn extract_article(html: &str, url: Option<&str>) -> ExtractedArticle
                 Some(article.title.to_string())
             };
 
-            if readable {
-                ExtractedArticle {
-                    title,
-                    byline: article.byline.map(|b| b.to_string()),
-                    published_time: article.published_time.map(|t| t.to_string()),
-                    content_html: article.content.to_string(),
-                    used_raw_fallback: false,
-                }
-            } else {
-                ExtractedArticle {
-                    title,
-                    byline: None,
-                    published_time: None,
-                    content_html: html.to_string(),
-                    used_raw_fallback: true,
-                }
+            ExtractedArticle {
+                title,
+                byline: article.byline.map(|b| b.to_string()),
+                published_time: article.published_time.map(|t| t.to_string()),
+                content_html: article.content.to_string(),
+                used_raw_fallback: false,
             }
         }
         Err(e) => {
@@ -136,11 +124,11 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_raw_on_minimal_html() {
+    fn uses_parsed_result_for_minimal_html() {
         let minimal = "<html><body><p>hi</p></body></html>";
         let result = extract_article(minimal, None);
 
-        assert!(result.used_raw_fallback);
+        assert!(!result.used_raw_fallback);
         assert!(result.content_html.contains("hi"));
     }
 
@@ -172,11 +160,11 @@ mod tests {
     }
 
     #[test]
-    fn fallback_still_extracts_title_from_minimal_html() {
+    fn extracts_title_from_minimal_html() {
         let html = "<html><head><title>Minimal Page</title></head><body><p>hi</p></body></html>";
         let result = extract_article(html, None);
 
-        assert!(result.used_raw_fallback);
+        assert!(!result.used_raw_fallback);
         assert_eq!(result.title, Some("Minimal Page".to_string()));
     }
 


### PR DESCRIPTION
## 概要

`extract_article` の `is_probably_readable()` ゲートを除去。readability のヒューリスティックが false を返すと、`parse()` が成功して構造化コンテンツを生成済みにもかかわらず raw HTML にフォールバックしていた。これにより、正常にパースできるページでも未処理の HTML が返されていた。

## 変更内容

- `readable` フラグと低スコア時に raw フォールバックへルーティングする条件分岐を除去 — `parse()` 成功時はヒューリスティックの結果にかかわらず常にパース結果を使用
- テスト2件（`falls_back_to_raw_on_minimal_html`, `fallback_still_extracts_title_from_minimal_html`）を修正後の挙動に更新: parse 成功時は minimal HTML でも `used_raw_fallback` が false

## スコープ

- **対象外**: `Err` パス — parse 失敗時の raw フォールバックは変更なし

## テスト方法

1. `cargo test -p scout` — extractor テストが全件パスすることを確認
2. readability ヒューリスティックが false を返すページ（短い記事等）を fetch し、raw HTML ではなくパース済みコンテンツが返ることを確認

Closes #4