### PR TITLE
一時障害を retryable として分類し exit code セマンティクスを整理

### DIFF
--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -4,17 +4,23 @@ use tracing::warn;
 use crate::fetch::FetchError;
 use crate::gemini::client::GeminiError;
 use crate::github;
+use crate::retry::is_transient_network;
 use crate::slack::SlackError;
 
 #[derive(Debug)]
 pub struct ScoutError {
     message: String,
     exit_code: i32,
+    retryable: bool,
 }
 
 impl fmt::Display for ScoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
+        write!(f, "{}", self.message)?;
+        if self.retryable {
+            write!(f, " (temporary failure; retry may succeed)")?;
+        }
+        Ok(())
     }
 }
 
@@ -25,6 +31,7 @@ impl ScoutError {
         Self {
             message: msg.into(),
             exit_code: 1,
+            retryable: false,
         }
     }
 
@@ -32,11 +39,26 @@ impl ScoutError {
         Self {
             message: msg.into(),
             exit_code: 2,
+            retryable: false,
+        }
+    }
+
+    pub(super) fn transient(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            exit_code: 2,
+            retryable: true,
         }
     }
 
     pub fn exit_code(&self) -> i32 {
         self.exit_code
+    }
+
+    /// Whether the error is transient and the operation may succeed on retry.
+    #[allow(dead_code)] // public API for future --json output
+    pub fn retryable(&self) -> bool {
+        self.retryable
     }
 }
 
@@ -53,14 +75,32 @@ impl From<github::GitHubError> for ScoutError {
             | github::GitHubError::InvalidPath(_)
             | github::GitHubError::InvalidLineRange(_)
             | github::GitHubError::InvalidPattern(_) => Self::user_error(e.to_string()),
-            github::GitHubError::RateLimited => Self::user_error(e.to_string()),
+            github::GitHubError::RateLimited => Self::transient(e.to_string()),
             github::GitHubError::Forbidden(_) => Self::user_error(format!(
                 "{e} — check that your GITHUB_TOKEN has the required scopes"
             )),
-            github::GitHubError::Api { .. }
-            | github::GitHubError::Network(_)
-            | github::GitHubError::Decode(_) => Self::internal(e.to_string()),
+            github::GitHubError::Network(_) => Self::transient(e.to_string()),
+            github::GitHubError::Api { code, .. } if (500..=599).contains(code) => {
+                Self::transient(e.to_string())
+            }
+            github::GitHubError::Api { .. } | github::GitHubError::Decode(_) => {
+                Self::internal(e.to_string())
+            }
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FetchHttpKind {
+    Transient,
+    Permanent,
+}
+
+fn classify_fetch_http(transient: bool) -> FetchHttpKind {
+    if transient {
+        FetchHttpKind::Transient
+    } else {
+        FetchHttpKind::Permanent
     }
 }
 
@@ -74,11 +114,20 @@ impl From<FetchError> for ScoutError {
             | FetchError::RedirectMissingLocation => Self::user_error(e.to_string()),
             FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
             FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
-            FetchError::Timeout(_) | FetchError::DnsResolution(_) => Self::internal(e.to_string()),
-            FetchError::Http(_)
-            | FetchError::Status(_)
-            | FetchError::TooLarge
-            | FetchError::TooManyRedirects(_) => Self::internal(e.to_string()),
+            FetchError::Status(408 | 429) => Self::transient(e.to_string()),
+            FetchError::Status(code) if (400..500).contains(code) => {
+                Self::user_error(e.to_string())
+            }
+            FetchError::TooLarge | FetchError::TooManyRedirects(_) => {
+                Self::user_error(e.to_string())
+            }
+            FetchError::Status(_) | FetchError::Timeout(_) | FetchError::DnsResolution(_) => {
+                Self::transient(e.to_string())
+            }
+            FetchError::Http(re) => match classify_fetch_http(is_transient_network(re)) {
+                FetchHttpKind::Transient => Self::transient(e.to_string()),
+                FetchHttpKind::Permanent => Self::internal(e.to_string()),
+            },
         }
     }
 }
@@ -87,9 +136,8 @@ impl From<SlackError> for ScoutError {
     fn from(e: SlackError) -> Self {
         match &e {
             SlackError::TokenNotSet | SlackError::Api { .. } => Self::user_error(e.to_string()),
-            SlackError::Network(_) | SlackError::Timeout(_) | SlackError::Decode(_) => {
-                Self::internal(e.to_string())
-            }
+            SlackError::Network(_) | SlackError::Timeout(_) => Self::transient(e.to_string()),
+            SlackError::Decode(_) => Self::internal(e.to_string()),
         }
     }
 }
@@ -98,11 +146,15 @@ impl From<GeminiError> for ScoutError {
     fn from(e: GeminiError) -> Self {
         match &e {
             GeminiError::ApiKeyNotSet => Self::user_error(e.to_string()),
-            GeminiError::RateLimited => Self::user_error(e.to_string()),
+            GeminiError::RateLimited => Self::transient(e.to_string()),
             GeminiError::QuotaExhausted(_) => Self::user_error(format!(
                 "{e} — check your API billing at https://aistudio.google.com"
             )),
-            GeminiError::Api { .. } | GeminiError::Network(_) => Self::internal(e.to_string()),
+            GeminiError::Network(_) => Self::transient(e.to_string()),
+            GeminiError::Api { code, .. } if (500..=599).contains(code) => {
+                Self::transient(e.to_string())
+            }
+            GeminiError::Api { .. } => Self::internal(e.to_string()),
         }
     }
 }
@@ -130,7 +182,6 @@ mod tests {
     fn user_errors_have_exit_code_1() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::NotFound("/test".into()).into(),
-            github::GitHubError::RateLimited.into(),
             github::GitHubError::Forbidden("denied".into()).into(),
             github::GitHubError::InvalidRepo("bad".into()).into(),
             FetchError::InvalidScheme.into(),
@@ -138,13 +189,18 @@ mod tests {
             FetchError::UnsupportedContentType("image/png".into()).into(),
             FetchError::RedirectMissingLocation.into(),
             FetchError::BrowserNotFound("not installed".into()).into(),
+            FetchError::Status(400).into(),
+            FetchError::Status(404).into(),
+            FetchError::Status(403).into(),
+            FetchError::Status(499).into(),
+            FetchError::TooLarge.into(),
+            FetchError::TooManyRedirects(10).into(),
             SlackError::TokenNotSet.into(),
             SlackError::Api {
                 error: "err".into(),
             }
             .into(),
             GeminiError::ApiKeyNotSet.into(),
-            GeminiError::RateLimited.into(),
             GeminiError::QuotaExhausted("limit".into()).into(),
         ];
         for err in &cases {
@@ -156,27 +212,85 @@ mod tests {
     fn internal_errors_have_exit_code_2() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::Api {
-                code: 500,
-                message: "server error".into(),
+                code: 400,
+                message: "bad request".into(),
             }
             .into(),
             github::GitHubError::Decode("decode error".into()).into(),
             FetchError::BrowserFailed("CDP protocol error".into()).into(),
-            FetchError::Status(500).into(),
-            FetchError::TooLarge.into(),
-            FetchError::TooManyRedirects(10).into(),
-            SlackError::Network("err".into()).into(),
-            SlackError::Timeout("err".into()).into(),
             SlackError::Decode("err".into()).into(),
             GeminiError::Api {
-                code: 500,
+                code: 400,
                 message: "err".into(),
             }
             .into(),
         ];
         for err in &cases {
             assert_eq!(err.exit_code(), 2, "expected internal error (2): {err}");
+            assert!(!err.retryable(), "internal should not be retryable: {err}");
         }
+    }
+
+    #[test]
+    fn transient_errors_are_retryable() {
+        let cases: Vec<ScoutError> = vec![
+            FetchError::Status(408).into(),
+            FetchError::Status(429).into(),
+            FetchError::Status(500).into(),
+            FetchError::Status(503).into(),
+            FetchError::DnsResolution("dns failed".into()).into(),
+            FetchError::Timeout("timed out".into()).into(),
+            github::GitHubError::RateLimited.into(),
+            github::GitHubError::Api {
+                code: 502,
+                message: "bad gateway".into(),
+            }
+            .into(),
+            GeminiError::RateLimited.into(),
+            GeminiError::Api {
+                code: 503,
+                message: "unavailable".into(),
+            }
+            .into(),
+            SlackError::Network("err".into()).into(),
+            SlackError::Timeout("err".into()).into(),
+        ];
+        for err in &cases {
+            assert!(err.retryable(), "expected retryable: {err}");
+            assert_eq!(err.exit_code(), 2, "retryable should be exit 2: {err}");
+            assert!(
+                err.to_string().contains("retry may succeed"),
+                "should include retry hint: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_transient_errors_are_not_retryable() {
+        let cases: Vec<ScoutError> = vec![
+            FetchError::InvalidScheme.into(),
+            FetchError::Status(404).into(),
+            FetchError::BrowserFailed("err".into()).into(),
+            github::GitHubError::Decode("err".into()).into(),
+            SlackError::Decode("err".into()).into(),
+        ];
+        for err in &cases {
+            assert!(!err.retryable(), "expected not retryable: {err}");
+            assert!(
+                !err.to_string().contains("retry may succeed"),
+                "should not include retry hint: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_fetch_http_transient_input() {
+        assert_eq!(classify_fetch_http(true), FetchHttpKind::Transient);
+    }
+
+    #[test]
+    fn classify_fetch_http_permanent_input() {
+        assert_eq!(classify_fetch_http(false), FetchHttpKind::Permanent);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`ScoutError` に `retryable` フラグを追加し、ネットワーク障害・レート制限・5xx エラーを transient として再分類。呼び出し元がリトライ可否を判断できるようにする。

## 変更内容

- `ScoutError` に `retryable: bool` と `transient()` コンストラクタを追加。Display に `(temporary failure; retry may succeed)` ヒントを付与
- `FetchError::Status`: 408/429 と 5xx → transient、その他 4xx → user error (exit 1)
- `FetchError::Http`: `is_transient_network` を `FetchHttpKind` enum 経由で分岐（テスト可能な境界）
- `FetchError::Timeout` / `DnsResolution` → transient
- `GitHubError::RateLimited` / `Network` / `Api` 5xx → transient
- `GeminiError::RateLimited` / `Network` / `Api` 5xx → transient
- `SlackError::Network` / `Timeout` → transient
- テスト: transient/non-transient/classify_fetch_http/境界値カバレッジ

## 設計判断

- exit code は 2 のまま維持（新しい exit code は導入しない）。`retryable()` アクセサと Display ヒントでシグナルを伝達し、将来の `--json` 出力にも対応可能
- `FetchHttpKind` enum で `is_transient_network` の bool を名前付き型に変換し、match の意図を明示化 + ユニットテスト可能に

## テスト計画

- [ ] 429 レスポンス → exit 2 + `(temporary failure; retry may succeed)`
- [ ] 404 レスポンス → exit 1、リトライヒントなし
- [ ] `cargo test` → 181 テスト全通過

Closes #16, #39