### PR TITLE
exit code を sysexits.h 6 種に拡張 (ADR-0065 Phase 3, 1.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout"
-version = "0.7.1"
+version = "1.0.0"
 dependencies = [
  "base64",
  "chardetng 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scout"
-version = "0.7.1"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.95"
 description = "CLI tool for web search (Gemini Grounding), page fetching, and GitHub repository exploration"

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -51,6 +51,19 @@ pub(crate) enum ErrorCode {
     TempFailure,
 }
 
+impl ErrorCode {
+    /// sysexits.h exit code mapped 1:1 from `error.code` per ADR-0065.
+    pub(crate) fn exit_code(self) -> u8 {
+        match self {
+            Self::UsageError => 64,  // EX_USAGE
+            Self::DataError => 65,   // EX_DATAERR
+            Self::NotFound => 66,    // EX_NOINPUT
+            Self::IoError => 74,     // EX_IOERR
+            Self::TempFailure => 75, // EX_TEMPFAIL
+        }
+    }
+}
+
 /// Success envelope wrapping command output per ADR-0065.
 #[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
 #[derive(Debug, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub async fn run() -> ExitCode {
                 Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("error: {e}");
-                    ExitCode::from(74) // EX_IOERR
+                    ExitCode::from(ErrorCode::IoError.exit_code())
                 }
             }
         }
@@ -158,7 +158,7 @@ fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
             } else {
                 let _ = err.print();
             }
-            ExitCode::from(64) // EX_USAGE
+            ExitCode::from(ErrorCode::UsageError.exit_code())
         }
     }
 }
@@ -172,7 +172,7 @@ fn emit_error(err: &ScoutError, json_mode: bool) -> ExitCode {
     } else {
         eprintln!("error: {err}");
     }
-    ExitCode::from(u8::try_from(err.exit_code()).unwrap_or(1_u8))
+    ExitCode::from(err.exit_code())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,13 @@ fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
     version,
     about = "Web search, page fetching, and GitHub repository exploration",
     after_help = "\
-Exit codes:
-  0  Success
-  1  User error (invalid input, not found, auth failure)
-  2  Internal error or transient network failure
+Exit codes (sysexits.h, ADR-0065):
+  0   Success
+  64  Usage error (clap parse, missing API key, conflicts_with violation)
+  65  Data error (invalid input, malformed format, encoding error)
+  66  Not found (repo/file not found, 404)
+  74  IO error (network IO, write failure other than BrokenPipe)
+  75  Temporary failure (rate limit, 5xx, retryable)
 
 Environment:
   GEMINI_API_KEY  Required for search and research commands
@@ -95,7 +98,7 @@ pub async fn run() -> ExitCode {
                 Err(e) if e.kind() == ErrorKind::BrokenPipe => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("error: {e}");
-                    ExitCode::from(2)
+                    ExitCode::from(74) // EX_IOERR
                 }
             }
         }
@@ -155,7 +158,7 @@ fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
             } else {
                 let _ = err.print();
             }
-            ExitCode::from(2)
+            ExitCode::from(64) // EX_USAGE
         }
     }
 }
@@ -213,13 +216,17 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
     }
 
-    /// [T-H000] root --help contains Exit codes: and Environment: sections
+    /// [T-H000] root --help contains sysexits Exit codes (ADR-0065) and Environment sections
     #[test]
     fn t_h000_root_help_contains_exit_codes_and_environment() {
         let help = super::Cli::command().render_long_help().to_string();
         assert!(
-            help.contains("Exit codes:"),
-            "root help missing Exit codes:"
+            help.contains("Exit codes"),
+            "root help missing Exit codes section"
+        );
+        assert!(
+            help.contains("ADR-0065"),
+            "root help should reference ADR-0065"
         );
         assert!(
             help.contains("GEMINI_API_KEY"),
@@ -229,13 +236,19 @@ mod tests {
             help.contains("GITHUB_TOKEN"),
             "root help missing GITHUB_TOKEN"
         );
+        for code in ["64", "65", "66", "74", "75"] {
+            assert!(
+                help.contains(code),
+                "root help should document sysexits code {code}"
+            );
+        }
         assert!(
-            help.contains("User error"),
-            "root help missing exit code 1 description"
+            help.contains("Usage error"),
+            "root help missing EX_USAGE description"
         );
         assert!(
-            help.contains("transient network failure"),
-            "root help missing exit code 2 description"
+            help.contains("Temporary failure"),
+            "root help missing EX_TEMPFAIL description"
         );
     }
 }

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -33,7 +33,7 @@ impl ScoutError {
     pub(super) fn user_error(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 1,
+            exit_code: 64, // EX_USAGE
             retryable: false,
             kind: ErrorCode::UsageError,
         }
@@ -42,7 +42,7 @@ impl ScoutError {
     pub(super) fn internal(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 2,
+            exit_code: 74, // EX_IOERR
             retryable: false,
             kind: ErrorCode::IoError,
         }
@@ -51,7 +51,7 @@ impl ScoutError {
     pub(super) fn transient(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 2,
+            exit_code: 75, // EX_TEMPFAIL
             retryable: true,
             kind: ErrorCode::TempFailure,
         }
@@ -60,7 +60,7 @@ impl ScoutError {
     pub(super) fn not_found(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 1,
+            exit_code: 66, // EX_NOINPUT
             retryable: false,
             kind: ErrorCode::NotFound,
         }
@@ -69,7 +69,7 @@ impl ScoutError {
     pub(super) fn data_error(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 1,
+            exit_code: 65, // EX_DATAERR
             retryable: false,
             kind: ErrorCode::DataError,
         }
@@ -262,24 +262,14 @@ mod tests {
         assert_eq!(err.error_kind(), ErrorCode::NotFound);
     }
 
-    /// [T-ER001] User-facing errors surface with exit code 1
+    /// [T-ER001a] UsageError errors surface with exit 64 (EX_USAGE per ADR-0065)
     #[test]
-    fn user_errors_have_exit_code_1() {
+    fn t_er001a_usage_errors_have_exit_code_64() {
         let cases: Vec<ScoutError> = vec![
-            github::GitHubError::NotFound("/test".into()).into(),
             github::GitHubError::Forbidden("denied".into()).into(),
-            github::GitHubError::InvalidRepo("bad".into()).into(),
-            FetchError::InvalidScheme.into(),
-            FetchError::InternalHost.into(),
-            FetchError::UnsupportedContentType("image/png".into()).into(),
-            FetchError::RedirectMissingLocation.into(),
             FetchError::BrowserNotFound("not installed".into()).into(),
-            FetchError::Status(400).into(),
-            FetchError::Status(404).into(),
+            FetchError::Status(401).into(),
             FetchError::Status(403).into(),
-            FetchError::Status(499).into(),
-            FetchError::TooLarge.into(),
-            FetchError::TooManyRedirects(10).into(),
             SlackError::TokenNotSet.into(),
             SlackError::Api {
                 error: "err".into(),
@@ -289,13 +279,47 @@ mod tests {
             GeminiError::QuotaExhausted("limit".into()).into(),
         ];
         for err in &cases {
-            assert_eq!(err.exit_code(), 1, "expected user error (1): {err}");
+            assert_eq!(err.error_kind(), ErrorCode::UsageError, "{err}");
+            assert_eq!(err.exit_code(), 64, "expected EX_USAGE (64): {err}");
         }
     }
 
-    /// [T-ER002] Internal errors surface with exit code 2 and are non-retryable
+    /// [T-ER001b] DataError errors surface with exit 65 (EX_DATAERR per ADR-0065)
     #[test]
-    fn internal_errors_have_exit_code_2() {
+    fn t_er001b_data_errors_have_exit_code_65() {
+        let cases: Vec<ScoutError> = vec![
+            github::GitHubError::InvalidRepo("bad".into()).into(),
+            FetchError::InvalidScheme.into(),
+            FetchError::InternalHost.into(),
+            FetchError::UnsupportedContentType("image/png".into()).into(),
+            FetchError::RedirectMissingLocation.into(),
+            FetchError::Status(400).into(),
+            FetchError::Status(499).into(),
+            FetchError::TooLarge.into(),
+            FetchError::TooManyRedirects(10).into(),
+        ];
+        for err in &cases {
+            assert_eq!(err.error_kind(), ErrorCode::DataError, "{err}");
+            assert_eq!(err.exit_code(), 65, "expected EX_DATAERR (65): {err}");
+        }
+    }
+
+    /// [T-ER001c] NotFound errors surface with exit 66 (EX_NOINPUT per ADR-0065)
+    #[test]
+    fn t_er001c_not_found_errors_have_exit_code_66() {
+        let cases: Vec<ScoutError> = vec![
+            github::GitHubError::NotFound("/test".into()).into(),
+            FetchError::Status(404).into(),
+        ];
+        for err in &cases {
+            assert_eq!(err.error_kind(), ErrorCode::NotFound, "{err}");
+            assert_eq!(err.exit_code(), 66, "expected EX_NOINPUT (66): {err}");
+        }
+    }
+
+    /// [T-ER002] IoError errors surface with exit 74 (EX_IOERR) and are non-retryable
+    #[test]
+    fn t_er002_io_errors_have_exit_code_74() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::Api {
                 code: 400,
@@ -312,14 +336,15 @@ mod tests {
             .into(),
         ];
         for err in &cases {
-            assert_eq!(err.exit_code(), 2, "expected internal error (2): {err}");
-            assert!(!err.retryable(), "internal should not be retryable: {err}");
+            assert_eq!(err.error_kind(), ErrorCode::IoError, "{err}");
+            assert_eq!(err.exit_code(), 74, "expected EX_IOERR (74): {err}");
+            assert!(!err.retryable(), "IoError should not be retryable: {err}");
         }
     }
 
-    /// [T-ER003] Transient errors are retryable and display retry hint
+    /// [T-ER003] TempFailure errors are retryable, display retry hint, exit 75 (EX_TEMPFAIL)
     #[test]
-    fn transient_errors_are_retryable() {
+    fn t_er003_temp_failure_errors_have_exit_code_75() {
         let cases: Vec<ScoutError> = vec![
             FetchError::Status(408).into(),
             FetchError::Status(429).into(),
@@ -344,8 +369,9 @@ mod tests {
             SlackError::Timeout("err".into()).into(),
         ];
         for err in &cases {
+            assert_eq!(err.error_kind(), ErrorCode::TempFailure, "{err}");
             assert!(err.retryable(), "expected retryable: {err}");
-            assert_eq!(err.exit_code(), 2, "retryable should be exit 2: {err}");
+            assert_eq!(err.exit_code(), 75, "expected EX_TEMPFAIL (75): {err}");
             assert!(
                 err.to_string().contains("retry may succeed"),
                 "should include retry hint: {err}"

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -12,7 +12,6 @@ use crate::slack::SlackError;
 #[derive(Debug)]
 pub struct ScoutError {
     message: String,
-    exit_code: i32,
     retryable: bool,
     kind: ErrorCode,
 }
@@ -33,7 +32,6 @@ impl ScoutError {
     pub(super) fn user_error(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 64, // EX_USAGE
             retryable: false,
             kind: ErrorCode::UsageError,
         }
@@ -42,7 +40,6 @@ impl ScoutError {
     pub(super) fn internal(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 74, // EX_IOERR
             retryable: false,
             kind: ErrorCode::IoError,
         }
@@ -51,7 +48,6 @@ impl ScoutError {
     pub(super) fn transient(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 75, // EX_TEMPFAIL
             retryable: true,
             kind: ErrorCode::TempFailure,
         }
@@ -60,7 +56,6 @@ impl ScoutError {
     pub(super) fn not_found(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 66, // EX_NOINPUT
             retryable: false,
             kind: ErrorCode::NotFound,
         }
@@ -69,14 +64,14 @@ impl ScoutError {
     pub(super) fn data_error(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            exit_code: 65, // EX_DATAERR
             retryable: false,
             kind: ErrorCode::DataError,
         }
     }
 
-    pub fn exit_code(&self) -> i32 {
-        self.exit_code
+    /// sysexits.h exit code derived from `kind` per ADR-0065.
+    pub fn exit_code(&self) -> u8 {
+        self.kind.exit_code()
     }
 
     /// Whether the error is transient and the operation may succeed on retry.

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -15,8 +15,12 @@ fn t_c001_help_exits_zero_and_contains_app_name() {
         "help output should mention app name, got:\n{stdout}"
     );
     assert!(
-        stdout.contains("Exit codes:"),
-        "help output should contain Exit codes: section, got:\n{stdout}"
+        stdout.contains("Exit codes"),
+        "help output should contain Exit codes section, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("ADR-0065"),
+        "help should reference ADR-0065, got:\n{stdout}"
     );
 }
 
@@ -37,7 +41,7 @@ fn t_c002_version_exits_zero() {
 
 // T-C003
 #[test]
-fn t_c003_search_without_api_key_exits_1() {
+fn t_c003_search_without_api_key_exits_64() {
     let output = scout()
         .args(["search", "test query"])
         .env_remove("GEMINI_API_KEY")
@@ -45,8 +49,8 @@ fn t_c003_search_without_api_key_exits_1() {
         .expect("scout search failed to run");
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "missing API key should be exit code 1 (user error)"
+        Some(64),
+        "missing API key should be exit 64 (EX_USAGE per ADR-0065)"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -57,15 +61,15 @@ fn t_c003_search_without_api_key_exits_1() {
 
 // T-C004
 #[test]
-fn t_c004_fetch_invalid_url_exits_1() {
+fn t_c004_fetch_invalid_url_exits_65() {
     let output = scout()
         .args(["fetch", "not-a-valid-url"])
         .output()
         .expect("scout fetch failed to run");
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "invalid URL should be exit code 1 (user error)"
+        Some(65),
+        "invalid URL should be exit 65 (EX_DATAERR per ADR-0065)"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -76,15 +80,15 @@ fn t_c004_fetch_invalid_url_exits_1() {
 
 // T-C005
 #[test]
-fn t_c005_repo_tree_bad_format_exits_1() {
+fn t_c005_repo_tree_bad_format_exits_65() {
     let output = scout()
         .args(["repo-tree", "no-slash-here"])
         .output()
         .expect("scout repo-tree failed to run");
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "malformed owner/repo should be exit code 1 (user error)"
+        Some(65),
+        "malformed owner/repo should be exit 65 (EX_DATAERR per ADR-0065)"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -113,8 +117,8 @@ fn t_c007_json_emits_envelope_on_error() {
         .expect("scout --json repo-tree failed to run");
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "malformed owner/repo should still exit 1 in --json mode"
+        Some(65),
+        "malformed owner/repo should still exit 65 (EX_DATAERR) in --json mode"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     let line = stderr
@@ -154,7 +158,11 @@ fn t_c008_json_missing_api_key_emits_usage_error() {
         .env_remove("GEMINI_API_KEY")
         .output()
         .expect("scout --json search failed to run");
-    assert_eq!(output.status.code(), Some(1), "missing API key → exit 1");
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "missing API key → exit 64 (EX_USAGE)"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     let line = stderr
         .lines()
@@ -174,6 +182,11 @@ fn t_c010_json_clap_parse_error_emits_envelope() {
         .args(["--json", "--definitely-not-a-flag"])
         .output()
         .expect("scout failed to run");
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "clap parse error should exit 64 (EX_USAGE per ADR-0065)"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     let line = stderr
         .lines()


### PR DESCRIPTION
> [!CAUTION]
> **Breaking change**: exit code が `0/1/2` から sysexits.h 6 種 (`0/64/65/66/74/75`) に変更される。`if [ $? -eq 1 ]` 想定の既存スクリプトに影響。Cargo.toml は `0.7.1 → 1.0.0` にメジャーバンプ。

## 概要と動機

ADR-0065 Migration Strategy の Phase 3 を実装。`exit code` を `0/1/2` から sysexits.h 6 種に拡張することで、エージェントとスクリプトが exit code 単独でエラー分類を判別できる API 契約を確立する。JSON `error.code` ↔ exit code は 1:1 対応。

| Exit | Const         | JSON `error.code` | scout での発生条件                              |
| ---- | ------------- | ----------------- | ----------------------------------------------- |
| 0    | EX_OK         | (none)            | Ok 経路                                         |
| 64   | EX_USAGE      | `USAGE_ERROR`     | clap parse error, missing API key, conflicts   |
| 65   | EX_DATAERR    | `DATA_ERROR`      | URL invalid, owner/repo malformed, encoding 不正 |
| 66   | EX_NOINPUT    | `NOT_FOUND`       | repo / file not found, 404                      |
| 74   | EX_IOERR      | `IO_ERROR`        | network IO error, write failure                 |
| 75   | EX_TEMPFAIL   | `TEMP_FAILURE`    | rate limit, 5xx, retryable network error        |

## 変更内容

**Commit 1 — sysexits.h migration (`2d055c8`):**
- `ScoutError` 5 種の constructor で exit_code を sysexits.h 値に書き換え
- `lib.rs` after_help を sysexits.h 表記に更新（ADR-0065 参照を明示）
- `handle_parse_error` の clap parse error 時 ExitCode を 64 (EX_USAGE) に
- write error 時 ExitCode を 74 (EX_IOERR) に
- `Cargo.toml`: 0.7.1 → 1.0.0
- 既存 9 テスト (T-C001/003/004/005/007/008/010, T-H000, T-ER001~003) を新 exit code 値に更新（T-ER001 は kind ごとに a/b/c に分割）

**Commit 2 — Polish refactor (`50da062`):**
- `/polish` レビュー consensus で検出: `ScoutError.exit_code: i32` field と `kind: ErrorCode` の dual source of truth を解消
- `ErrorCode::exit_code()` メソッドを envelope.rs に追加（kind ↔ sysexits.h の単一マッピング表）
- `ScoutError.exit_code` field を削除、accessor を `self.kind.exit_code()` 経由に
- lib.rs の `ExitCode::from(74)` / `ExitCode::from(64)` magic number を `ErrorCode::*.exit_code()` 経由に
- `u8::try_from(...).unwrap_or(1_u8)` の死コードも除去

## スコープ

- **含めない**: `next_step` + `candidates` 自動推論 (typo corrector) — 後続 PR
- **含めない**: `conflicts_with` parse-time validation — 後続 PR
- **含めない**: 既存 `#[allow(dead_code)]` annotations の整理 — 別 tidy PR

## 設計上の判断

- **sysexits.h 6 種固定 (16 種フル準拠ではない)**: ADR-0065 で「scout の現エラー分類 (3 種) からの拡張幅が現実的」と確定済み。将来の不足時は ADR を superseded して新 ADR で記録。
- **ErrorCode を single source of truth に集約**: polish レビューで kind ↔ exit_code の duplicate state を検出。`ErrorCode::exit_code()` メソッドを唯一のマッピング表とすることで、future variant 追加時の修正点を 1 箇所に絞る。
- **メジャーバンプ (1.0.0)**: ADR-0065 Migration Strategy で「Phase 3 = 1.0.0 major bump」と確定。exit code は scripting からの contract surface であり、変更は破壊的。

## テスト方法

1. `cargo test --all-targets` → 312 lib tests + 10 integration tests pass
2. `cargo clippy --all-targets --all-features -- -D warnings` → clean
3. `scout fetch not-a-valid-url; echo $?` → `65` (EX_DATAERR)
4. `scout repo-tree no-slash; echo $?` → `65` (EX_DATAERR)
5. `unset GEMINI_API_KEY && scout search test; echo $?` → `64` (EX_USAGE)
6. `scout --bad-flag; echo $?` → `2` (clap default — note: `--json --bad-flag` returns `64`)
7. `scout --help` → Exit codes section に sysexits.h 6 種 + ADR-0065 参照が表示

## 関連

- Refs #67 (ADR-0060 監査適用)
- ADR-0065: scout JSON output schema and sysexits exit code policy (Migration Strategy Phase 3)
- 前段: #75 (Phase 2.1: envelope types) / #76 (Phase 2.2: --json flag wiring)
- 次段: `next_step` + `candidates` 自動推論 / `conflicts_with` validation (1.0.x で minor 積み増し予定)
