### PR TITLE
parse_mentions / substitute_mentions のユニットテスト追加

### DIFF
--- a/src/slack/mod.rs
+++ b/src/slack/mod.rs
@@ -846,8 +846,7 @@ parent body
             Mock::given(method("GET"))
                 .and(path("/auth.test"))
                 .respond_with(
-                    ResponseTemplate::new(200)
-                        .set_body_json(serde_json::json!({"ok": true})),
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})),
                 )
                 .mount(&server)
                 .await;


### PR DESCRIPTION
## 概要

- `SlackClient::new` コンストラクタ追加（#32/#33）— 環境変数なしでテスト構築可能に
- `parse_mentions` / `substitute_mentions` の11件ユニットテスト追加: メンションなし、単一/複数、pipe-label、マルチバイト（CJK/emoji）バイトオフセット、known/unknown user 置換、コンストラクタ smoke test
- `msg.user == None` に `debug!`、`msg.ts == None` に `warn!` ログ追加（#34）

## テスト計画

- [ ] `cargo test --bin scout -- slack::tests` — mention / constructor テスト全通過
- [ ] `t006` マルチバイトオフセット（CJK 3-byte、emoji 4-byte）が正しいこと
- [ ] `t010_new_constructs_usable_client` が wiremock 経由で `Ok` を返すこと
- [ ] `cargo build` — クリーンビルド

Closes #32, Closes #33, Closes #34