### PR TITLE
ADR-0065 準拠の --json フラグと CommandOutput envelope を配線

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,9 +1,44 @@
 //! Output envelopes per ADR-0065 (scout JSON output schema).
 //!
-//! Production wiring lands in Phase 2.2 (`--json` global flag); Phase 2.1
-//! exposes the types so `ScoutError::error_kind()` can classify against them.
+//! `CommandOutput` is the internal shape produced by each command handler;
+//! `lib::run` then serializes it as Markdown (default) or as a `SuccessEnvelope`
+//! JSON line (when `--json` is set).
 
 use serde::Serialize;
+
+/// Internal command output: holds both the Markdown rendering and the
+/// structured `data` payload, plus degradation signals. Each handler builds
+/// one of these; `lib::run` picks the path (Markdown or JSON) at the boundary.
+#[derive(Debug)]
+pub(crate) struct CommandOutput {
+    pub markdown: String,
+    pub data: serde_json::Value,
+    pub notes: Vec<String>,
+    pub degraded: bool,
+}
+
+impl CommandOutput {
+    /// Construct an output with no degradation signal (notes empty, degraded=false).
+    pub fn ok(markdown: String, data: serde_json::Value) -> Self {
+        Self {
+            markdown,
+            data,
+            notes: Vec::new(),
+            degraded: false,
+        }
+    }
+
+    /// Construct an output with degradation notes; `degraded` is set iff `notes` is non-empty.
+    pub fn with_notes(markdown: String, data: serde_json::Value, notes: Vec<String>) -> Self {
+        let degraded = !notes.is_empty();
+        Self {
+            markdown,
+            data,
+            notes,
+            degraded,
+        }
+    }
+}
 
 /// JSON-serializable error classification per ADR-0065.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -159,6 +194,36 @@ mod tests {
             json.contains(r#""notes":["Could not fetch contributors"]"#),
             "got: {json}"
         );
+    }
+
+    /// [T-EN008] CommandOutput::ok produces non-degraded with empty notes
+    #[test]
+    fn t_en008_command_output_ok_is_not_degraded() {
+        let out = CommandOutput::ok(String::from("md"), serde_json::json!({"a": 1}));
+        assert_eq!(out.markdown, "md");
+        assert_eq!(out.data, serde_json::json!({"a": 1}));
+        assert!(out.notes.is_empty());
+        assert!(!out.degraded);
+    }
+
+    /// [T-EN009] CommandOutput::with_notes sets degraded=true when notes non-empty
+    #[test]
+    fn t_en009_command_output_with_notes_is_degraded() {
+        let out = CommandOutput::with_notes(
+            String::from("md"),
+            serde_json::Value::Null,
+            vec![String::from("partial fetch")],
+        );
+        assert!(out.degraded);
+        assert_eq!(out.notes, vec!["partial fetch"]);
+    }
+
+    /// [T-EN010] CommandOutput::with_notes sets degraded=false when notes empty
+    #[test]
+    fn t_en010_command_output_with_empty_notes_is_not_degraded() {
+        let out =
+            CommandOutput::with_notes(String::from("md"), serde_json::Value::Null, Vec::new());
+        assert!(!out.degraded);
     }
 
     /// [T-EN001] ErrorCode serializes per ADR-0065 SCREAMING_SNAKE_CASE

--- a/src/fetch/converter.rs
+++ b/src/fetch/converter.rs
@@ -1,12 +1,16 @@
 use std::fmt::Write;
 
+use serde::Serialize;
+
 use super::extractor::ExtractedArticle;
 
 /// Fetched page content converted to Markdown.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub(crate) struct FetchResult {
     pub url: String,
     pub markdown: String,
+    /// Internal flag: surfaced as a `notes` entry in scout's JSON output, not as data.
+    #[serde(skip_serializing)]
     pub used_raw_fallback: bool,
 }
 

--- a/src/gemini/types.rs
+++ b/src/gemini/types.rs
@@ -64,13 +64,13 @@ pub(crate) struct ApiError {
 }
 
 /// LLM answer with grounding sources from Google Search.
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub(crate) struct GroundedResult {
     pub(crate) answer: Option<String>,
     pub(crate) sources: Vec<Source>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct Source {
     pub(crate) url: String,
     pub(crate) title: String,

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -1,7 +1,7 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Repository metadata from `GET /repos/{owner}/{repo}`.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct RepoInfo {
     pub full_name: String,
     pub description: Option<String>,
@@ -15,7 +15,7 @@ pub(crate) struct RepoInfo {
     pub license: Option<LicenseInfo>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct LicenseInfo {
     pub spdx_id: Option<String>,
     pub name: String,
@@ -29,7 +29,7 @@ pub(crate) struct TreeResponse {
 }
 
 /// Git object type. `Other` captures unknown types via `#[serde(other)]` for forward compat.
-#[derive(Deserialize, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum EntryType {
     Blob,
@@ -40,7 +40,7 @@ pub(crate) enum EntryType {
 }
 
 /// A single entry in a git tree (file, directory, or submodule).
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct TreeEntry {
     pub path: String,
     #[serde(rename = "type")]
@@ -61,22 +61,25 @@ pub(crate) struct BlobResponse {
     pub content: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct IssueInfo {
     pub number: u64,
     pub title: String,
     pub html_url: String,
     pub labels: Vec<LabelInfo>,
     pub user: Option<UserInfo>,
+    /// Internal: present when GitHub's issues endpoint returns a PR.
+    /// Not part of scout's public JSON output (#67/ADR-0065).
+    #[serde(skip_serializing)]
     pub pull_request: Option<serde_json::Value>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct LabelInfo {
     pub name: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct PullInfo {
     pub number: u64,
     pub title: String,
@@ -85,12 +88,12 @@ pub(crate) struct PullInfo {
     pub user: Option<UserInfo>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct UserInfo {
     pub login: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct ReleaseInfo {
     pub tag_name: String,
     pub name: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,13 @@ mod tools;
 
 pub(crate) const USER_AGENT: &str = concat!("scout/", env!("CARGO_PKG_VERSION"));
 
+use std::env;
 use std::io::{self, ErrorKind, Write, stderr, stdout};
 use std::process::ExitCode;
 
 use clap::Parser;
-use tools::{Command, Scout};
+use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload, SuccessEnvelope};
+use tools::{Command, Scout, ScoutError};
 
 fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
     w.write_all(output.as_bytes())?;
@@ -43,6 +45,11 @@ Environment:
   GITHUB_TOKEN    Optional for GitHub commands (higher rate limits)"
 )]
 pub(crate) struct Cli {
+    /// Emit output as a JSON envelope (one line per ADR-0065) on stdout
+    /// instead of Markdown. Errors print a JSON envelope on stderr.
+    #[arg(long, global = true)]
+    json: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -60,20 +67,30 @@ pub async fn run() -> ExitCode {
         )
         .init();
 
-    let cli = Cli::parse();
+    // Pre-scan argv so a clap parse error (which exits before `cli.json` is
+    // populated) still routes through the JSON envelope path when requested.
+    let json_mode_pre = env::args().any(|a| a == "--json");
+
+    let cli = match Cli::try_parse() {
+        Ok(c) => c,
+        Err(e) => return handle_parse_error(&e, json_mode_pre),
+    };
+    let json_mode = cli.json;
 
     let scout = match Scout::new().await {
         Ok(s) => s,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1_u8));
-        }
+        Err(e) => return emit_error(&e, json_mode),
     };
 
     match scout.run(cli.command).await {
         Ok(output) => {
+            let rendered = if json_mode {
+                render_json_success(output)
+            } else {
+                output.markdown
+            };
             let mut handle = stdout().lock();
-            match write_output(&mut handle, &output) {
+            match write_output(&mut handle, &rendered) {
                 Ok(()) => ExitCode::SUCCESS,
                 Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
                 Err(e) => {
@@ -82,11 +99,77 @@ pub async fn run() -> ExitCode {
                 }
             }
         }
-        Err(e) => {
-            eprintln!("error: {e}");
-            ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1_u8))
+        Err(e) => emit_error(&e, json_mode),
+    }
+}
+
+/// Serialize a successful `CommandOutput` as a one-line JSON envelope per ADR-0065.
+/// Takes `CommandOutput` by value so `data` and `notes` move into the envelope
+/// instead of being deep-cloned.
+fn render_json_success(output: CommandOutput) -> String {
+    let envelope = SuccessEnvelope {
+        data: output.data,
+        degraded: output.degraded,
+        notes: output.notes,
+    };
+    serde_json::to_string(&envelope).expect("envelope is Serialize")
+}
+
+/// Serialize a `ScoutError` as a one-line JSON envelope per ADR-0065.
+fn render_json_error(err: &ScoutError) -> String {
+    let envelope = ErrorEnvelope {
+        error: ErrorPayload {
+            code: err.error_kind(),
+            message: err.to_string(),
+            next_step: None,
+            candidates: Vec::new(),
+            retryable: err.retryable(),
+        },
+    };
+    serde_json::to_string(&envelope).expect("envelope is Serialize")
+}
+
+/// Handle a `clap::Error` from `Cli::try_parse()`. Help/version display
+/// stay on stdout per clap convention; usage errors route through the JSON
+/// envelope when `--json` was passed in argv.
+fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
+    use clap::error::ErrorKind;
+    match err.kind() {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+            let _ = err.print();
+            ExitCode::SUCCESS
+        }
+        _ => {
+            if json_mode {
+                let envelope = ErrorEnvelope {
+                    error: ErrorPayload {
+                        code: ErrorCode::UsageError,
+                        message: err.to_string().trim().to_owned(),
+                        next_step: None,
+                        candidates: Vec::new(),
+                        retryable: false,
+                    },
+                };
+                let line = serde_json::to_string(&envelope).expect("envelope is Serialize");
+                eprintln!("{line}");
+            } else {
+                let _ = err.print();
+            }
+            ExitCode::from(2)
         }
     }
+}
+
+/// Print error to stderr (JSON envelope when `--json`, plain `error: <msg>` otherwise)
+/// and return the appropriate `ExitCode`.
+fn emit_error(err: &ScoutError, json_mode: bool) -> ExitCode {
+    if json_mode {
+        let line = render_json_error(err);
+        eprintln!("{line}");
+    } else {
+        eprintln!("error: {err}");
+    }
+    ExitCode::from(u8::try_from(err.exit_code()).unwrap_or(1_u8))
 }
 
 #[cfg(test)]

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -23,15 +23,18 @@ const MAX_PAGE_BYTES: usize = 4_500;
 const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Aggregated output of a multi-source research session.
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub(crate) struct ResearchReport {
+    /// Internal: per-query grounded results consumed by the report formatter.
+    /// Not part of scout's public JSON output (#67/ADR-0065).
+    #[serde(skip_serializing)]
     pub(crate) search_results: Vec<GroundedResult>,
     pub(crate) fetched_pages: Vec<FetchResult>,
     pub(crate) failed_urls: Vec<FailedUrl>,
     pub(crate) all_sources: Vec<Source>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub(crate) struct FailedUrl {
     pub(crate) url: String,
     pub(crate) reason: String,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -20,6 +20,7 @@ use params::{
     resolve_input,
 };
 
+use crate::envelope::CommandOutput;
 use crate::fetch::converter::{FetchResult, RAW_FALLBACK_NOTE};
 use crate::fetch::{FetchError, FetchOptions, TokioDnsResolver, fetch_page};
 use crate::gemini::client::{GeminiClient, GeminiError, SearchClient as _};
@@ -171,7 +172,7 @@ impl Scout {
             .ok_or_else(|| ScoutError::from(GeminiError::ApiKeyNotSet))
     }
 
-    pub async fn run(&self, cmd: Command) -> Result<String, ScoutError> {
+    pub async fn run(&self, cmd: Command) -> Result<CommandOutput, ScoutError> {
         match cmd {
             Command::Search(params) => self.search(params).await,
             Command::Fetch(params) => self.fetch(params).await,
@@ -182,7 +183,7 @@ impl Scout {
         }
     }
 
-    async fn search(&self, params: SearchParams) -> Result<String, ScoutError> {
+    async fn search(&self, params: SearchParams) -> Result<CommandOutput, ScoutError> {
         let query = resolve_stdin_arg(params.query, "query", "<QUERY>").await?;
 
         info!(query = %query, "search");
@@ -192,18 +193,15 @@ impl Scout {
         let result = gemini.search(&search_query).await?;
 
         // Shift by 2, consistent with fetch standalone output.
-        let mut output = shift_headings(
-            &result.answer.unwrap_or_else(|| {
-                "(No answer returned — the query may have been filtered by safety settings.)"
-                    .to_owned()
-            }),
-            2,
-        );
+        let answer_md = result.answer.clone().unwrap_or_else(|| {
+            "(No answer returned — the query may have been filtered by safety settings.)".to_owned()
+        });
+        let mut markdown = shift_headings(&answer_md, 2);
 
         if !result.sources.is_empty() {
-            output.push_str("\n\n---\n**Sources:**\n");
+            markdown.push_str("\n\n---\n**Sources:**\n");
             for source in &result.sources {
-                output.push_str(&format!(
+                markdown.push_str(&format!(
                     "- [{}]({})\n",
                     escape_md_inline(&source.title),
                     escape_md_link(&source.url)
@@ -212,10 +210,11 @@ impl Scout {
         }
 
         info!(sources = result.sources.len(), "search complete");
-        Ok(output)
+        let data = serde_json::to_value(&result).expect("GroundedResult is Serialize");
+        Ok(CommandOutput::ok(markdown, data))
     }
 
-    async fn fetch(&self, params: FetchParams) -> Result<String, ScoutError> {
+    async fn fetch(&self, params: FetchParams) -> Result<CommandOutput, ScoutError> {
         let url = resolve_stdin_arg(params.url, "url", "<URL>").await?;
 
         if let Some(slack_url) = parse_slack_url(&url) {
@@ -245,31 +244,42 @@ impl Scout {
         }
 
         info!(url = %url, "fetch complete");
-        Ok(format_fetch_output(&result))
+        let markdown = format_fetch_output(&result);
+        let data = serde_json::to_value(&result).expect("FetchResult is Serialize");
+        let notes = if result.used_raw_fallback {
+            vec![String::from(
+                "Readability extraction failed; raw page conversion was used instead.",
+            )]
+        } else {
+            Vec::new()
+        };
+        Ok(CommandOutput::with_notes(markdown, data, notes))
     }
 
-    async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<String, ScoutError> {
+    async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<CommandOutput, ScoutError> {
         info!(workspace = %slack_url.workspace, channel = %slack_url.channel, "fetch (slack)");
         let client = SlackClient::from_env(self.http.clone())?;
-        let output = timeout(
-            SLACK_TOOL_TIMEOUT,
-            client.fetch_message(&slack_url),
-        )
-        .await
-        .unwrap_or_else(|_| {
-            Err(SlackError::Timeout(format!(
-                "slack fetch timed out after {}s",
-                SLACK_TOOL_TIMEOUT.as_secs()
-            )))
-        })
-        .inspect_err(|e| {
-            warn!(workspace = %slack_url.workspace, channel = %slack_url.channel, error = %e, "slack fetch failed");
-        })?;
+        let output = timeout(SLACK_TOOL_TIMEOUT, client.fetch_message(&slack_url))
+            .await
+            .unwrap_or_else(|_| {
+                Err(SlackError::Timeout(format!(
+                    "slack fetch timed out after {}s",
+                    SLACK_TOOL_TIMEOUT.as_secs()
+                )))
+            })
+            .inspect_err(|e| {
+                warn!(workspace = %slack_url.workspace, channel = %slack_url.channel, error = %e, "slack fetch failed");
+            })?;
         info!(workspace = %slack_url.workspace, channel = %slack_url.channel, "fetch (slack) complete");
-        Ok(truncate_with_note(&output, MAX_FETCH_OUTPUT_BYTES).into_owned())
+        let markdown = truncate_with_note(&output, MAX_FETCH_OUTPUT_BYTES).into_owned();
+        let data = serde_json::json!({
+            "url": slack_url.raw_url,
+            "markdown": markdown,
+        });
+        Ok(CommandOutput::ok(markdown, data))
     }
 
-    async fn research(&self, params: ResearchParams) -> Result<String, ScoutError> {
+    async fn research(&self, params: ResearchParams) -> Result<CommandOutput, ScoutError> {
         let query = resolve_stdin_arg(params.query, "query", "<QUERY>").await?;
 
         info!(query = %query, depth = params.depth, "research");
@@ -290,10 +300,32 @@ impl Scout {
             "research complete"
         );
 
-        Ok(engine::format_report(&report, &query))
+        let markdown = engine::format_report(&report, &query);
+        let mut data = serde_json::to_value(&report).expect("ResearchReport is Serialize");
+        if let Some(map) = data.as_object_mut() {
+            map.insert("query".to_owned(), serde_json::Value::String(query.clone()));
+        }
+        let mut notes: Vec<String> = report
+            .failed_urls
+            .iter()
+            .map(|f| format!("Failed to fetch {}: {}", f.url, f.reason))
+            .collect();
+        let raw_fallback_pages: Vec<&str> = report
+            .fetched_pages
+            .iter()
+            .filter(|p| p.used_raw_fallback)
+            .map(|p| p.url.as_str())
+            .collect();
+        if !raw_fallback_pages.is_empty() {
+            notes.push(format!(
+                "Readability extraction failed for: {}",
+                raw_fallback_pages.join(", ")
+            ));
+        }
+        Ok(CommandOutput::with_notes(markdown, data, notes))
     }
 
-    async fn repo_tree(&self, params: RepoTreeParams) -> Result<String, ScoutError> {
+    async fn repo_tree(&self, params: RepoTreeParams) -> Result<CommandOutput, ScoutError> {
         let repository = resolve_stdin_arg(params.repository, "repository", "<OWNER/REPO>").await?;
 
         let (owner, repo) = parse_repo_param(&repository)?;
@@ -322,13 +354,20 @@ impl Scout {
             params.pattern.as_deref(),
         )?;
 
-        let output = github::format::format_tree(owner, repo, &ref_, &filtered, tree.truncated);
+        let markdown = github::format::format_tree(owner, repo, &ref_, &filtered, tree.truncated);
+        let data = serde_json::json!({
+            "owner": owner,
+            "repo": repo,
+            "ref": ref_,
+            "entries": filtered,
+            "truncated": tree.truncated,
+        });
 
         info!(files = filtered.len(), "repo_tree complete");
-        Ok(output)
+        Ok(CommandOutput::ok(markdown, data))
     }
 
-    async fn repo_read(&self, params: RepoReadParams) -> Result<String, ScoutError> {
+    async fn repo_read(&self, params: RepoReadParams) -> Result<CommandOutput, ScoutError> {
         let is_terminal = stdin().is_terminal();
         let content = read_stdin(
             params.repository.as_deref() == Some("-")
@@ -384,14 +423,20 @@ impl Scout {
             github::apply_line_range(&raw, 1, None)
         };
 
-        let output =
+        let markdown =
             github::format::format_file_content(&path, total, &content, encoding_label.as_deref());
+        let data = serde_json::json!({
+            "path": path,
+            "total_lines": total,
+            "content": content,
+            "encoding": encoding_label,
+        });
 
         info!(path = %path, lines = total, "repo_read complete");
-        Ok(output)
+        Ok(CommandOutput::ok(markdown, data))
     }
 
-    async fn repo_overview(&self, params: RepoOverviewParams) -> Result<String, ScoutError> {
+    async fn repo_overview(&self, params: RepoOverviewParams) -> Result<CommandOutput, ScoutError> {
         let repository = resolve_stdin_arg(params.repository, "repository", "<OWNER/REPO>").await?;
 
         let (owner, repo) = parse_repo_param(&repository)?;
@@ -416,7 +461,7 @@ impl Scout {
         let pulls = unwrap_or_note(pulls, "pull requests", &mut notes);
         let releases = unwrap_or_note(releases, "releases", &mut notes);
 
-        let mut output = github::format::format_overview(
+        let mut markdown = github::format::format_overview(
             &repo_info,
             readme_content.as_deref(),
             &issues,
@@ -425,10 +470,22 @@ impl Scout {
         );
 
         if !notes.is_empty() {
-            output.push_str("\n> **Note:** ");
-            output.push_str(&notes.join(". "));
-            output.push_str(".\n");
+            markdown.push_str("\n> **Note:** ");
+            markdown.push_str(&notes.join(". "));
+            markdown.push_str(".\n");
         }
+
+        // GitHub's issues endpoint returns PRs too; filter them out so JSON
+        // consumers don't see PRs duplicated under issues.
+        let real_issues: Vec<&github::types::IssueInfo> =
+            issues.iter().filter(|i| i.pull_request.is_none()).collect();
+        let data = serde_json::json!({
+            "repository": repo_info,
+            "readme": readme_content,
+            "issues": real_issues,
+            "pulls": pulls,
+            "releases": releases,
+        });
 
         info!(
             issues = issues.len(),
@@ -437,7 +494,7 @@ impl Scout {
             has_readme = readme_content.is_some(),
             "repo_overview complete"
         );
-        Ok(output)
+        Ok(CommandOutput::with_notes(markdown, data, notes))
     }
 }
 
@@ -555,13 +612,15 @@ mod tests {
         };
 
         let result = s.search(params).await.unwrap();
-        assert!(!result.is_empty());
+        assert!(!result.markdown.is_empty());
         assert!(
-            result.contains("Rust is a systems programming language"),
+            result
+                .markdown
+                .contains("Rust is a systems programming language"),
             "should contain answer text"
         );
         assert!(
-            !result.contains("**Query:**"),
+            !result.markdown.contains("**Query:**"),
             "should not contain Query header (redundant for LLMs)"
         );
     }
@@ -602,11 +661,11 @@ mod tests {
 
         let result = s.research(params).await.unwrap();
         assert!(
-            result.contains("Rust"),
-            "report should contain search answer, got: {result}"
+            result.markdown.contains("Rust"),
+            "report should contain search answer, got: {result:?}"
         );
         assert!(
-            result.contains("rust-lang.org"),
+            result.markdown.contains("rust-lang.org"),
             "report should reference source URL"
         );
     }
@@ -672,8 +731,8 @@ mod tests {
 
         let result = s.search(params).await.unwrap();
         assert!(
-            result.contains("No answer returned"),
-            "should contain fallback message, got:\n{result}"
+            result.markdown.contains("No answer returned"),
+            "should contain fallback message, got:\n{result:?}"
         );
     }
 
@@ -707,12 +766,12 @@ mod tests {
 
         let result = s.search(params).await.unwrap();
         assert!(
-            result.contains("### Title"),
-            "h1 should shift to h3 (shift by 2), got:\n{result}"
+            result.markdown.contains("### Title"),
+            "h1 should shift to h3 (shift by 2), got:\n{result:?}"
         );
         assert!(
-            result.contains("#### Sub"),
-            "h2 should shift to h4 (shift by 2), got:\n{result}"
+            result.markdown.contains("#### Sub"),
+            "h2 should shift to h4 (shift by 2), got:\n{result:?}"
         );
     }
 
@@ -747,16 +806,16 @@ mod tests {
 
         let result = s.search(params).await.unwrap();
         assert!(
-            result.contains("### Real heading"),
-            "h1 outside code block should shift to h3, got:\n{result}"
+            result.markdown.contains("### Real heading"),
+            "h1 outside code block should shift to h3, got:\n{result:?}"
         );
         assert!(
-            result.contains("#### Another heading"),
-            "h2 outside code block should shift to h4, got:\n{result}"
+            result.markdown.contains("#### Another heading"),
+            "h2 outside code block should shift to h4, got:\n{result:?}"
         );
         assert!(
-            result.contains("# comment in script"),
-            "# inside fenced code block should remain unchanged, got:\n{result}"
+            result.markdown.contains("# comment in script"),
+            "# inside fenced code block should remain unchanged, got:\n{result:?}"
         );
     }
 
@@ -1141,12 +1200,12 @@ mod tests {
 
         let result = s.repo_read(params).await.unwrap();
         assert!(
-            result.contains("テスト"),
-            "output should contain decoded Shift_JIS text, got: {result}"
+            result.markdown.contains("テスト"),
+            "output should contain decoded Shift_JIS text, got: {result:?}"
         );
         assert!(
-            result.contains("[encoding: shift_jis]"),
-            "header should include encoding label, got: {result}"
+            result.markdown.contains("[encoding: shift_jis]"),
+            "header should include encoding label, got: {result:?}"
         );
     }
 
@@ -1199,16 +1258,16 @@ mod tests {
 
         let result = s.repo_tree(params).await.unwrap();
         assert!(
-            result.contains("src/main.rs"),
-            "path filter should include src/main.rs, got:\n{result}"
+            result.markdown.contains("src/main.rs"),
+            "path filter should include src/main.rs, got:\n{result:?}"
         );
         assert!(
-            !result.contains("README.md"),
-            "path filter should exclude README.md, got:\n{result}"
+            !result.markdown.contains("README.md"),
+            "path filter should exclude README.md, got:\n{result:?}"
         );
         assert!(
-            !result.contains("Cargo.toml"),
-            "path filter should exclude Cargo.toml, got:\n{result}"
+            !result.markdown.contains("Cargo.toml"),
+            "path filter should exclude Cargo.toml, got:\n{result:?}"
         );
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -92,3 +92,112 @@ fn t_c005_repo_tree_bad_format_exits_1() {
         "stderr should contain error: prefix, got:\n{stderr}"
     );
 }
+
+// T-C006: --json appears in --help under Options
+#[test]
+fn t_c006_help_advertises_json_flag() {
+    let output = scout().arg("--help").output().expect("scout --help failed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--json"),
+        "help output should advertise --json flag, got:\n{stdout}"
+    );
+}
+
+// T-C007: --json with malformed repo emits a JSON envelope on stderr
+#[test]
+fn t_c007_json_emits_envelope_on_error() {
+    let output = scout()
+        .args(["--json", "repo-tree", "no-slash-here"])
+        .output()
+        .expect("scout --json repo-tree failed to run");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "malformed owner/repo should still exit 1 in --json mode"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr
+        .lines()
+        .find(|l| l.starts_with('{'))
+        .expect("stderr should contain a JSON envelope line");
+    let value: serde_json::Value = serde_json::from_str(line).expect("envelope must be valid JSON");
+    assert_eq!(
+        value["error"]["code"], "DATA_ERROR",
+        "code should be DATA_ERROR per ADR-0065, got: {value}"
+    );
+    assert_eq!(
+        value["error"]["retryable"], false,
+        "retryable should be false for DATA_ERROR, got: {value}"
+    );
+    assert!(
+        value["error"]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("Invalid repository format")),
+        "message should describe the input failure, got: {value}"
+    );
+    assert!(
+        value["error"].get("next_step").is_none(),
+        "next_step should be omitted when None, got: {value}"
+    );
+    assert!(
+        value["error"].get("candidates").is_none(),
+        "candidates should be omitted when empty, got: {value}"
+    );
+}
+
+// T-C008: --json missing API key surfaces a USAGE_ERROR envelope on stderr
+#[test]
+fn t_c008_json_missing_api_key_emits_usage_error() {
+    let output = scout()
+        .args(["--json", "search", "test query"])
+        .env_remove("GEMINI_API_KEY")
+        .output()
+        .expect("scout --json search failed to run");
+    assert_eq!(output.status.code(), Some(1), "missing API key → exit 1");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr
+        .lines()
+        .find(|l| l.starts_with('{'))
+        .expect("stderr should contain a JSON envelope line");
+    let value: serde_json::Value = serde_json::from_str(line).expect("envelope must be valid JSON");
+    assert_eq!(
+        value["error"]["code"], "USAGE_ERROR",
+        "missing API key is a usage problem per ADR-0065, got: {value}"
+    );
+}
+
+// T-C010: --json with a clap parse error (unknown flag) routes through JSON envelope
+#[test]
+fn t_c010_json_clap_parse_error_emits_envelope() {
+    let output = scout()
+        .args(["--json", "--definitely-not-a-flag"])
+        .output()
+        .expect("scout failed to run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr
+        .lines()
+        .find(|l| l.starts_with('{'))
+        .expect("stderr should contain a JSON envelope line for clap parse errors");
+    let value: serde_json::Value = serde_json::from_str(line).expect("envelope must be valid JSON");
+    assert_eq!(
+        value["error"]["code"], "USAGE_ERROR",
+        "clap parse error should be USAGE_ERROR per ADR-0065, got: {value}"
+    );
+}
+
+// T-C009: --json error envelope is exactly one line (single-line JSON contract)
+#[test]
+fn t_c009_json_error_envelope_is_single_line() {
+    let output = scout()
+        .args(["--json", "repo-tree", "no-slash-here"])
+        .output()
+        .expect("scout --json repo-tree failed to run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let json_lines: Vec<&str> = stderr.lines().filter(|l| l.starts_with('{')).collect();
+    assert_eq!(
+        json_lines.len(),
+        1,
+        "expected exactly one JSON envelope line, got: {json_lines:?}"
+    );
+}


### PR DESCRIPTION
## 概要と動機

ADR-0065 Phase 2.2 を実装。`--json` グローバルフラグから各コマンドハンドラを通じて JSON envelope 出力までを一本の経路で繋ぐ。エージェント向けの構造化出力を有効化しつつ、既存の Markdown 経路は変更なし。

Phase 2.1 (#75) で envelope 型を追加済み。本 PR でそれらを実際の出力経路に接続する。

## 変更内容

- `Cli` に `#[arg(long, global = true)] json: bool` を追加（既存 `yaml` フラグを置換）
- argv 事前スキャンで clap parse error 時も --json モードを保持（`Cli::try_parse()` + `handle_parse_error()`）
- 全 6 コマンドハンドラの戻り値型を `String` → `CommandOutput`（markdown + data + notes + degraded）
- `render_json_success()` / `render_json_error()` で one-line JSON envelope を serialize
- ドメイン型 12 種（GitHub、Fetch、Gemini）に `#[derive(Serialize)]` を追加
- 内部フィールド（`pull_request`、`used_raw_fallback`、`search_results`）は `#[serde(skip_serializing)]` で JSON 出力から除外
- degradation シグナル（failed URLs、raw_fallback）を `notes` に集約

## スコープ

- **含めない**: 各コマンドの `data` 内構造化（Phase 3 で別 PR）
- **含めない**: `next_step` / `candidates` 自動推論（後続 PR）

## 設計上の判断

- **CommandOutput 中間形式**: handler 側で Markdown と data 両方を組み立て、`lib::run` 境界で出力経路を分岐。両経路の壊しにくさを優先。
- **argv 事前スキャン**: `Cli::parse()` は parse error 時に `cli.json` populate 前に exit するため、`env::args().any(|a| a == "--json")` で事前検出。
- **`#[serde(skip_serializing)]` で内部フィールド除外**: `pull_request` は repo_overview で PR 一覧と重複、`used_raw_fallback` は notes で伝播、`search_results` は Markdown summary に既に含まれる。

## テスト方法

1. `cargo test --all-targets` → lib + integration tests pass
2. `cargo clippy --all-targets --all-features -- -D warnings` → clean
3. `scout --help | grep -- --json` → フラグが advertise されているか確認
4. `scout --json repo-tree no-slash-here 2>&1` → DATA_ERROR JSON envelope
5. `scout --json --unknown-flag 2>&1` → USAGE_ERROR JSON envelope（clap parse error path）
6. `unset GEMINI_API_KEY && scout --json search test 2>&1` → USAGE_ERROR JSON envelope

## 関連

- Refs #67 (ADR-0060 監査適用)
- ADR-0065: scout JSON output schema
- 前段: #75 (Phase 2.1: envelope types)
- 次段: Phase 3 (`data` 内構造化、別 PR)
