### PR TITLE
loopback bind不可環境でwiremockテストをgraceful skipする

### DIFF
--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -730,9 +730,10 @@ mod content_type_tests {
 #[cfg(test)]
 mod download_tests {
     use super::*;
+    use crate::test_support::try_spawn_mock_server;
     use std::net::IpAddr;
     use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, ResponseTemplate};
 
     fn no_redirect_client() -> Client {
         Client::builder()
@@ -751,7 +752,9 @@ mod download_tests {
 
     #[tokio::test]
     async fn download_success_returns_html() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/page"))
             .respond_with(
@@ -777,7 +780,9 @@ mod download_tests {
 
     #[tokio::test]
     async fn download_non_success_returns_status_error() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/404"))
             .respond_with(ResponseTemplate::new(404))
@@ -815,7 +820,9 @@ mod download_tests {
     #[tokio::test]
     async fn download_too_large_body_rejected() {
         let oversized = "x".repeat(MAX_RESPONSE_BYTES + 1);
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/huge"))
             .respond_with(ResponseTemplate::new(200).set_body_string(oversized))
@@ -835,7 +842,9 @@ mod download_tests {
 
     #[tokio::test]
     async fn download_rejects_non_html_content_type() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/binary"))
             .respond_with(
@@ -862,7 +871,9 @@ mod download_tests {
 
     #[tokio::test]
     async fn redirect_to_private_ip_blocked() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/redir"))
             .respond_with(
@@ -895,7 +906,9 @@ mod download_tests {
             }
         }
 
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/redir"))
             .respond_with(
@@ -920,7 +933,9 @@ mod download_tests {
 
     #[tokio::test]
     async fn too_many_redirects_returns_error() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/redir"))
             .respond_with(
@@ -945,7 +960,9 @@ mod download_tests {
 
     #[tokio::test]
     async fn redirect_missing_location_header_returns_error() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/bad-redir"))
             .respond_with(ResponseTemplate::new(302))
@@ -970,8 +987,9 @@ mod download_tests {
 #[cfg(test)]
 mod fetch_page_tests {
     use super::*;
+    use crate::test_support::try_spawn_mock_server;
     use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, ResponseTemplate};
 
     fn no_redirect_client() -> Client {
         Client::builder()
@@ -996,7 +1014,9 @@ mod fetch_page_tests {
     #[tokio::test]
     async fn js_flag_attempts_rendering_on_rich_body() {
         let content = "x".repeat(200);
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/rich"))
             .respond_with(

--- a/src/gemini/client.rs
+++ b/src/gemini/client.rs
@@ -232,12 +232,15 @@ mod tests {
 #[cfg(test)]
 mod http_tests {
     use super::*;
+    use crate::test_support::try_spawn_mock_server;
     use wiremock::matchers::{method, path_regex};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, ResponseTemplate};
 
     #[tokio::test]
     async fn search_success_returns_grounded_result() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("gemini::http").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -269,7 +272,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn search_429_returns_rate_limited() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("gemini::http").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(429))
@@ -283,7 +288,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn search_500_with_error_body_classified() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("gemini::http").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
@@ -307,7 +314,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn search_500_with_invalid_body_returns_generic_error() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("gemini::http").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(500).set_body_string("not json"))
@@ -329,7 +338,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn search_200_with_error_field_returns_classified_error() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("gemini::http").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -330,12 +330,15 @@ async fn resolve_token_with(env_reader: impl Fn(&str) -> Option<String>) -> Opti
 #[cfg(test)]
 mod http_tests {
     use super::*;
+    use crate::test_support::try_spawn_mock_server;
     use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, ResponseTemplate};
 
     #[tokio::test]
     async fn get_json_404_returns_not_found() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("github::get_json_404").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/repos/owner/repo"))
             .respond_with(ResponseTemplate::new(404))
@@ -349,7 +352,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn get_json_429_returns_rate_limited() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("github::http").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/repos/owner/repo"))
             .respond_with(ResponseTemplate::new(429))
@@ -363,7 +368,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn get_json_403_with_zero_remaining_returns_rate_limited() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("github::http").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/repos/owner/repo"))
             .respond_with(
@@ -381,7 +388,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn get_json_403_with_remaining_returns_forbidden() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("github::http").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/repos/owner/repo"))
             .respond_with(
@@ -415,7 +424,9 @@ mod http_tests {
 
     #[tokio::test]
     async fn get_json_500_returns_api_error() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("github::http").await else {
+            return;
+        };
         Mock::given(method("GET"))
             .and(path("/test"))
             .respond_with(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod redacted;
 mod retry;
 mod search;
 mod slack;
+#[cfg(test)]
+mod test_support;
 mod tools;
 
 pub const USER_AGENT: &str = concat!("scout/", env!("CARGO_PKG_VERSION"));

--- a/src/slack/mod.rs
+++ b/src/slack/mod.rs
@@ -539,13 +539,16 @@ mod tests {
 
     mod http_tests {
         use super::*;
+        use crate::test_support::try_spawn_mock_server;
         use reqwest::Client;
         use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use wiremock::{Mock, ResponseTemplate};
 
         #[tokio::test]
         async fn api_get_once_429_returns_rate_limited() {
-            let server = MockServer::start().await;
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
             Mock::given(method("GET"))
                 .and(path("/test.method"))
                 .respond_with(ResponseTemplate::new(429))
@@ -562,7 +565,9 @@ mod tests {
 
         #[tokio::test]
         async fn api_get_once_429_with_retry_after_header() {
-            let server = MockServer::start().await;
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
             Mock::given(method("GET"))
                 .and(path("/test.method"))
                 .respond_with(ResponseTemplate::new(429).append_header("Retry-After", "30"))
@@ -581,7 +586,9 @@ mod tests {
 
         #[tokio::test]
         async fn api_get_once_body_ratelimited_returns_rate_limited() {
-            let server = MockServer::start().await;
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
             Mock::given(method("GET"))
                 .and(path("/test.method"))
                 .respond_with(
@@ -598,7 +605,9 @@ mod tests {
 
         #[tokio::test]
         async fn api_get_once_api_error_returns_api_variant() {
-            let server = MockServer::start().await;
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
             Mock::given(method("GET"))
                 .and(path("/test.method"))
                 .respond_with(
@@ -841,13 +850,16 @@ parent body
 
     mod constructor_tests {
         use super::*;
+        use crate::test_support::try_spawn_mock_server;
         use reqwest::Client;
         use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
+        use wiremock::{Mock, ResponseTemplate};
 
         #[tokio::test]
         async fn t010_new_constructs_usable_client() {
-            let server = MockServer::start().await;
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
             Mock::given(method("GET"))
                 .and(path("/auth.test"))
                 .respond_with(

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,83 @@
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use wiremock::MockServer;
+
+static NETWORK_SKIP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Spawn a wiremock server, returning `None` if loopback bind is unavailable.
+pub async fn try_spawn_mock_server(test_name: &str) -> Option<MockServer> {
+    let force = std::env::var("SCOUT_NETWORK_TESTS").is_ok();
+    try_spawn_with_bind(test_name, TcpListener::bind("127.0.0.1:0"), force).await
+}
+
+/// Testable core: inject bind result and force flag to control skip-vs-panic.
+pub async fn try_spawn_with_bind(
+    test_name: &str,
+    bind_result: std::io::Result<TcpListener>,
+    force: bool,
+) -> Option<MockServer> {
+    match bind_result {
+        Ok(listener) => Some(MockServer::builder().listener(listener).start().await),
+        Err(e) => {
+            if force {
+                panic!(
+                    "[network-guard] {test_name}: bind failed and SCOUT_NETWORK_TESTS is set: {e}"
+                );
+            }
+            let count = NETWORK_SKIP_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+            tracing::warn!(
+                "[network-guard] {test_name}: loopback bind unavailable, early return ({count} skipped)"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use tracing_test::traced_test;
+
+    #[tokio::test]
+    async fn t001_try_spawn_mock_server_returns_some_in_normal_env() {
+        let Some(server) = try_spawn_mock_server("t001_normal_env").await else {
+            return; // bind unavailable — can't verify happy path
+        };
+
+        let uri = server.uri();
+        assert!(
+            uri.starts_with("http://127.0.0.1:"),
+            "MockServer URI should be on loopback: {uri}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn t004_bind_failure_without_force_returns_none_and_warns() {
+        let bind_err: io::Result<TcpListener> = Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "mock bind failure",
+        ));
+
+        let result = try_spawn_with_bind("t004_permission_denied", bind_err, false).await;
+
+        assert!(
+            result.is_none(),
+            "try_spawn_with_bind should return None on bind failure"
+        );
+        assert!(logs_contain("t004_permission_denied"));
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "t005_forced_panic")]
+    async fn t005_bind_failure_with_force_panics() {
+        let bind_err: io::Result<TcpListener> = Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "mock bind failure",
+        ));
+
+        let _result = try_spawn_with_bind("t005_forced_panic", bind_err, true).await;
+    }
+}

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -307,4 +307,43 @@ mod tests {
         let err = ScoutError::from(GeminiError::QuotaExhausted("limit".into()));
         assert!(err.to_string().contains("aistudio.google.com"));
     }
+
+    // TcpListener::drop is synchronous, so the port is immediately closed
+    // with no async shutdown race (unlike MockServer).
+    #[tokio::test]
+    async fn t003_fetch_error_http_connection_refused_is_transient() {
+        use reqwest::Client;
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let dead_url = format!("http://{addr}/should-refuse");
+
+        let client = Client::new();
+        let reqwest_err = client
+            .get(&dead_url)
+            .send()
+            .await
+            .expect_err("request to dead port should fail");
+
+        assert!(
+            is_transient_network(&reqwest_err),
+            "expected transient network error, got: {reqwest_err}"
+        );
+
+        let fetch_err = FetchError::Http(reqwest_err);
+        let scout_err = ScoutError::from(fetch_err);
+
+        assert!(
+            scout_err.retryable(),
+            "connection-refused FetchError::Http should produce transient ScoutError"
+        );
+        assert!(
+            scout_err.to_string().contains("retry may succeed"),
+            "transient error should contain retry hint: {}",
+            scout_err
+        );
+    }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -352,8 +352,9 @@ fn format_fetch_output(result: &crate::fetch::converter::FetchResult) -> String 
 mod tests {
     use super::*;
     use crate::search::Lang;
+    use crate::test_support::try_spawn_mock_server;
     use wiremock::matchers::{method, path_regex};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::{Mock, ResponseTemplate};
 
     fn scout_with_gemini(gemini_uri: &str) -> Scout {
         let http = Client::builder()
@@ -378,7 +379,9 @@ mod tests {
 
     #[tokio::test]
     async fn search_success_returns_content() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("tools::integration").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -420,7 +423,9 @@ mod tests {
 
     #[tokio::test]
     async fn research_success_returns_report() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("tools::integration").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -492,7 +497,9 @@ mod tests {
     /// the fallback message path in `search()`.
     #[tokio::test]
     async fn search_none_answer_returns_fallback() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("tools::integration").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -525,7 +532,9 @@ mod tests {
     /// [T-001] search standalone: answer with headings should have them shifted by 2
     #[tokio::test]
     async fn t_001_search_shifts_headings_in_answer() {
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("tools::integration").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -563,7 +572,9 @@ mod tests {
     #[tokio::test]
     async fn t_003_search_preserves_headings_in_code_blocks() {
         let answer = "# Real heading\n\n```bash\n# comment in script\n```\n\n## Another heading";
-        let server = MockServer::start().await;
+        let Some(server) = try_spawn_mock_server("tools::integration").await else {
+            return;
+        };
         Mock::given(method("POST"))
             .and(path_regex(r":generateContent$"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({


### PR DESCRIPTION
## 概要

Closes #21

29箇所のwiremock依存テストが、loopback port bindが制限される環境（CI、sandbox等）で `PermissionDenied` により失敗していた。共通 `test_support` モジュールを追加し、panicではなくgraceful skipで対応。

## 設計判断

**Y pattern（bind-then-pass）:** `TcpListener::bind` の結果を `MockServer::builder().listener()` に直接渡し、bindとserver起動の間のTOCTOUを排除。

**Feature gateではなくランタイムskip:** `Cargo.toml` やCI設定の変更不要。コードは常にコンパイルされ、bind不可時のみランタイムでskip。`SCOUT_NETWORK_TESTS` env var設定時はpanicで強制実行（opt-in strict mode）。

**`force: bool` の依存性注入:** `SCOUT_NETWORK_TESTS` env varは公開API（`try_spawn_mock_server`）で1回だけ読み取り、テスト可能な核（`try_spawn_with_bind`）には `bool` として注入。環境変数操作なしでテスト可能。

**`FetchError::Http` → `ScoutError` のe2eカバレッジ:** Issue #21で指摘されていた `From<FetchError> for ScoutError` のHttp分岐のe2e未検証を、connection-refusedによる統合テストで解消。

## テスト計画

- [ ] `cargo test` が通常環境でpass（全wiremockテスト実行）
- [ ] port制限環境でwiremockテストが `[network-guard]` warnログ付きで早期returnする
- [ ] `SCOUT_NETWORK_TESTS=1` でbind失敗時にpanicする
- [ ] `t004_bind_failure_without_force_returns_none_and_warns` でskip + ログ出力を検証
- [ ] `t005_bind_failure_with_force_panics` でstrict modeのpanicを検証
- [ ] `FetchError::Http` → `ScoutError` 変換をconnection-refusedでe2e検証