### PR TITLE
feat(envelope): ADR-0065 準拠の JSON 出力型を追加 (Phase 2.1)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,0 +1,182 @@
+//! Output envelopes per ADR-0065 (scout JSON output schema).
+//!
+//! Production wiring lands in Phase 2.2 (`--json` global flag); Phase 2.1
+//! exposes the types so `ScoutError::error_kind()` can classify against them.
+
+use serde::Serialize;
+
+/// JSON-serializable error classification per ADR-0065.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum ErrorCode {
+    UsageError,
+    DataError,
+    NotFound,
+    IoError,
+    TempFailure,
+}
+
+/// Success envelope wrapping command output per ADR-0065.
+#[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
+#[derive(Debug, Serialize)]
+pub(crate) struct SuccessEnvelope {
+    pub data: serde_json::Value,
+    pub degraded: bool,
+    pub notes: Vec<String>,
+}
+
+/// Error envelope per ADR-0065. Wraps the payload under an `error` key so
+/// JSON output matches `{"error": { "code": ..., "message": ..., ... }}`.
+#[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorEnvelope {
+    pub error: ErrorPayload,
+}
+
+/// Error payload nested under `ErrorEnvelope::error` per ADR-0065.
+#[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
+#[derive(Debug, Serialize)]
+pub(crate) struct ErrorPayload {
+    pub code: ErrorCode,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_step: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<String>,
+    pub retryable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [T-EN002] ErrorPayload omits next_step when None
+    #[test]
+    fn t_en002_error_payload_omits_optional_next_step() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: String::from("Missing query"),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !json.contains("next_step"),
+            "next_step should be omitted when None, got: {json}"
+        );
+    }
+
+    /// [T-EN003] ErrorPayload omits candidates when empty
+    #[test]
+    fn t_en003_error_payload_omits_empty_candidates() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: String::from("invalid"),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            !json.contains("candidates"),
+            "candidates should be omitted when empty, got: {json}"
+        );
+    }
+
+    /// [T-EN004] ErrorPayload includes next_step and candidates when present
+    #[test]
+    fn t_en004_error_payload_includes_present_optional_fields() {
+        let payload = ErrorPayload {
+            code: ErrorCode::UsageError,
+            message: String::from("did you mean"),
+            next_step: Some(String::from("Pass <QUERY>")),
+            candidates: vec![String::from("query"), String::from("queries")],
+            retryable: false,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(
+            json.contains(r#""next_step":"Pass <QUERY>""#),
+            "got: {json}"
+        );
+        assert!(
+            json.contains(r#""candidates":["query","queries"]"#),
+            "got: {json}"
+        );
+    }
+
+    /// [T-EN007] ErrorEnvelope wraps payload under `error` key per ADR-0065
+    #[test]
+    fn t_en007_error_envelope_wraps_payload_under_error_key() {
+        let env = ErrorEnvelope {
+            error: ErrorPayload {
+                code: ErrorCode::UsageError,
+                message: String::from("Missing query"),
+                next_step: None,
+                candidates: vec![],
+                retryable: false,
+            },
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.starts_with(r#"{"error":"#),
+            "envelope should start with `{{\"error\":` per ADR-0065, got: {json}"
+        );
+        assert!(
+            json.contains(r#""code":"USAGE_ERROR""#),
+            "payload should contain code, got: {json}"
+        );
+    }
+
+    /// [T-EN005] SuccessEnvelope serializes data + degraded + notes
+    #[test]
+    fn t_en005_success_envelope_serializes_required_fields() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!({"markdown": "hello"}),
+            degraded: false,
+            notes: vec![],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.contains(r#""data":{"markdown":"hello"}"#),
+            "got: {json}"
+        );
+        assert!(json.contains(r#""degraded":false"#), "got: {json}");
+        assert!(json.contains(r#""notes":[]"#), "got: {json}");
+    }
+
+    /// [T-EN006] SuccessEnvelope surfaces degraded=true with notes
+    #[test]
+    fn t_en006_success_envelope_surfaces_degradation() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!(null),
+            degraded: true,
+            notes: vec![String::from("Could not fetch contributors")],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(json.contains(r#""degraded":true"#), "got: {json}");
+        assert!(
+            json.contains(r#""notes":["Could not fetch contributors"]"#),
+            "got: {json}"
+        );
+    }
+
+    /// [T-EN001] ErrorCode serializes per ADR-0065 SCREAMING_SNAKE_CASE
+    #[test]
+    fn t_en001_error_code_serializes_screaming_snake_case() {
+        let pairs = [
+            (ErrorCode::UsageError, r#""USAGE_ERROR""#),
+            (ErrorCode::DataError, r#""DATA_ERROR""#),
+            (ErrorCode::NotFound, r#""NOT_FOUND""#),
+            (ErrorCode::IoError, r#""IO_ERROR""#),
+            (ErrorCode::TempFailure, r#""TEMP_FAILURE""#),
+        ];
+        for (code, expected) in pairs {
+            let actual = serde_json::to_string(&code).unwrap();
+            assert_eq!(
+                actual, expected,
+                "code {code:?} should serialize as {expected}"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod envelope;
 mod fetch;
 mod gemini;
 mod github;

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt;
 use tracing::warn;
 
+use crate::envelope::ErrorCode;
 use crate::fetch::FetchError;
 use crate::gemini::client::GeminiError;
 use crate::github;
@@ -13,6 +14,7 @@ pub struct ScoutError {
     message: String,
     exit_code: i32,
     retryable: bool,
+    kind: ErrorCode,
 }
 
 impl fmt::Display for ScoutError {
@@ -33,6 +35,7 @@ impl ScoutError {
             message: msg.into(),
             exit_code: 1,
             retryable: false,
+            kind: ErrorCode::UsageError,
         }
     }
 
@@ -41,6 +44,7 @@ impl ScoutError {
             message: msg.into(),
             exit_code: 2,
             retryable: false,
+            kind: ErrorCode::IoError,
         }
     }
 
@@ -49,6 +53,25 @@ impl ScoutError {
             message: msg.into(),
             exit_code: 2,
             retryable: true,
+            kind: ErrorCode::TempFailure,
+        }
+    }
+
+    pub(super) fn not_found(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            exit_code: 1,
+            retryable: false,
+            kind: ErrorCode::NotFound,
+        }
+    }
+
+    pub(super) fn data_error(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            exit_code: 1,
+            retryable: false,
+            kind: ErrorCode::DataError,
         }
     }
 
@@ -61,6 +84,12 @@ impl ScoutError {
     pub fn retryable(&self) -> bool {
         self.retryable
     }
+
+    /// JSON-serializable error classification per ADR-0065.
+    #[allow(dead_code)] // public API for future --json output
+    pub fn error_kind(&self) -> ErrorCode {
+        self.kind
+    }
 }
 
 pub(super) fn parse_repo_param(repository: &str) -> Result<(&str, &str), ScoutError> {
@@ -70,13 +99,13 @@ pub(super) fn parse_repo_param(repository: &str) -> Result<(&str, &str), ScoutEr
 impl From<github::GitHubError> for ScoutError {
     fn from(e: github::GitHubError) -> Self {
         match &e {
-            github::GitHubError::NotFound(_)
-            | github::GitHubError::InvalidRepo(_)
+            github::GitHubError::NotFound(_) => Self::not_found(e.to_string()),
+            github::GitHubError::InvalidRepo(_)
             | github::GitHubError::InvalidRef(_)
             | github::GitHubError::InvalidPath(_)
             | github::GitHubError::InvalidLineRange(_)
             | github::GitHubError::InvalidPattern(_)
-            | github::GitHubError::NonUtf8(_) => Self::user_error(e.to_string()),
+            | github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string()),
             github::GitHubError::RateLimited { .. } => Self::transient(e.to_string()),
             github::GitHubError::Forbidden(_) => Self::user_error(format!(
                 "{e} — check that your GITHUB_TOKEN has the required scopes"
@@ -113,15 +142,17 @@ impl From<FetchError> for ScoutError {
             | FetchError::InvalidUrl(_)
             | FetchError::InternalHost
             | FetchError::UnsupportedContentType(_)
-            | FetchError::RedirectMissingLocation => Self::user_error(e.to_string()),
+            | FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
             FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
             FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
             FetchError::Status(408 | 429) => Self::transient(e.to_string()),
+            FetchError::Status(404) => Self::not_found(e.to_string()),
+            FetchError::Status(401 | 403) => Self::user_error(e.to_string()),
             FetchError::Status(code) if (400..500).contains(code) => {
-                Self::user_error(e.to_string())
+                Self::data_error(e.to_string())
             }
             FetchError::TooLarge | FetchError::TooManyRedirects(_) => {
-                Self::user_error(e.to_string())
+                Self::data_error(e.to_string())
             }
             FetchError::Status(_) | FetchError::Timeout(_) | FetchError::DnsResolution(_) => {
                 Self::transient(e.to_string())
@@ -181,6 +212,55 @@ pub(super) fn unwrap_or_note<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [T-ER010] user_error returns ErrorCode::UsageError
+    #[test]
+    fn t_er010_user_error_kind_is_usage() {
+        let err = ScoutError::user_error("test");
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+    }
+
+    /// [T-ER011] transient returns ErrorCode::TempFailure
+    #[test]
+    fn t_er011_transient_kind_is_temp_failure() {
+        let err = ScoutError::transient("test");
+        assert_eq!(err.error_kind(), ErrorCode::TempFailure);
+    }
+
+    /// [T-ER012] internal returns ErrorCode::IoError
+    #[test]
+    fn t_er012_internal_kind_is_io_error() {
+        let err = ScoutError::internal("test");
+        assert_eq!(err.error_kind(), ErrorCode::IoError);
+    }
+
+    /// [T-ER013] GitHubError::NotFound classifies as ErrorCode::NotFound
+    #[test]
+    fn t_er013_github_not_found_classifies_as_not_found() {
+        let err = ScoutError::from(github::GitHubError::NotFound("/test".into()));
+        assert_eq!(err.error_kind(), ErrorCode::NotFound);
+    }
+
+    /// [T-ER014] GitHubError::InvalidRepo classifies as ErrorCode::DataError
+    #[test]
+    fn t_er014_github_invalid_repo_classifies_as_data_error() {
+        let err = ScoutError::from(github::GitHubError::InvalidRepo("bad".into()));
+        assert_eq!(err.error_kind(), ErrorCode::DataError);
+    }
+
+    /// [T-ER015] FetchError::InvalidScheme classifies as ErrorCode::DataError
+    #[test]
+    fn t_er015_fetch_invalid_scheme_classifies_as_data_error() {
+        let err = ScoutError::from(FetchError::InvalidScheme);
+        assert_eq!(err.error_kind(), ErrorCode::DataError);
+    }
+
+    /// [T-ER016] FetchError::Status(404) classifies as ErrorCode::NotFound
+    #[test]
+    fn t_er016_fetch_status_404_classifies_as_not_found() {
+        let err = ScoutError::from(FetchError::Status(404));
+        assert_eq!(err.error_kind(), ErrorCode::NotFound);
+    }
 
     /// [T-ER001] User-facing errors surface with exit code 1
     #[test]


### PR DESCRIPTION
## 概要

[ADR-0065](https://github.com/thkt/scout/issues/67) Phase 2.1: JSON envelope types と error classification の追加。`--json` flag への wiring は Phase 2.2 で対応。既存の Markdown 出力経路は影響なし。

## 変更点

| File | Type | Summary |
|------|------|---------|
| `src/envelope.rs` | new | `ErrorCode` enum (5 variants, SCREAMING_SNAKE_CASE), `SuccessEnvelope` / `ErrorPayload` / `ErrorEnvelope` structs (serde::Serialize) |
| `src/lib.rs` | mod | `mod envelope;` 追加 |
| `src/tools/errors.rs` | feat | `error_kind()` メソッド, `not_found()` / `data_error()` コンストラクタ, `From<GitHubError>` / `From<FetchError>` の分類精度向上 |

## エラー分類

`ScoutError::error_kind()` が ADR-0065 の sysexits.h 6 種への分類を返す:

| ErrorCode | scout source | sysexits (Phase 3) |
|-----------|--------------|---------------------|
| `USAGE_ERROR` | clap parse error, conflicts_with violation | EX_USAGE (64) |
| `DATA_ERROR` | URL/owner/repo malformed, encoding不正 | EX_DATAERR (65) |
| `NOT_FOUND` | repo/file not found, 404 | EX_NOINPUT (66) |
| `IO_ERROR` | network IO, write failure | EX_IOERR (74) |
| `TEMP_FAILURE` | rate limit, 5xx, retryable | EX_TEMPFAIL (75) |

## 非破壊的変更

- `error_kind()` は新規メソッド (既存 API 変更なし)
- envelope 型は Phase 2.2 で消費 (現状 `#[allow(dead_code)]`)
- 既存テスト 312 件 (307 lib + 5 integration) すべて pass
- clippy --all-targets --all-features -- -D warnings clean

## Phase ロードマップ

| Phase | Scope | Status |
|-------|-------|--------|
| 1 | BrokenPipe handling (#74) | ✅ merged |
| **2.1** | **JSON types + error classification** | **このPR** |
| 2.2 | `--json` global flag wiring | next PR |
| 3 | sysexits exit code expansion (major bump) | future |

## テスト計画

- [x] `cargo test` (312 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] /polish review (Codex P2 finding: ErrorEnvelope outer wrapping → fixed)
- [x] T-EN001~007 (envelope serialization)
- [x] T-ER010~016 (error_kind classification)

Closes part of #67 (Phase 2.1 only, full closure after Phase 2.2)

References:
- ADR-0065: scout JSON output schema and sysexits exit code policy
- Phase 1 PR: #74