### PR TITLE
feat(cli): stdout 書き込みで BrokenPipe を gracefully に扱う (ADR-0060 Phase 1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,19 @@ mod tools;
 
 pub(crate) const USER_AGENT: &str = concat!("scout/", env!("CARGO_PKG_VERSION"));
 
-use std::io::stderr;
+use std::io::{self, ErrorKind, Write, stderr, stdout};
 use std::process::ExitCode;
 
 use clap::Parser;
 use tools::{Command, Scout};
+
+fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
+    w.write_all(output.as_bytes())?;
+    if !output.ends_with('\n') {
+        w.write_all(b"\n")?;
+    }
+    Ok(())
+}
 
 #[derive(Parser)]
 #[command(
@@ -63,11 +71,15 @@ pub async fn run() -> ExitCode {
 
     match scout.run(cli.command).await {
         Ok(output) => {
-            print!("{output}");
-            if !output.ends_with('\n') {
-                println!();
+            let mut handle = stdout().lock();
+            match write_output(&mut handle, &output) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::from(2)
+                }
             }
-            ExitCode::SUCCESS
         }
         Err(e) => {
             eprintln!("error: {e}");
@@ -78,7 +90,44 @@ pub async fn run() -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{self, Write};
+
     use clap::CommandFactory;
+
+    use super::write_output;
+
+    /// [T-W001] write_output appends newline when output lacks trailing newline
+    #[test]
+    fn t_w001_write_output_appends_newline_when_missing() {
+        let mut buf = Vec::new();
+        write_output(&mut buf, "hello").unwrap();
+        assert_eq!(&buf, b"hello\n");
+    }
+
+    /// [T-W002] write_output preserves single trailing newline
+    #[test]
+    fn t_w002_write_output_preserves_existing_newline() {
+        let mut buf = Vec::new();
+        write_output(&mut buf, "hello\n").unwrap();
+        assert_eq!(&buf, b"hello\n");
+    }
+
+    /// [T-W003] write_output propagates BrokenPipe error from writer
+    #[test]
+    fn t_w003_write_output_propagates_broken_pipe() {
+        struct BrokenPipeWriter;
+        impl Write for BrokenPipeWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::from(io::ErrorKind::BrokenPipe))
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+        let mut w = BrokenPipeWriter;
+        let err = write_output(&mut w, "hello").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
 
     /// [T-H000] root --help contains Exit codes: and Environment: sections
     #[test]


### PR DESCRIPTION
## 概要

ADR-0060 (agent-friendly CLI 設計原則) Phase 1 として、`scout` の stdout 出力経路で `ErrorKind::BrokenPipe` を捕捉し `ExitCode::SUCCESS` を返すようにする。

`scout ... | head` のような pipe 運用で受け側が早期終了したとき、`print!`/`println!` 直接呼び出しでは SIGPIPE 由来の panic / 異常 exit が発生していた。BrokenPipe を graceful に扱うことで、agent-friendly CLI の機械可読軸の前提条件 (パイプ運用で安定した動作) を満たす。

Refs #67

## 変更内容

- `write_output<W: Write>` ヘルパーを `src/lib.rs` に追加
  - `Write` 抽象 (テストで mock writer を渡せる)
  - 末尾改行が無い場合に追加
- `run()` を `stdout().lock()` + `write_output` 経由に切り替え
  - `ErrorKind::BrokenPipe` → `ExitCode::SUCCESS` で graceful exit
  - 他の IO error は exit code 2 (既存 internal error と同等) + stderr に error 出力
- unit test 3 件を追加
  - T-W001: 改行なし入力に改行を付与
  - T-W002: 既存の単一改行を保持
  - T-W003: BrokenPipe を Writer から伝播 (`Vec<u8>` は決して error を返さないため、専用の `BrokenPipeWriter` test double で確定的に再現)

## 検証

- `cargo test`: lib 296 件 (T-W001/T-W002/T-W003 を含む 293 → 296) + integration 5 件 = 全 301 件 pass
- `cargo clippy --all-targets --all-features -- -D warnings`: warning なし
- `/polish` (Codex + CodeRabbit + simplify 3 reviewers + enhancer-code) で 0 actionable findings

## Phase 計画 (参考)

| Phase | 内容 | 状態 |
| --- | --- | --- |
| 1 | 非破壊・低リスク (BrokenPipe handling) | 本 PR |
| 2 | `--json` global flag + 構造化エラー JSON (ADR-0061 候補) | 未着手 |
| 3 | sysexits.h 6 種 exit code 拡張 (破壊的) | 未着手 |
| 4 | Noun-Verb 命名統一 (議論先行) | 未着手 |

`conflicts_with` parse-time バリデーションは現コマンドに論理矛盾するペアが見当たらないため、Phase 2 で `--json` 等の新規 global flag 導入時に同時適用する方針。

## 受け入れ基準

- [x] BrokenPipe で SIGPIPE 由来の panic / 異常 exit が起きない
- [x] 既存テスト (293 件) すべて pass
- [x] 新規 BrokenPipe path の unit test (T-W003) で確定的に再現
- [x] clippy / lint clean