### PR TITLE
fetched pagesの表示順を検索順位順に保持する

### DIFF
--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -495,9 +495,30 @@ mod tests {
     fn fetch_sources_sort_restores_input_order() {
         // Simulate buffer_unordered completion order (2,0,1) differing from input order (0,1,2)
         let mut indexed_pages: Vec<(usize, FetchResult)> = vec![
-            (2, FetchResult { url: "https://c.com".into(), markdown: String::new(), used_raw_fallback: false }),
-            (0, FetchResult { url: "https://a.com".into(), markdown: String::new(), used_raw_fallback: false }),
-            (1, FetchResult { url: "https://b.com".into(), markdown: String::new(), used_raw_fallback: false }),
+            (
+                2,
+                FetchResult {
+                    url: "https://c.com".into(),
+                    markdown: String::new(),
+                    used_raw_fallback: false,
+                },
+            ),
+            (
+                0,
+                FetchResult {
+                    url: "https://a.com".into(),
+                    markdown: String::new(),
+                    used_raw_fallback: false,
+                },
+            ),
+            (
+                1,
+                FetchResult {
+                    url: "https://b.com".into(),
+                    markdown: String::new(),
+                    used_raw_fallback: false,
+                },
+            ),
         ];
 
         indexed_pages.sort_by_key(|(idx, _)| *idx);


### PR DESCRIPTION
Closes #24

## 問題

`buffer_unordered(5)` は並列フェッチの完了順で結果を返すため、元の検索順位と表示順がズレていた。

## 変更内容

- `stream::iter` に `enumerate()` を追加し、各 URL に元インデックスを付与
- フェッチ完了後、`sort_by_key` でインデックス順に並べ直す
- 並列度は `buffer_unordered(5)` のまま維持（head-of-line blocking を避けるため `buffered(5)` は不採用）

## テスト

完了順がバラバラな入力 `(2, 0, 1)` を与えてソート後に `(0, 1, 2)` の順に並ぶことを確認するユニットテストを追加。
統合テストではなくソートロジック単体のテストにした理由: SSRF ガードがローカルの wiremock サーバーへの接続をブロックするため。