### PR TITLE
JSON拒否、tracing フォールバック、タイムアウトコメント修正

### DIFF
--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -636,7 +636,6 @@ fn check_content_type(content_type: &str) -> Result<(), FetchError> {
         && !mime.starts_with("text/")
         && mime != "application/xhtml+xml"
         && mime != "application/xml"
-        && mime != "application/json"
     {
         return Err(FetchError::UnsupportedContentType(mime.to_string()));
     }
@@ -708,7 +707,6 @@ mod content_type_tests {
             "text/plain",
             "application/xhtml+xml",
             "application/xml",
-            "application/json",
             "; charset=utf-8", // edge: empty mime before semicolon → permissive
         ] {
             assert!(check_content_type(ct).is_ok(), "should accept: {ct}");
@@ -717,7 +715,7 @@ mod content_type_tests {
 
     #[test]
     fn rejects_non_textual_content_types() {
-        for ct in ["application/pdf", "image/png"] {
+        for ct in ["application/pdf", "image/png", "application/json"] {
             assert!(
                 matches!(
                     check_content_type(ct),

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,11 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("scout=info".parse().expect("valid tracing directive")),
+            tracing_subscriber::EnvFilter::from_default_env().add_directive(
+                "scout=info".parse().unwrap_or_else(|_| {
+                    tracing_subscriber::filter::Directive::from(tracing::Level::INFO)
+                }),
+            ),
         )
         .init();
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -31,7 +31,7 @@ impl From<&FetchParams> for FetchOptions {
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
-/// HTTP_TIMEOUT (30s) + PLAYWRIGHT_TIMEOUT (60s) + 5s margin.
+/// HTTP_TIMEOUT (30s) + CDP_TIMEOUT (60s) + 5s margin.
 const FETCH_TOOL_TIMEOUT: Duration = Duration::from_secs(95);
 const MAX_REDIRECTS: usize = 5;
 const OVERVIEW_ITEMS: u8 = 5;


### PR DESCRIPTION
## 概要

- `scout fetch` が `application/json` を HTML パイプラインに通していた問題を修正。"web page to clean Markdown" の契約に合わせて拒否するように変更 (#15)
- tracing 初期化の `expect` を `unwrap_or_else` フォールバックに置き換え、起動時 panic のリスクを除去 (#29)
- `FETCH_TOOL_TIMEOUT` のコメントで `PLAYWRIGHT_TIMEOUT` → `CDP_TIMEOUT` に修正 (#37)

## テスト計画

- [ ] `cargo test` → 181 テスト全通過
- [ ] `scout fetch` で JSON API URL を指定 → `UnsupportedContentType` エラー

Closes #15, #29, #37