### PR TITLE
Slack返信permalinkでスレッド全体ではなく対象の返信を返す

### DIFF
--- a/src/slack/mod.rs
+++ b/src/slack/mod.rs
@@ -313,17 +313,11 @@ impl SlackClient {
             resolved.push(ResolvedMessage { author, text, ts });
         }
 
-        let (first, resolved) =
-            extract_target(resolved, &slack_url.ts, fetched.is_thread).ok_or_else(|| {
-                SlackError::Api {
-                    error: format!("message {} not found in thread", slack_url.ts),
-                }
+        let (first, resolved) = extract_target(resolved, &slack_url.ts, fetched.is_thread)
+            .ok_or_else(|| SlackError::Api {
+                error: format!("message {} not found in thread", slack_url.ts),
             })?;
-        let replies: &[ResolvedMessage] = if fetched.is_thread {
-            &resolved
-        } else {
-            &[]
-        };
+        let replies: &[ResolvedMessage] = if fetched.is_thread { &resolved } else { &[] };
         let output = format_slack_output(slack_url, &channel_name, &first, replies);
         info!(
             workspace = %slack_url.workspace,
@@ -490,7 +484,9 @@ mod tests {
             channel: "C123".into(),
             ts: "1111111111.222222".into(),
             thread_ts: Some("1234567890.123456".into()),
-            raw_url: "https://team.slack.com/archives/C123/p1111111111222222?thread_ts=1234567890.123456".into(),
+            raw_url:
+                "https://team.slack.com/archives/C123/p1111111111222222?thread_ts=1234567890.123456"
+                    .into(),
         };
         let reply = ResolvedMessage {
             author: "reply-author".into(),
@@ -547,10 +543,7 @@ parent body
 
     #[test]
     fn extract_target_returns_none_when_ts_missing() {
-        let messages = vec![
-            msg("1000.000000", "parent"),
-            msg("1001.000000", "reply-1"),
-        ];
+        let messages = vec![msg("1000.000000", "parent"), msg("1001.000000", "reply-1")];
         assert!(extract_target(messages, "9999.999999", true).is_none());
     }
 


### PR DESCRIPTION
## 概要

Slack返信permalink（`thread_ts` を含むURL）を `scout fetch` に渡すと、スレッド全体が返り親メッセージが主出力になっていた。この修正により、リンク先の返信を主メッセージとして返し、残りをコンテキストとして付加する。

Closes #14

## 変更内容

- `extract_target`: スレッドから `ts` 一致メッセージを選択する関数を切り出し（未発見時は `None` → エラー）
- 返信permalinkで `extract_target` を使い対象返信を主メッセージに、残りを `context_messages` に配置
- フロントマターフィールド `replies` → `context_messages` にリネーム（親メッセージの overcount 回避）
- `ts` フィールドに `escape_yaml` を適用（SEC-01: 一貫性確保）

## テスト

新規テスト6件:

| テスト | カバー範囲 |
| ---- | ------ |
| 返信permalink URLパーシング | URLから `thread_ts` 抽出 |
| format出力 exact match | 返信permalink時の完全出力形状 |
| `extract_target` — 一致あり | 正しいメッセージを返す |
| `extract_target` — 一致なし | `None` を返す |
| `extract_target` — 契約証明 | non-threadパスが ts を無視することを証明 |
| `parse_parent_permalink_with_thread_ts`（リネーム） | 既存テスト名の正確性修正 |