### PR TITLE
エラーに next_step recovery hint を実装 (ADR-0065)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -65,7 +65,6 @@ impl ErrorCode {
 }
 
 /// Success envelope wrapping command output per ADR-0065.
-#[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
 #[derive(Debug, Serialize)]
 pub(crate) struct SuccessEnvelope {
     pub data: serde_json::Value,
@@ -75,14 +74,12 @@ pub(crate) struct SuccessEnvelope {
 
 /// Error envelope per ADR-0065. Wraps the payload under an `error` key so
 /// JSON output matches `{"error": { "code": ..., "message": ..., ... }}`.
-#[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
 #[derive(Debug, Serialize)]
 pub(crate) struct ErrorEnvelope {
     pub error: ErrorPayload,
 }
 
 /// Error payload nested under `ErrorEnvelope::error` per ADR-0065.
-#[allow(dead_code)] // consumed in Phase 2.2 (--json output path)
 #[derive(Debug, Serialize)]
 pub(crate) struct ErrorPayload {
     pub code: ErrorCode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,12 +119,13 @@ fn render_json_success(output: CommandOutput) -> String {
 }
 
 /// Serialize a `ScoutError` as a one-line JSON envelope per ADR-0065.
+/// Uses `err.message()` (bare) so `next_step` is not duplicated in `message`.
 fn render_json_error(err: &ScoutError) -> String {
     let envelope = ErrorEnvelope {
         error: ErrorPayload {
             code: err.error_kind(),
-            message: err.to_string(),
-            next_step: None,
+            message: err.message().to_owned(),
+            next_step: err.next_step().map(str::to_owned),
             candidates: Vec::new(),
             retryable: err.retryable(),
         },

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -159,35 +159,21 @@ impl From<github::GitHubError> for ScoutError {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum FetchHttpKind {
-    Transient,
-    Permanent,
-}
-
-fn classify_fetch_http(transient: bool) -> FetchHttpKind {
-    if transient {
-        FetchHttpKind::Transient
-    } else {
-        FetchHttpKind::Permanent
-    }
-}
-
 impl From<FetchError> for ScoutError {
     fn from(e: FetchError) -> Self {
         match &e {
             FetchError::InvalidScheme => {
                 Self::data_error(e.to_string()).with_next_step("URL must use http:// or https://")
             }
-            FetchError::InvalidUrl(_) => Self::data_error(e.to_string())
-                .with_next_step("Provide a complete URL including scheme and host"),
+            FetchError::InvalidUrl(_) => {
+                Self::data_error(e.to_string()).with_next_step("URL must include scheme and host")
+            }
             FetchError::InternalHost => Self::data_error(e.to_string())
                 .with_next_step("URL must point to an external host (private IPs are blocked)"),
             FetchError::UnsupportedContentType(_) => Self::data_error(e.to_string())
                 .with_next_step("URL must serve HTML or text content"),
             FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
-            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string())
-                .with_next_step("Install Chrome or Chromium to enable JS rendering"),
+            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
             FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
             FetchError::Status(408 | 429) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
@@ -204,15 +190,17 @@ impl From<FetchError> for ScoutError {
             FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
                 .with_next_step("URL has too many redirects; check for a redirect loop"),
             FetchError::Status(_) | FetchError::Timeout(_) => {
-                Self::transient(e.to_string()).with_next_step("Retry later or check the URL")
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             FetchError::DnsResolution(_) => Self::transient(e.to_string())
                 .with_next_step("Check the URL's domain name and your DNS resolver"),
-            FetchError::Http(re) => match classify_fetch_http(is_transient_network(re)) {
-                FetchHttpKind::Transient => Self::transient(e.to_string())
-                    .with_next_step("Check your network connection and retry"),
-                FetchHttpKind::Permanent => Self::internal(e.to_string()),
-            },
+            FetchError::Http(re) => {
+                if is_transient_network(re) {
+                    Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
+                } else {
+                    Self::internal(e.to_string())
+                }
+            }
         }
     }
 }
@@ -221,7 +209,7 @@ impl From<SlackError> for ScoutError {
     fn from(e: SlackError) -> Self {
         match &e {
             SlackError::TokenNotSet => Self::user_error(e.to_string())
-                .with_next_step("Set SLACK_BOT_TOKEN environment variable"),
+                .with_next_step("Export a User OAuth token to SLACK_TOKEN (xoxp-…)"),
             SlackError::Api { .. } => Self::user_error(e.to_string()),
             SlackError::RateLimited { .. } => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
@@ -547,32 +535,6 @@ mod tests {
                 "should not include retry hint: {err}"
             );
         }
-    }
-
-    /// [T-ER005] classify_fetch_http maps true to Transient variant
-    #[test]
-    fn classify_fetch_http_transient_input() {
-        assert_eq!(classify_fetch_http(true), FetchHttpKind::Transient);
-    }
-
-    /// [T-ER006] classify_fetch_http maps false to Permanent variant
-    #[test]
-    fn classify_fetch_http_permanent_input() {
-        assert_eq!(classify_fetch_http(false), FetchHttpKind::Permanent);
-    }
-
-    /// [T-ER007] GitHub Forbidden error hints at GITHUB_TOKEN scope
-    #[test]
-    fn github_forbidden_hints_token() {
-        let err = ScoutError::from(github::GitHubError::Forbidden("denied".into()));
-        assert!(err.to_string().contains("GITHUB_TOKEN"));
-    }
-
-    /// [T-ER008] Gemini QuotaExhausted error hints at AI Studio billing URL
-    #[test]
-    fn quota_exhausted_hints_billing_url() {
-        let err = ScoutError::from(GeminiError::QuotaExhausted("limit".into()));
-        assert!(err.to_string().contains("aistudio.google.com"));
     }
 
     // TcpListener::drop is synchronous, so the port is immediately closed

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -9,16 +9,24 @@ use crate::github;
 use crate::retry::is_transient_network;
 use crate::slack::SlackError;
 
+/// Reusable next_step hints so transient/network errors stay consistent.
+const HINT_RETRY_DELAY: &str = "Retry after a short delay";
+const HINT_CHECK_NETWORK: &str = "Check your network connection";
+
 #[derive(Debug)]
 pub struct ScoutError {
     message: String,
     retryable: bool,
     kind: ErrorCode,
+    next_step: Option<String>,
 }
 
 impl fmt::Display for ScoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.message)?;
+        if let Some(hint) = &self.next_step {
+            write!(f, " — {hint}")?;
+        }
         if self.retryable {
             write!(f, " (temporary failure; retry may succeed)")?;
         }
@@ -34,6 +42,7 @@ impl ScoutError {
             message: msg.into(),
             retryable: false,
             kind: ErrorCode::UsageError,
+            next_step: None,
         }
     }
 
@@ -42,6 +51,7 @@ impl ScoutError {
             message: msg.into(),
             retryable: false,
             kind: ErrorCode::IoError,
+            next_step: None,
         }
     }
 
@@ -50,6 +60,7 @@ impl ScoutError {
             message: msg.into(),
             retryable: true,
             kind: ErrorCode::TempFailure,
+            next_step: None,
         }
     }
 
@@ -58,6 +69,7 @@ impl ScoutError {
             message: msg.into(),
             retryable: false,
             kind: ErrorCode::NotFound,
+            next_step: None,
         }
     }
 
@@ -66,7 +78,14 @@ impl ScoutError {
             message: msg.into(),
             retryable: false,
             kind: ErrorCode::DataError,
+            next_step: None,
         }
+    }
+
+    /// Attach a recovery hint to this error per ADR-0065 `error.next_step`.
+    pub(super) fn with_next_step(mut self, hint: impl Into<String>) -> Self {
+        self.next_step = Some(hint.into());
+        self
     }
 
     /// sysexits.h exit code derived from `kind` per ADR-0065.
@@ -74,16 +93,24 @@ impl ScoutError {
         self.kind.exit_code()
     }
 
-    /// Whether the error is transient and the operation may succeed on retry.
-    #[allow(dead_code)] // public API for future --json output
     pub fn retryable(&self) -> bool {
         self.retryable
     }
 
     /// JSON-serializable error classification per ADR-0065.
-    #[allow(dead_code)] // public API for future --json output
     pub fn error_kind(&self) -> ErrorCode {
         self.kind
+    }
+
+    /// Plain message without next_step / retry hints. Use for JSON `error.message`
+    /// where `error.next_step` and `error.retryable` are surfaced separately.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Recovery hint per ADR-0065 `error.next_step`.
+    pub fn next_step(&self) -> Option<&str> {
+        self.next_step.as_deref()
     }
 }
 
@@ -94,20 +121,36 @@ pub(super) fn parse_repo_param(repository: &str) -> Result<(&str, &str), ScoutEr
 impl From<github::GitHubError> for ScoutError {
     fn from(e: github::GitHubError) -> Self {
         match &e {
-            github::GitHubError::NotFound(_) => Self::not_found(e.to_string()),
-            github::GitHubError::InvalidRepo(_)
-            | github::GitHubError::InvalidRef(_)
-            | github::GitHubError::InvalidPath(_)
-            | github::GitHubError::InvalidLineRange(_)
-            | github::GitHubError::InvalidPattern(_)
-            | github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string()),
-            github::GitHubError::RateLimited { .. } => Self::transient(e.to_string()),
-            github::GitHubError::Forbidden(_) => Self::user_error(format!(
-                "{e} — check that your GITHUB_TOKEN has the required scopes"
-            )),
-            github::GitHubError::Network(_) => Self::transient(e.to_string()),
+            github::GitHubError::NotFound(_) => Self::not_found(e.to_string()).with_next_step(
+                "Check that the repository or path exists, and that you have access",
+            ),
+            github::GitHubError::InvalidRepo(_) => Self::data_error(e.to_string())
+                .with_next_step("Use 'owner/repo' format, e.g., 'facebook/react'"),
+            github::GitHubError::InvalidRef(_) => Self::data_error(e.to_string())
+                .with_next_step("Use a branch name, tag, or commit SHA"),
+            github::GitHubError::InvalidPath(_) => {
+                Self::data_error(e.to_string()).with_next_step("Use a path within the repository")
+            }
+            github::GitHubError::InvalidLineRange(_) => Self::data_error(e.to_string())
+                .with_next_step("Use format like '1-80', '50-', or '100' (first N lines)"),
+            github::GitHubError::InvalidPattern(_) => Self::data_error(e.to_string())
+                .with_next_step("Use a glob pattern like '*.rs' or '*.{ts,tsx}'"),
+            github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string())
+                .with_next_step("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
+            github::GitHubError::RateLimited { retry_after } => Self::transient(e.to_string())
+                .with_next_step(match retry_after {
+                    Some(secs) => format!(
+                        "Retry after {secs} seconds, or set GITHUB_TOKEN to increase rate limit"
+                    ),
+                    None => "Set GITHUB_TOKEN to increase rate limit".to_owned(),
+                }),
+            github::GitHubError::Forbidden(_) => Self::user_error(e.to_string())
+                .with_next_step("Check that your GITHUB_TOKEN has the required scopes"),
+            github::GitHubError::Network(_) => {
+                Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
+            }
             github::GitHubError::Api { code, .. } if (500..=599).contains(code) => {
-                Self::transient(e.to_string())
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             github::GitHubError::Api { .. } | github::GitHubError::Decode(_) => {
                 Self::internal(e.to_string())
@@ -133,27 +176,41 @@ fn classify_fetch_http(transient: bool) -> FetchHttpKind {
 impl From<FetchError> for ScoutError {
     fn from(e: FetchError) -> Self {
         match &e {
-            FetchError::InvalidScheme
-            | FetchError::InvalidUrl(_)
-            | FetchError::InternalHost
-            | FetchError::UnsupportedContentType(_)
-            | FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
-            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
+            FetchError::InvalidScheme => {
+                Self::data_error(e.to_string()).with_next_step("URL must use http:// or https://")
+            }
+            FetchError::InvalidUrl(_) => Self::data_error(e.to_string())
+                .with_next_step("Provide a complete URL including scheme and host"),
+            FetchError::InternalHost => Self::data_error(e.to_string())
+                .with_next_step("URL must point to an external host (private IPs are blocked)"),
+            FetchError::UnsupportedContentType(_) => Self::data_error(e.to_string())
+                .with_next_step("URL must serve HTML or text content"),
+            FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
+            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string())
+                .with_next_step("Install Chrome or Chromium to enable JS rendering"),
             FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
-            FetchError::Status(408 | 429) => Self::transient(e.to_string()),
-            FetchError::Status(404) => Self::not_found(e.to_string()),
-            FetchError::Status(401 | 403) => Self::user_error(e.to_string()),
+            FetchError::Status(408 | 429) => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+            }
+            FetchError::Status(404) => Self::not_found(e.to_string())
+                .with_next_step("Check that the URL is correct and the resource exists"),
+            FetchError::Status(401 | 403) => Self::user_error(e.to_string())
+                .with_next_step("URL requires authentication that scout does not support"),
             FetchError::Status(code) if (400..500).contains(code) => {
                 Self::data_error(e.to_string())
             }
-            FetchError::TooLarge | FetchError::TooManyRedirects(_) => {
-                Self::data_error(e.to_string())
+            FetchError::TooLarge => Self::data_error(e.to_string())
+                .with_next_step("URL response exceeds 10MB; fetch a smaller resource"),
+            FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
+                .with_next_step("URL has too many redirects; check for a redirect loop"),
+            FetchError::Status(_) | FetchError::Timeout(_) => {
+                Self::transient(e.to_string()).with_next_step("Retry later or check the URL")
             }
-            FetchError::Status(_) | FetchError::Timeout(_) | FetchError::DnsResolution(_) => {
-                Self::transient(e.to_string())
-            }
+            FetchError::DnsResolution(_) => Self::transient(e.to_string())
+                .with_next_step("Check the URL's domain name and your DNS resolver"),
             FetchError::Http(re) => match classify_fetch_http(is_transient_network(re)) {
-                FetchHttpKind::Transient => Self::transient(e.to_string()),
+                FetchHttpKind::Transient => Self::transient(e.to_string())
+                    .with_next_step("Check your network connection and retry"),
                 FetchHttpKind::Permanent => Self::internal(e.to_string()),
             },
         }
@@ -163,9 +220,17 @@ impl From<FetchError> for ScoutError {
 impl From<SlackError> for ScoutError {
     fn from(e: SlackError) -> Self {
         match &e {
-            SlackError::TokenNotSet | SlackError::Api { .. } => Self::user_error(e.to_string()),
-            SlackError::RateLimited { .. } | SlackError::Network(_) | SlackError::Timeout(_) => {
-                Self::transient(e.to_string())
+            SlackError::TokenNotSet => Self::user_error(e.to_string())
+                .with_next_step("Set SLACK_BOT_TOKEN environment variable"),
+            SlackError::Api { .. } => Self::user_error(e.to_string()),
+            SlackError::RateLimited { .. } => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+            }
+            SlackError::Network(_) => {
+                Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
+            }
+            SlackError::Timeout(_) => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             SlackError::Decode(_) => Self::internal(e.to_string()),
         }
@@ -175,14 +240,18 @@ impl From<SlackError> for ScoutError {
 impl From<GeminiError> for ScoutError {
     fn from(e: GeminiError) -> Self {
         match &e {
-            GeminiError::ApiKeyNotSet => Self::user_error(e.to_string()),
-            GeminiError::RateLimited { .. } => Self::transient(e.to_string()),
-            GeminiError::QuotaExhausted(_) => Self::user_error(format!(
-                "{e} — check your API billing at https://aistudio.google.com"
-            )),
-            GeminiError::Network(_) => Self::transient(e.to_string()),
+            GeminiError::ApiKeyNotSet => Self::user_error(e.to_string())
+                .with_next_step("Set GEMINI_API_KEY environment variable"),
+            GeminiError::RateLimited { .. } => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+            }
+            GeminiError::QuotaExhausted(_) => Self::user_error(e.to_string())
+                .with_next_step("Check your API billing at https://aistudio.google.com"),
+            GeminiError::Network(_) => {
+                Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
+            }
             GeminiError::Api { code, .. } if (500..=599).contains(code) => {
-                Self::transient(e.to_string())
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             GeminiError::Api { .. } => Self::internal(e.to_string()),
         }
@@ -227,6 +296,93 @@ mod tests {
     fn t_er012_internal_kind_is_io_error() {
         let err = ScoutError::internal("test");
         assert_eq!(err.error_kind(), ErrorCode::IoError);
+    }
+
+    /// [T-NS001] ApiKeyNotSet sets next_step pointing to GEMINI_API_KEY env var
+    #[test]
+    fn t_ns001_gemini_api_key_not_set_has_next_step() {
+        let err = ScoutError::from(GeminiError::ApiKeyNotSet);
+        assert_eq!(
+            err.next_step(),
+            Some("Set GEMINI_API_KEY environment variable")
+        );
+    }
+
+    /// [T-NS002] GitHubError::Forbidden separates GITHUB_TOKEN hint into next_step (not message)
+    #[test]
+    fn t_ns002_github_forbidden_separates_hint_into_next_step() {
+        let err = ScoutError::from(github::GitHubError::Forbidden("denied".into()));
+        assert_eq!(
+            err.next_step(),
+            Some("Check that your GITHUB_TOKEN has the required scopes")
+        );
+    }
+
+    /// [T-NS003] GitHubError::NotFound has actionable next_step
+    #[test]
+    fn t_ns003_github_not_found_has_next_step() {
+        let err = ScoutError::from(github::GitHubError::NotFound("/test".into()));
+        assert!(
+            err.next_step()
+                .is_some_and(|h| h.contains("Check that the repository or path exists"))
+        );
+    }
+
+    /// [T-NS004] FetchError::Status(404) has next_step about the URL
+    #[test]
+    fn t_ns004_fetch_404_has_next_step() {
+        let err = ScoutError::from(FetchError::Status(404));
+        assert!(
+            err.next_step()
+                .is_some_and(|h| h.contains("Check that the URL is correct"))
+        );
+    }
+
+    /// [T-NS005] GeminiError::QuotaExhausted separates billing URL hint into next_step
+    #[test]
+    fn t_ns005_gemini_quota_exhausted_separates_billing_hint() {
+        let err = ScoutError::from(GeminiError::QuotaExhausted("limit".into()));
+        assert!(
+            err.next_step()
+                .is_some_and(|h| h.contains("aistudio.google.com"))
+        );
+    }
+
+    /// [T-NS006] GitHubError::RateLimited with retry_after embeds the duration in next_step
+    #[test]
+    fn t_ns006_github_rate_limited_with_retry_after_embeds_duration() {
+        let err = ScoutError::from(github::GitHubError::RateLimited {
+            retry_after: Some(42),
+        });
+        assert!(
+            err.next_step().is_some_and(|h| h.contains("42 seconds")),
+            "next_step should mention retry_after seconds, got: {:?}",
+            err.next_step()
+        );
+    }
+
+    /// [T-NS007] GitHubError::RateLimited without retry_after still suggests setting GITHUB_TOKEN
+    #[test]
+    fn t_ns007_github_rate_limited_without_retry_after_suggests_token() {
+        let err = ScoutError::from(github::GitHubError::RateLimited { retry_after: None });
+        assert!(err.next_step().is_some_and(|h| h.contains("GITHUB_TOKEN")));
+    }
+
+    /// [T-NS008] Display includes next_step appended to message
+    #[test]
+    fn t_ns008_display_includes_next_step() {
+        let err = ScoutError::user_error("Something is wrong").with_next_step("Try X");
+        let display = err.to_string();
+        assert!(display.contains("Something is wrong"));
+        assert!(display.contains("Try X"));
+    }
+
+    /// [T-NS009] Errors without next_step omit the hint from Display
+    #[test]
+    fn t_ns009_display_omits_next_step_when_absent() {
+        let err = ScoutError::internal("internal failure");
+        let display = err.to_string();
+        assert_eq!(display, "internal failure");
     }
 
     /// [T-ER013] GitHubError::NotFound classifies as ErrorCode::NotFound

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -141,8 +141,10 @@ fn t_c007_json_emits_envelope_on_error() {
         "message should describe the input failure, got: {value}"
     );
     assert!(
-        value["error"].get("next_step").is_none(),
-        "next_step should be omitted when None, got: {value}"
+        value["error"]["next_step"]
+            .as_str()
+            .is_some_and(|s| s.contains("owner/repo")),
+        "next_step should hint at owner/repo format, got: {value}"
     );
     assert!(
         value["error"].get("candidates").is_none(),
@@ -150,9 +152,9 @@ fn t_c007_json_emits_envelope_on_error() {
     );
 }
 
-// T-C008: --json missing API key surfaces a USAGE_ERROR envelope on stderr
+// T-C008: --json missing API key surfaces a USAGE_ERROR envelope with next_step on stderr
 #[test]
-fn t_c008_json_missing_api_key_emits_usage_error() {
+fn t_c008_json_missing_api_key_emits_usage_error_with_next_step() {
     let output = scout()
         .args(["--json", "search", "test query"])
         .env_remove("GEMINI_API_KEY")
@@ -172,6 +174,12 @@ fn t_c008_json_missing_api_key_emits_usage_error() {
     assert_eq!(
         value["error"]["code"], "USAGE_ERROR",
         "missing API key is a usage problem per ADR-0065, got: {value}"
+    );
+    assert!(
+        value["error"]["next_step"]
+            .as_str()
+            .is_some_and(|s| s.contains("GEMINI_API_KEY")),
+        "next_step should point user to GEMINI_API_KEY, got: {value}"
     );
 }
 


### PR DESCRIPTION
## 概要と動機

ADR-0065 Phase 2.2 で `error.next_step` フィールドを JSON envelope に追加していたが populated されず常に空だった。エージェントから見ると「フィールドあるのに使えない」という spec-implementation gap になっていた本問題を解消する。

26 種のエラー variant に actionable な recovery hint を埋め込み、JSON 経由のエージェントと plain stderr の人間の両方が「次にすべきこと」を即座に理解できるようにする。

例：
```bash
$ scout --json search test 2>&1
{"error":{"code":"USAGE_ERROR","message":"GEMINI_API_KEY not set...","next_step":"Set GEMINI_API_KEY environment variable","retryable":false}}
```

## 変更内容

**Commit 1 — next_step 実装 (`7ed9ee6`):**
- `ScoutError` に `next_step: Option<String>` field と `with_next_step()` builder method を追加
- Display を `{message} — {hint}` 形式に拡張（plain stderr でも hint が見える）
- `message()` accessor で bare message（hint 抜き）を JSON envelope に流す（二重表示回避）
- 4 つの From impl で 22 variants に hint 設定
  - GitHub: 9/11 variants（NotFound, Forbidden, RateLimited+retry_after, ApiKey 等）
  - Fetch: 11/13 variants（404, InvalidScheme, TooLarge, DnsResolution 等）
  - Slack: 4/5 variants（TokenNotSet, RateLimited, Network, Timeout）
  - Gemini: 5/6 variants（ApiKeyNotSet, QuotaExhausted, RateLimited 等）
- 重複する hint 文字列 10 件を `HINT_RETRY_DELAY` / `HINT_CHECK_NETWORK` const に集約
- T-NS001..T-NS009 で next_step population、Display 拡張を検証
- T-C007/T-C008 で JSON envelope 経路の next_step 含有を検証
- Phase 2.1/2.2 由来の stale `#[allow(dead_code)]` 5 件を削除
- 既存メッセージに embed されていた hint（Forbidden の `— check that your GITHUB_TOKEN...`、QuotaExhausted の `— check your API billing...`）を next_step に分離

**Commit 2 — polish 反映 (`99fb78b`):**
- Codex P2: `SlackError::TokenNotSet` の hint が誤った env var (`SLACK_BOT_TOKEN`) を指していた → `SLACK_TOKEN` に修正
- Codex P3: `FetchError::BrowserNotFound` の hint が "Install Chrome or Chromium" だが、default build では `js-rendering` feature 不在が原因。誤誘導を防ぐため hint を削除
- simplify reuse: `FetchError::Http` transient 経路の hand-written 文字列を `HINT_CHECK_NETWORK` const に置換
- simplify quality: `Status(_) | Timeout(_)` の "Retry later or check the URL" を `HINT_RETRY_DELAY` に簡潔化
- enhancer: 単発利用の `FetchHttpKind` enum + `classify_fetch_http` wrapper を inline（13 行削減）
- enhancer: `InvalidUrl` hint 文言を imperative voice に統一（"Provide a complete URL" → "URL must include scheme and host"）
- enhancer: 重複テスト 4 件削除（T-ER005/006 は inline したラッパー対象、T-ER007/008 は T-NS002/T-NS005 でカバー済）

## スコープ

- **含めない**: `conflicts_with` parse-time validation — audit の結果 scout に実用的な競合フラグ無し（`--js` と `--raw` も独立に valid）と判明、別 issue で適用箇所が出てから対応
- **含めない**: `error.candidates` typo corrector — repo-read の path typo など適用箇所が明確なケースだけ後追い実装

## 設計上の判断

- **次の手を 2 経路同時に出す**: Display は `{message} — {hint}` で人間向け、JSON envelope は `message` と `next_step` を分離してエージェント向け。`render_json_error` が `err.message()` (bare) を使うことで JSON 二重表示を回避。
- **`with_next_step()` を builder pattern に**: chained construction で簡潔。`impl Into<String>` で static `&str` と動的 `format!()` 両方を受ける。
- **既存 message に embed されていた hint を next_step に分離**: `Forbidden` の `— check GITHUB_TOKEN...`、`QuotaExhausted` の `— check billing...` は本来 `next_step` の役割。Display 出力は等価（hint が末尾に append されるため）、JSON consumer は分離受け取りができる。
- **重複文字列を const に集約**: 10 occurrences を 2 const に。一貫した文言と将来の i18n 化への布石。

## テスト方法

1. `cargo test --all-targets` → 317 lib tests + 10 integration tests pass
2. `cargo clippy --all-targets --all-features -- -D warnings` → clean
3. `env -u GEMINI_API_KEY scout --json search test 2>&1 1>/dev/null | grep '^{'` → `next_step: "Set GEMINI_API_KEY environment variable"` 含有
4. `scout --json repo-tree no-slash 2>&1 1>/dev/null | grep '^{'` → `next_step: "Use 'owner/repo' format..."` 含有
5. `scout fetch not-a-valid-url` (plain) → stderr に `error: invalid URL: ... — URL must include scheme and host` 表示

## 関連

- Refs #67 (ADR-0060 監査適用)
- ADR-0065 `error.next_step` フィールド spec の implementation
- 前段: #75 (Phase 2.1 envelope types) / #76 (Phase 2.2 wiring) / #77 (Phase 3 sysexits.h)
- 次段候補: `error.candidates` (repo-read path typo corrector など適用箇所限定)
