### PR TITLE
エラーに candidates (typo corrector) を実装し ADR-0060 監査を完了

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ fn render_json_error(err: &ScoutError) -> String {
             code: err.error_kind(),
             message: err.message().to_owned(),
             next_step: err.next_step().map(str::to_owned),
-            candidates: Vec::new(),
+            candidates: err.candidates().to_vec(),
             retryable: err.retryable(),
         },
     };

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -513,8 +513,19 @@ impl Scout {
     }
 }
 
-/// Best-effort: fetch the repo tree and return up to 3 paths most similar
-/// to `target` (OSA distance ≤ 3). Returns empty on any API failure.
+/// Maximum time spent on best-effort candidate generation in the NotFound
+/// error path. The user is already waiting on a failure; we'd rather skip
+/// candidates than block them on a slow tree fetch.
+const CANDIDATE_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum OSA distance and number of suggestions returned per error.
+const CANDIDATE_MAX_DISTANCE: usize = 3;
+const CANDIDATE_TOP_N: usize = 3;
+
+/// Best-effort: fetch the repo tree and return up to `CANDIDATE_TOP_N` paths
+/// most similar to `target` (OSA distance ≤ `CANDIDATE_MAX_DISTANCE`).
+/// Returns empty on any API failure or if the fetch exceeds
+/// `CANDIDATE_FETCH_TIMEOUT`.
 async fn collect_path_candidates(
     github: &GitHubClient,
     owner: &str,
@@ -522,24 +533,37 @@ async fn collect_path_candidates(
     ref_: Option<&str>,
     target: &str,
 ) -> Vec<String> {
-    let resolved_ref = match ref_ {
-        Some(r) => r.to_owned(),
-        None => match github.get_repo(owner, repo).await {
-            Ok(info) => info.default_branch,
-            Err(_) => return Vec::new(),
-        },
+    let fut = async {
+        let resolved_ref = match ref_ {
+            Some(r) => r.to_owned(),
+            None => match github.get_repo(owner, repo).await {
+                Ok(info) => info.default_branch,
+                Err(e) => {
+                    warn!(%e, "candidate fetch: get_repo failed");
+                    return Vec::new();
+                }
+            },
+        };
+        let tree = match github.get_tree(owner, repo, &resolved_ref).await {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(%e, "candidate fetch: get_tree failed");
+                return Vec::new();
+            }
+        };
+        if tree.truncated {
+            warn!("candidate fetch: tree truncated (>100k entries); candidates may be incomplete");
+        }
+        let entries = tree
+            .tree
+            .iter()
+            .filter(|e| matches!(e.entry_type, github::types::EntryType::Blob))
+            .map(|e| e.path.as_str());
+        typo::closest_matches(target, entries, CANDIDATE_MAX_DISTANCE, CANDIDATE_TOP_N)
     };
-    let tree = match github.get_tree(owner, repo, &resolved_ref).await {
-        Ok(t) => t,
-        Err(_) => return Vec::new(),
-    };
-    let entries: Vec<&str> = tree
-        .tree
-        .iter()
-        .filter(|e| matches!(e.entry_type, github::types::EntryType::Blob))
-        .map(|e| e.path.as_str())
-        .collect();
-    typo::closest_matches(target, entries.iter().copied(), 3, 3)
+    timeout(CANDIDATE_FETCH_TIMEOUT, fut)
+        .await
+        .unwrap_or_default()
 }
 
 async fn resolve_readme(

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,5 +1,6 @@
 mod errors;
 mod params;
+mod typo;
 
 pub use errors::ScoutError;
 pub use params::Command;
@@ -394,9 +395,23 @@ impl Scout {
 
         let github = self.github().await;
 
-        let contents = github
+        let contents = match github
             .get_contents(owner, repo, &path, params.ref_.as_deref())
-            .await?;
+            .await
+        {
+            Ok(c) => c,
+            Err(github::GitHubError::NotFound(_)) => {
+                let candidates =
+                    collect_path_candidates(github, owner, repo, params.ref_.as_deref(), &path)
+                        .await;
+                let mut err = ScoutError::from(github::GitHubError::NotFound(path.clone()));
+                if !candidates.is_empty() {
+                    err = err.with_candidates(candidates);
+                }
+                return Err(err);
+            }
+            Err(e) => return Err(ScoutError::from(e)),
+        };
 
         let hint = params.encoding.as_deref();
         let decode_result =
@@ -496,6 +511,35 @@ impl Scout {
         );
         Ok(CommandOutput::with_notes(markdown, data, notes))
     }
+}
+
+/// Best-effort: fetch the repo tree and return up to 3 paths most similar
+/// to `target` (OSA distance ≤ 3). Returns empty on any API failure.
+async fn collect_path_candidates(
+    github: &GitHubClient,
+    owner: &str,
+    repo: &str,
+    ref_: Option<&str>,
+    target: &str,
+) -> Vec<String> {
+    let resolved_ref = match ref_ {
+        Some(r) => r.to_owned(),
+        None => match github.get_repo(owner, repo).await {
+            Ok(info) => info.default_branch,
+            Err(_) => return Vec::new(),
+        },
+    };
+    let tree = match github.get_tree(owner, repo, &resolved_ref).await {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    let entries: Vec<&str> = tree
+        .tree
+        .iter()
+        .filter(|e| matches!(e.entry_type, github::types::EntryType::Blob))
+        .map(|e| e.path.as_str())
+        .collect();
+    typo::closest_matches(target, entries.iter().copied(), 3, 3)
 }
 
 async fn resolve_readme(

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -19,6 +19,7 @@ pub struct ScoutError {
     retryable: bool,
     kind: ErrorCode,
     next_step: Option<String>,
+    candidates: Vec<String>,
 }
 
 impl fmt::Display for ScoutError {
@@ -43,6 +44,7 @@ impl ScoutError {
             retryable: false,
             kind: ErrorCode::UsageError,
             next_step: None,
+            candidates: Vec::new(),
         }
     }
 
@@ -52,6 +54,7 @@ impl ScoutError {
             retryable: false,
             kind: ErrorCode::IoError,
             next_step: None,
+            candidates: Vec::new(),
         }
     }
 
@@ -61,6 +64,7 @@ impl ScoutError {
             retryable: true,
             kind: ErrorCode::TempFailure,
             next_step: None,
+            candidates: Vec::new(),
         }
     }
 
@@ -70,6 +74,7 @@ impl ScoutError {
             retryable: false,
             kind: ErrorCode::NotFound,
             next_step: None,
+            candidates: Vec::new(),
         }
     }
 
@@ -79,12 +84,19 @@ impl ScoutError {
             retryable: false,
             kind: ErrorCode::DataError,
             next_step: None,
+            candidates: Vec::new(),
         }
     }
 
     /// Attach a recovery hint to this error per ADR-0065 `error.next_step`.
     pub(super) fn with_next_step(mut self, hint: impl Into<String>) -> Self {
         self.next_step = Some(hint.into());
+        self
+    }
+
+    /// Attach correction candidates per ADR-0065 `error.candidates` (e.g., typo suggestions).
+    pub(super) fn with_candidates(mut self, candidates: Vec<String>) -> Self {
+        self.candidates = candidates;
         self
     }
 
@@ -111,6 +123,11 @@ impl ScoutError {
     /// Recovery hint per ADR-0065 `error.next_step`.
     pub fn next_step(&self) -> Option<&str> {
         self.next_step.as_deref()
+    }
+
+    /// Correction candidates per ADR-0065 `error.candidates` (e.g., similar paths after typo).
+    pub fn candidates(&self) -> &[String] {
+        &self.candidates
     }
 }
 
@@ -284,6 +301,21 @@ mod tests {
     fn t_er012_internal_kind_is_io_error() {
         let err = ScoutError::internal("test");
         assert_eq!(err.error_kind(), ErrorCode::IoError);
+    }
+
+    /// [T-CD001] Errors default to empty candidates list
+    #[test]
+    fn t_cd001_default_candidates_empty() {
+        let err = ScoutError::not_found("test");
+        assert!(err.candidates().is_empty());
+    }
+
+    /// [T-CD002] with_candidates attaches correction suggestions
+    #[test]
+    fn t_cd002_with_candidates_attaches_list() {
+        let err = ScoutError::not_found("path not found")
+            .with_candidates(vec!["README.md".into(), "REDAME.md".into()]);
+        assert_eq!(err.candidates(), &["README.md", "REDAME.md"]);
     }
 
     /// [T-NS001] ApiKeyNotSet sets next_step pointing to GEMINI_API_KEY env var

--- a/src/tools/typo.rs
+++ b/src/tools/typo.rs
@@ -3,11 +3,16 @@
 //! Uses Optimal String Alignment (OSA) distance — Levenshtein extended with
 //! adjacent transpositions, so "REDAME" matches "README" at distance 1.
 
-/// Compute the OSA distance between two strings.
-/// Allowed edit operations: insert, delete, substitute, transpose adjacent.
-pub(super) fn osa_distance(a: &str, b: &str) -> usize {
+#[cfg(test)]
+fn osa_distance(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();
+    osa_distance_chars(&a, &b)
+}
+
+/// Compute the OSA distance between two char slices.
+/// Allowed edit operations: insert, delete, substitute, transpose adjacent.
+fn osa_distance_chars(a: &[char], b: &[char]) -> usize {
     let m = a.len();
     let n = b.len();
 
@@ -50,9 +55,13 @@ pub(super) fn closest_matches<'a>(
     max_distance: usize,
     top_n: usize,
 ) -> Vec<String> {
+    let target: Vec<char> = target.chars().collect();
     let mut scored: Vec<(usize, &str)> = pool
         .into_iter()
-        .map(|c| (osa_distance(target, c), c))
+        .map(|c| {
+            let candidate: Vec<char> = c.chars().collect();
+            (osa_distance_chars(&target, &candidate), c)
+        })
         .filter(|(d, _)| *d <= max_distance)
         .collect();
     scored.sort_by_key(|(d, _)| *d);

--- a/src/tools/typo.rs
+++ b/src/tools/typo.rs
@@ -1,0 +1,137 @@
+//! Typo correction utilities for ADR-0065 `error.candidates`.
+//!
+//! Uses Optimal String Alignment (OSA) distance — Levenshtein extended with
+//! adjacent transpositions, so "REDAME" matches "README" at distance 1.
+
+/// Compute the OSA distance between two strings.
+/// Allowed edit operations: insert, delete, substitute, transpose adjacent.
+pub(super) fn osa_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let m = a.len();
+    let n = b.len();
+
+    if m == 0 {
+        return n;
+    }
+    if n == 0 {
+        return m;
+    }
+
+    let mut d = vec![vec![0usize; n + 1]; m + 1];
+    for (i, row) in d.iter_mut().enumerate() {
+        row[0] = i;
+    }
+    for (j, val) in d[0].iter_mut().enumerate() {
+        *val = j;
+    }
+
+    for i in 1..=m {
+        for j in 1..=n {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            d[i][j] = (d[i - 1][j] + 1)
+                .min(d[i][j - 1] + 1)
+                .min(d[i - 1][j - 1] + cost);
+
+            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                d[i][j] = d[i][j].min(d[i - 2][j - 2] + 1);
+            }
+        }
+    }
+
+    d[m][n]
+}
+
+/// Pick the top-N closest matches by OSA distance, filtered by `max_distance`.
+/// Sorted by ascending distance (most similar first).
+pub(super) fn closest_matches<'a>(
+    target: &str,
+    pool: impl IntoIterator<Item = &'a str>,
+    max_distance: usize,
+    top_n: usize,
+) -> Vec<String> {
+    let mut scored: Vec<(usize, &str)> = pool
+        .into_iter()
+        .map(|c| (osa_distance(target, c), c))
+        .filter(|(d, _)| *d <= max_distance)
+        .collect();
+    scored.sort_by_key(|(d, _)| *d);
+    scored
+        .into_iter()
+        .take(top_n)
+        .map(|(_, c)| c.to_owned())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [T-TY001] osa_distance: identical strings have distance 0
+    #[test]
+    fn t_ty001_identical_strings_have_distance_zero() {
+        assert_eq!(osa_distance("README.md", "README.md"), 0);
+        assert_eq!(osa_distance("", ""), 0);
+    }
+
+    /// [T-TY002] osa_distance: empty input returns the other's length
+    #[test]
+    fn t_ty002_empty_input_returns_length() {
+        assert_eq!(osa_distance("", "hello"), 5);
+        assert_eq!(osa_distance("hello", ""), 5);
+    }
+
+    /// [T-TY003] osa_distance: single transposition counts as 1
+    #[test]
+    fn t_ty003_transposition_counts_as_one() {
+        assert_eq!(osa_distance("REDAME", "README"), 1);
+        assert_eq!(osa_distance("ab", "ba"), 1);
+    }
+
+    /// [T-TY004] osa_distance: substitution counts as 1
+    #[test]
+    fn t_ty004_substitution_counts_as_one() {
+        assert_eq!(osa_distance("kitten", "sitten"), 1);
+    }
+
+    /// [T-TY005] osa_distance: classic kitten/sitting case is 3
+    #[test]
+    fn t_ty005_kitten_sitting_distance_three() {
+        assert_eq!(osa_distance("kitten", "sitting"), 3);
+    }
+
+    /// [T-TY006] closest_matches: returns top-N filtered by max_distance
+    #[test]
+    fn t_ty006_closest_matches_filters_by_distance() {
+        let pool = ["README.md", "Cargo.toml", "src/main.rs", "REDAME.md"];
+        let matches = closest_matches("REDME.md", pool.iter().copied(), 3, 3);
+        assert!(matches.contains(&"REDAME.md".to_owned()));
+        assert!(matches.contains(&"README.md".to_owned()));
+        assert!(!matches.contains(&"Cargo.toml".to_owned()));
+        assert!(!matches.contains(&"src/main.rs".to_owned()));
+    }
+
+    /// [T-TY007] closest_matches: empty pool returns empty
+    #[test]
+    fn t_ty007_closest_matches_empty_pool_returns_empty() {
+        let pool: Vec<&str> = vec![];
+        let matches = closest_matches("REDAME.md", pool, 3, 3);
+        assert!(matches.is_empty());
+    }
+
+    /// [T-TY008] closest_matches: all-too-far returns empty
+    #[test]
+    fn t_ty008_closest_matches_all_too_far_returns_empty() {
+        let pool = ["totally-different.txt", "completely-unrelated.json"];
+        let matches = closest_matches("REDAME.md", pool.iter().copied(), 3, 3);
+        assert!(matches.is_empty());
+    }
+
+    /// [T-TY009] closest_matches: respects top_n cap even with many in-range
+    #[test]
+    fn t_ty009_closest_matches_respects_top_n_cap() {
+        let pool = ["a", "ab", "abc", "abcd", "abcde"];
+        let matches = closest_matches("a", pool.iter().copied(), 5, 2);
+        assert_eq!(matches.len(), 2);
+    }
+}


### PR DESCRIPTION
## 概要と動機

ADR-0065 の `error.candidates` フィールドを実装し、ADR-0060 / ADR-0065 の agent-friendly CLI 監査 (#67) を **完了** する。

repo-read で path typo が発生したときに repo tree を best-effort で fetch して OSA distance で類似 path を suggest する。エージェントが typo を即座に修正できる体験を提供。

例：
```bash
$ scout --json repo-read facebook/react REDAME.md 2>&1
{"error":{"code":"NOT_FOUND","message":"...","next_step":"Check that the repository or path exists, and that you have access","candidates":["README.md"],"retryable":false}}
```

## 変更内容

**Commit 1 — candidates 実装 (`86bc6bb`)**:
- `ScoutError` に `candidates: Vec<String>` field、`with_candidates()` builder、`candidates() -> &[String]` accessor を追加
- 新規 `src/tools/typo.rs`: `osa_distance` (Optimal String Alignment Distance, transposition 含む)、`closest_matches` (top-N filter + sort)
- 新規 `collect_path_candidates()` helper in `tools.rs`: tree fetch + Blob filter + OSA distance match
- `repo_read` が `GitHubError::NotFound` を intercept して候補を attach
- `lib.rs render_json_error` で `err.candidates().to_vec()` を envelope に流す
- T-TY001..T-TY009 (osa_distance + closest_matches), T-CD001/T-CD002 (ScoutError builder/accessor)

**Commit 2 — polish (`3297819`)**:
- CodeRabbit major: 5秒の `tokio::time::timeout` で candidate fetch を bound（巨大 repo で 60s+ ブロックを防止）
- simplify quality CQ2: `tracing::warn!` で get_repo / get_tree 失敗を可視化
- Tree truncated (>100k entries) 時の警告 log
- simplify EFF-1: `closest_matches` で target chars を一度だけ precompute（80k repo で 80k 回の Vec<char> alloc を回避）
- simplify EFF-3: 中間 `Vec<&str>` を iterator chain に
- simplify CQ3: magic numbers `3, 3` を `CANDIDATE_MAX_DISTANCE` / `CANDIDATE_TOP_N` const に
- enhancer: `osa_distance` を `#[cfg(test)]` 限定（production は `osa_distance_chars` 直接呼び出し）

## スコープ

- **含めない**: 他の error variants 用の candidates（path 以外、URL typo correction 等）→ scout の error space で実用的なのは path typo のみと判断
- **含めない**: levenshtein crate 依存 → 実装は ~50 行で完結、外部 dep 不要

## 設計上の判断

- **OSA distance 採用**: 標準 Levenshtein + adjacent transposition で "REDAME" → "README" の transposition を distance 1 で検出。手動実装で 50 行程度、外部 dep 不要。
- **best-effort + timeout**: candidate fetch が失敗しても元の NotFound error はそのまま伝播（degradation）。5s timeout で巨大 repo での待ち時間を bound。
- **match parameters**: `MAX_DISTANCE=3`, `TOP_N=3`。distance 3 はファイル名 typo の十分な許容範囲（例: "README.md" との distance: "REDAME.md"=1, "REDME.md"=1, "RAEDME.md"=2）。
- **case sensitivity**: OSA は char-by-char 比較。"readme" vs "README" は別物として扱われる（GitHub の case-sensitive path semantics に準拠）。

## ADR-0060 / ADR-0065 監査 完了報告 (#67)

### 必須 (3 軸)
- [x] グローバル `--json` + serde + stdout/stderr 分離 — #76 (Phase 2.2)
- [x] sysexits.h 準拠 exit code (0/64/65/66/74/75) — #77 (Phase 3, 1.0.0 メジャーバンプ)
- [x] エラー JSON に `next_step` + `candidates` — #78 (next_step) + 本 PR (candidates)
- [x] Noun-Verb サブコマンド構造 — GitHub 系 (`repo-tree`/`repo-read`/`repo-overview`) 完了。Web 系 (`search`/`fetch`/`research`) は監査時点で「web は対象が暗黙の page/web」と判断、現状維持
- [x] parse-time `conflicts_with` バリデーション — audit の結果 scout に実用的な競合フラグ無しと判明（`--js` と `--raw` は独立に valid）。新たな対象が出た時点で追加予定

### 推奨 (補強)
- [x] 構造化 degradation signal (`degraded`/`notes` field) — #76 (Phase 2.2)
- [x] BrokenPipe handling — `lib.rs` で実装済み
- [-] Shorthand expansion + safety rail — scout の 6 サブコマンド構造で適用箇所が現状不明、将来の有効ケースが見つかった時点で対応
- [x] stdin 統一 (`IsTerminal` + `-`) — `StdinResolver` で実装済み
- [-] `--dry-run` on mutating ops — N/A（scout は read-only な CLI、mutating ops 無し）

3 軸はすべて完了。Issue #67 は本 PR マージ後に close 予定。

## テスト方法

1. `cargo test --all-targets` → 328 lib tests + 10 integration tests pass
2. `cargo clippy --all-targets --all-features -- -D warnings` → clean
3. 動作確認（要 GitHub access）:
   ```bash
   scout --json repo-read facebook/react REDAME.md 2>&1 1>/dev/null | grep '^{'
   # → candidates: ["README.md", ...] 含有
   ```
4. 大規模 repo テスト: huge tree (linux 等) で 5s 以内に応答（timeout 効く）

## 関連

- Closes part of #67 (ADR-0060 監査完了)
- ADR-0065 `error.candidates` field の implementation
- 前段: #75 (Phase 2.1 envelope types) / #76 (Phase 2.2 wiring) / #77 (Phase 3 sysexits.h) / #78 (next_step)
