### PR TITLE
chore(ci): dependabot 設定で github-actions と cargo の自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## 概要

dependabot を設定して GitHub Actions / Cargo 依存の自動更新 PR を受け取れるようにする。

Closes #65

## 変更内容

- `.github/dependabot.yml` を新規追加
  - `github-actions`: weekly 監視、ラベル `dependencies` / `ci`
  - `cargo`: weekly 監視、ラベル `dependencies` / `rust`、minor/patch は `patch-and-minor` グループで 1 PR にまとめる (major は個別 PR)
  - commit-message prefix は `chore`

## 検証

- `cargo build` 成功（Cargo.lock の transitive update なし）
- ラベル `dependencies` / `ci` / `rust` は repository に既存（事前 `gh label create` 不要）

## 受け入れ基準

- [x] `.github/dependabot.yml` が追加されている
- [x] ラベル `dependencies` / `ci` / `rust` が repository に存在
- [ ] GitHub Dependabot が設定を認識し、weekly で更新 PR を立てる（マージ後に Insights → Dependency graph → Dependabot で確認）