### PR TITLE
全サブコマンドの --help に使用例と環境変数を追加

### DIFF
--- a/src/tools/params.rs
+++ b/src/tools/params.rs
@@ -19,6 +19,13 @@ pub enum Command {
 }
 
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  scout search \"Rust async patterns\"
+  scout search \"状態管理\" --lang ja
+
+Environment:
+  GEMINI_API_KEY  Required. Gemini API key for web search.")]
 pub struct SearchParams {
     /// Search query
     pub query: String,
@@ -28,6 +35,11 @@ pub struct SearchParams {
 }
 
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  scout fetch https://example.com
+  scout fetch https://example.com --js
+  scout fetch https://example.com --raw")]
 pub struct FetchParams {
     /// URL to fetch (must be HTTP or HTTPS)
     pub url: String,
@@ -40,6 +52,14 @@ pub struct FetchParams {
 }
 
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  scout research \"state management\"
+  scout research \"Rust error handling\" --depth 5
+  scout research \"型安全\" --lang ja --depth 3
+
+Environment:
+  GEMINI_API_KEY  Required. Gemini API key for web search.")]
 pub struct ResearchParams {
     /// Research query
     pub query: String,
@@ -52,6 +72,15 @@ pub struct ResearchParams {
 }
 
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  scout repo-tree facebook/react
+  scout repo-tree facebook/react --path src/
+  scout repo-tree facebook/react --pattern \"*.rs\"
+  scout repo-tree facebook/react --ref v18.0.0
+
+Environment:
+  GITHUB_TOKEN  Optional. Increases rate limit and enables private repos.")]
 pub struct RepoTreeParams {
     /// GitHub repository in "owner/repo" format (e.g., "facebook/react")
     pub repository: String,
@@ -67,6 +96,14 @@ pub struct RepoTreeParams {
 }
 
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  scout repo-read facebook/react README.md
+  scout repo-read facebook/react src/index.ts --lines 1-80
+  scout repo-read facebook/react Cargo.toml --ref main
+
+Environment:
+  GITHUB_TOKEN  Optional. Increases rate limit and enables private repos.")]
 pub struct RepoReadParams {
     /// GitHub repository in "owner/repo" format (e.g., "facebook/react")
     pub repository: String,
@@ -81,6 +118,13 @@ pub struct RepoReadParams {
 }
 
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  scout repo-overview facebook/react
+  scout repo-overview rust-lang/rust
+
+Environment:
+  GITHUB_TOKEN  Optional. Increases rate limit and enables private repos.")]
 pub struct RepoOverviewParams {
     /// GitHub repository in "owner/repo" format (e.g., "facebook/react")
     pub repository: String,


### PR DESCRIPTION
## 概要

全6サブコマンドの `--help` 出力に、使用例と環境変数のセクションを追加する。
エージェントが CLIの使い方をヘルプテキストから推論できるようにするための対応 (C-03 audit item)。

## 変更内容

- `src/tools/params.rs`: clap の `after_help` を使い、`search` / `fetch` / `research` / `repo-tree` / `repo-read` / `repo-overview` の全6コマンドに `Examples:` と `Environment:` セクションを追加

## 設計判断

- `after_help` を選択: フラグ一覧の後に表示されるため、既存のオプション説明と干渉しない
- 環境変数は必須 / 任意の区別 (`Required` / `Optional`) を明示し、エージェントが API キー不足を事前に検知できるようにした

## テスト手順

1. `cargo build` でビルドが通ることを確認
2. 各サブコマンドで `--help` を実行し、`Examples:` と `Environment:` セクションが表示されること
3. 既存の動作に変化がないことを確認 (ヘルプテキスト変更のみ、ロジック変更なし)

Closes #1