### PR TITLE
GitHub clientのlazy初期化とrepo-overviewのAPI呼び出しガード

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -797,11 +797,8 @@ mod tests {
 
         // Parallel: barrier(4) releases instantly → completes in ms.
         // Sequential: barrier never reaches 4 → deadlock → timeout.
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            s.repo_overview(params),
-        )
-        .await;
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(5), s.repo_overview(params)).await;
 
         assert!(
             result.is_ok(),


### PR DESCRIPTION
## 概要

- `Scout.github` を即時初期化の `GitHubClient` から
  `tokio::sync::OnceCell<GitHubClient>` に変更し、GitHubを使わないコマンド
  (search, fetch, research) が起動時の `gh auth token` サブプロセスコストを
  払わないようにした (#30)。
- `Scout::github()` アクセサを追加。`get_or_init` で初回のみ初期化し、
  以降はキャッシュされた値を返す。
- `repo_overview` で `get_repo` を先に呼び出し、エラー時は早期リターン。
  存在しないリポジトリへの4本の並列APIコール (readme, issues, pulls, releases)
  を防止 (#18)。

## テスト計画

- [ ] T-001: `get_repo` が404 → 他4 APIへのリクエストが0件 (wiremock `expect(0)`)
- [ ] T-002: barrier同期で4 APIの並列実行を証明。逐次実装ならデッドロック
- [ ] T-003: `scout_lazy` 構築直後に `OnceCell` が未初期化
- [ ] T-004: `search` コマンド実行後も `OnceCell` が未初期化
- [ ] T-005: `fetch` コマンド実行後も `OnceCell` が未初期化
- [ ] T-006: `research` コマンド実行後も `OnceCell` が未初期化
- [ ] T-007: `github()` 2回呼び出しで同一ポインタ (キャッシュ確認)
- [ ] T-007b: 空のセルに対する `github()` が `from_env` 経由で初期化し、以降は同一参照