### PR TITLE
Markdownへの外部入力をエスケープしてテーブル破壊・リンク注入を防ぐ

### DIFF
--- a/src/github/format.rs
+++ b/src/github/format.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use super::types::{IssueInfo, PullInfo, ReleaseInfo, RepoInfo, TreeEntry};
-use crate::markdown::{escape_md_link, shift_headings};
+use crate::markdown::{escape_md_inline, escape_md_link, shift_headings};
 
 const MAX_README_LINES: usize = 200;
 
@@ -48,10 +48,10 @@ pub(crate) fn format_overview(
     pulls: &[PullInfo],
     releases: &[ReleaseInfo],
 ) -> String {
-    let mut out = format!("# {}\n\n", repo.full_name);
+    let mut out = format!("# {}\n\n", escape_md_inline(&repo.full_name));
 
     if let Some(ref desc) = repo.description {
-        let _ = writeln!(out, "{desc}\n");
+        let _ = writeln!(out, "{}\n", escape_md_inline(desc));
     }
 
     format_metadata_table(repo, &mut out);
@@ -66,21 +66,25 @@ pub(crate) fn format_overview(
 fn format_metadata_table(repo: &RepoInfo, out: &mut String) {
     out.push_str("| Attribute | Value |\n|-----------|-------|\n");
     if let Some(ref lang) = repo.language {
-        let _ = writeln!(out, "| Language | {lang} |");
+        let _ = writeln!(out, "| Language | {} |", escape_md_inline(lang));
     }
     let _ = writeln!(out, "| Stars | {} |", repo.stargazers_count);
     let _ = writeln!(out, "| Forks | {} |", repo.forks_count);
     let _ = writeln!(out, "| Open Issues | {} |", repo.open_issues_count);
     if let Some(ref license) = repo.license {
         let name = license.spdx_id.as_deref().unwrap_or(&license.name);
-        let _ = writeln!(out, "| License | {name} |");
+        let _ = writeln!(out, "| License | {} |", escape_md_inline(name));
     }
-    let _ = writeln!(out, "| Default Branch | {} |", repo.default_branch);
+    let _ = writeln!(
+        out,
+        "| Default Branch | {} |",
+        escape_md_inline(&repo.default_branch)
+    );
     let topics = repo.topics.as_deref().unwrap_or(&[]);
     if !topics.is_empty() {
-        let _ = writeln!(out, "| Topics | {} |", topics.join(", "));
+        let _ = writeln!(out, "| Topics | {} |", escape_md_inline(&topics.join(", ")));
     }
-    let _ = writeln!(out, "| URL | {} |\n", repo.html_url);
+    let _ = writeln!(out, "| URL | {} |\n", escape_md_inline(&repo.html_url));
 }
 
 fn format_readme_section(readme: Option<&str>, out: &mut String) {
@@ -120,15 +124,15 @@ fn format_issues_section(issues: &[IssueInfo], out: &mut String) {
         let user = issue
             .user
             .as_ref()
-            .map(|u| format!(" — @{}", u.login))
+            .map(|u| format!(" — @{}", escape_md_inline(&u.login)))
             .unwrap_or_default();
         let _ = writeln!(
             out,
             "- [#{}]({}) {}{}{}",
             issue.number,
             escape_md_link(&issue.html_url),
-            issue.title,
-            labels,
+            escape_md_inline(&issue.title),
+            escape_md_inline(&labels),
             user
         );
     }
@@ -149,14 +153,14 @@ fn format_pulls_section(pulls: &[PullInfo], out: &mut String) {
         let user = pr
             .user
             .as_ref()
-            .map(|u| format!(" — @{}", u.login))
+            .map(|u| format!(" — @{}", escape_md_inline(&u.login)))
             .unwrap_or_default();
         let _ = writeln!(
             out,
             "- [#{}]({}) {}{}{}",
             pr.number,
             escape_md_link(&pr.html_url),
-            pr.title,
+            escape_md_inline(&pr.title),
             draft,
             user
         );
@@ -184,7 +188,7 @@ fn format_releases_section(releases: &[ReleaseInfo], out: &mut String) {
         let _ = writeln!(
             out,
             "- [{}]({}) — {}{}",
-            escape_md_link(name),
+            escape_md_inline(name),
             escape_md_link(&release.html_url),
             date,
             pre
@@ -379,7 +383,7 @@ mod tests {
             pull_request: None,
         }];
         let output = format_overview(&repo, None, &issues, &[], &[]);
-        assert!(output.contains("(bug, urgent)"));
+        assert!(output.contains(r"\(bug, urgent\)"));
         assert!(output.contains("@reporter"));
     }
 
@@ -410,5 +414,62 @@ mod tests {
             "h1 should shift to h3 even when truncated"
         );
         assert!(output.contains("truncated, 251 lines total"));
+    }
+
+    #[test]
+    fn format_overview_escapes_description_with_pipe() {
+        let mut repo = sample_repo();
+        repo.description = Some("col1 | col2".into());
+        let output = format_overview(&repo, None, &[], &[], &[]);
+        assert!(
+            !output.contains("col1 | col2"),
+            "raw pipe should be escaped"
+        );
+        assert!(output.contains(r"col1 \| col2"));
+    }
+
+    #[test]
+    fn format_overview_escapes_table_cell_metadata() {
+        let mut repo = sample_repo();
+        repo.language = Some("Rust | Go".into());
+        let output = format_overview(&repo, None, &[], &[], &[]);
+        assert!(output.contains(r"Rust \| Go"));
+    }
+
+    #[test]
+    fn format_overview_escapes_default_branch() {
+        let mut repo = sample_repo();
+        repo.default_branch = "feat|injection".into();
+        let output = format_overview(&repo, None, &[], &[], &[]);
+        assert!(output.contains(r"feat\|injection"));
+    }
+
+    #[test]
+    fn format_overview_escapes_issue_title() {
+        let repo = sample_repo();
+        let issues = vec![IssueInfo {
+            number: 1,
+            title: "bug [click](http://evil)".into(),
+            html_url: "https://github.com/o/r/issues/1".into(),
+            labels: vec![],
+            user: None,
+            pull_request: None,
+        }];
+        let output = format_overview(&repo, None, &issues, &[], &[]);
+        assert!(!output.contains("[click](http://evil)"));
+    }
+
+    #[test]
+    fn format_overview_escapes_pr_title() {
+        let repo = sample_repo();
+        let pulls = vec![PullInfo {
+            number: 1,
+            title: "feat | [link](http://evil)".into(),
+            html_url: "https://github.com/o/r/pull/1".into(),
+            draft: None,
+            user: None,
+        }];
+        let output = format_overview(&repo, None, &[], &pulls, &[]);
+        assert!(!output.contains("[link](http://evil)"));
     }
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -13,6 +13,23 @@ pub(crate) fn escape_md_link(s: &str) -> String {
     out
 }
 
+/// Sanitize untrusted input for embedding in Markdown table cells and inline text.
+/// Prevents column breaks (`|`), row breaks (newlines), and link injection (`[]()`).
+pub(crate) fn escape_md_inline(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '|' | '[' | ']' | '(' | ')' => {
+                out.push('\\');
+                out.push(c);
+            }
+            '\n' | '\r' => out.push(' '),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// Sanitize user input for embedding in a Markdown heading.
 /// Replaces newlines (which would break heading structure) with spaces.
 pub(crate) fn sanitize_heading(s: &str) -> String {
@@ -77,6 +94,26 @@ mod tests {
     fn escapes_special_chars() {
         assert_eq!(escape_md_link("normal text"), "normal text");
         assert_eq!(escape_md_link("a[b]c(d)e"), r"a\[b\]c\(d\)e");
+    }
+
+    #[test]
+    fn escape_md_inline_pipes_and_newlines() {
+        assert_eq!(escape_md_inline("col1 | col2"), r"col1 \| col2");
+        assert_eq!(escape_md_inline("line1\nline2"), "line1 line2");
+        assert_eq!(escape_md_inline("a\r\nb"), "a  b");
+    }
+
+    #[test]
+    fn escape_md_inline_link_syntax() {
+        assert_eq!(
+            escape_md_inline("[click](http://evil)"),
+            r"\[click\]\(http://evil\)"
+        );
+    }
+
+    #[test]
+    fn escape_md_inline_passthrough() {
+        assert_eq!(escape_md_inline("normal text"), "normal text");
     }
 
     #[test]

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -11,7 +11,9 @@ use crate::fetch::DnsResolver;
 use crate::fetch::converter::FetchResult;
 use crate::gemini::client::{GeminiError, SearchClient};
 use crate::gemini::types::{GroundedResult, Source};
-use crate::markdown::{escape_md_link, sanitize_heading, shift_headings, truncate_with_note};
+use crate::markdown::{
+    escape_md_inline, escape_md_link, sanitize_heading, shift_headings, truncate_with_note,
+};
 use crate::search::Lang;
 use crate::search::bilingual::expand_bilingual;
 
@@ -190,7 +192,7 @@ fn format_fetched_pages(pages: &[FetchResult], out: &mut String) {
     }
     out.push_str("---\n\n## Fetched Pages\n\n");
     for page in pages {
-        let _ = writeln!(out, "### {}\n", escape_md_link(&page.url));
+        let _ = writeln!(out, "### {}\n", sanitize_heading(&page.url));
         if page.used_raw_fallback {
             out.push_str(fetch::converter::RAW_FALLBACK_NOTE);
         }
@@ -208,7 +210,12 @@ fn format_failed_urls(failed: &[FailedUrl], out: &mut String) {
     }
     out.push_str("## Failed URLs\n\n");
     for f in failed {
-        let _ = writeln!(out, "- {} ({})", escape_md_link(&f.url), f.reason);
+        let _ = writeln!(
+            out,
+            "- {} ({})",
+            escape_md_link(&f.url),
+            escape_md_inline(&f.reason)
+        );
     }
     out.push('\n');
 }
@@ -222,7 +229,7 @@ fn format_sources(sources: &[Source], out: &mut String) {
         let _ = writeln!(
             out,
             "- [{}]({})",
-            escape_md_link(&source.title),
+            escape_md_inline(&source.title),
             escape_md_link(&source.url)
         );
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,7 +17,7 @@ use params::{
 use crate::fetch::{FetchOptions, TokioDnsResolver};
 use crate::gemini::client::{GeminiClient, GeminiError, SearchClient as _};
 use crate::github::{self, GitHubClient};
-use crate::markdown::{escape_md_link, shift_headings, truncate_with_note};
+use crate::markdown::{escape_md_inline, escape_md_link, shift_headings, truncate_with_note};
 use crate::search::engine;
 
 impl From<&FetchParams> for FetchOptions {
@@ -109,7 +109,7 @@ impl Scout {
             for source in &result.sources {
                 output.push_str(&format!(
                     "- [{}]({})\n",
-                    escape_md_link(&source.title),
+                    escape_md_inline(&source.title),
                     escape_md_link(&source.url)
                 ));
             }


### PR DESCRIPTION
Closes #17

## 概要

- `escape_md_inline()` 関数を `src/markdown.rs` に追加。`|`、`[`、`]`、`(`、`)` をバックスラッシュエスケープし、改行をスペースに置換する
- `repo-overview` 出力の全フィールド（リポジトリ名、説明文、言語、ライセンス、デフォルトブランチ、トピック、Issue/PRタイトル、ユーザー名）に適用
- 検索エンジンのソースタイトルと失敗URL理由文字列にも同エスケープを適用
- `format_fetched_pages` のURL見出しを `escape_md_link` から `sanitize_heading` に修正（URL文字列はリンク構文ではなくHeadingとして扱うため）

## テスト計画

- [ ] `cargo test` が全パス（ユニットテスト8件追加済み）
- [ ] `|` を含む説明文がテーブルを破壊しないことを確認
- [ ] `[text](url)` 形式のIssue/PRタイトルがリンク注入されないことを確認
- [ ] 改行を含むフィールドが単一行として出力されることを確認