### PR TITLE
fix: issue-labeler templates を上流から同期 (closes #69)

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,5 +1,5 @@
 # Maps Issue Forms dropdown selections to labels.
-# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+# See https://github.com/redhat-plumbers-in-action/advanced-issue-labeler for syntax.
 #
 # Per-repo extension: target repos can append additional `policy` entries
 # (e.g. for area:* labels) by editing this file directly. The shared base
@@ -9,12 +9,12 @@ policy:
       - bug.yml
       - feature.yml
     section:
-      - id: priority
-        block-list:
-          - high
-          - medium
-          - low
+      - id: [priority]
+        block-list: []
         label:
-          - priority:high
-          - priority:medium
-          - priority:low
+          - name: 'priority:high'
+            keys: ['high']
+          - name: 'priority:medium'
+            keys: ['medium']
+          - name: 'priority:low'
+            keys: ['low']

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -13,16 +13,36 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Apply priority labels
-        uses: stefanbuck/[email protected]
+      - uses: actions/checkout@v4
+
+      - name: Parse bug.yml
+        id: parse-bug
+        uses: stefanbuck/github-issue-parser@v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/bug.yml
+        continue-on-error: true
+
+      - name: Apply labels for bug
+        if: steps.parse-bug.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.parse-bug.outputs.jsonString }}
           template: bug.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply priority labels (feature)
-        uses: stefanbuck/[email protected]
+      - name: Parse feature.yml
+        id: parse-feature
+        uses: stefanbuck/github-issue-parser@v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/feature.yml
+        continue-on-error: true
+
+      - name: Apply labels for feature
+        if: steps.parse-feature.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.parse-feature.outputs.jsonString }}
           template: feature.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

`thkt/github-labels#5` の修正を scout に同期。Cloudflare の email-obfuscation placeholder が混入していた template を正規化。

- `.github/workflows/label-from-issue.yml`: `[email protected]` で parse 段階 reject されていた問題を 2-step pattern (`stefanbuck/github-issue-parser@v3` → `redhat-plumbers-in-action/advanced-issue-labeler@v2`) で書き直し。bug.yml / feature.yml の両方に対応
- `.github/advanced-issue-labeler.yml`: 同一 harvest 由来の policy schema 破損を修正
  - `block-list: [high, medium, low]` → `[]`（旧設定では valid な dropdown 値を全除外しており label が一切付かなかった）
  - `label: [string]` → `[{name, keys}]` の object 配列（README schema 準拠）
  - 先頭コメントの誤URL `stefanbuck/advanced-issue-labeler` → `redhat-plumbers-in-action/advanced-issue-labeler`

両ファイルとも上流 templates と byte-for-byte 一致を確認済み。

## 背景

Issue #69 で報告されていた "label-from-issue.yml が push イベントで 0s failure になる" 問題の根本原因は、当初想定していた "GH Actions の表示挙動" や "trigger event 不一致" ではなく、**workflow ファイル自体が parse できない状態** だった。Research レポートでバイトレベル確認済（`5b 65 6d 61 69 6c 20 70 72 6f 74 65 63 74 65 64 5d` = `[email protected]`）。

issue 本文に挙げられていた対処案 A/B/C はいずれも症状ベースで、根本原因に届かない:

- A (現状維持): label が機能しないまま放置
- B (`if:` ガード): jobs 到達前に reject されるため無効
- C (workflow 分離): 破損ファイルを 2 つに増やすだけ

## テスト計画

- [x] `actionlint 1.7.12 .github/workflows/label-from-issue.yml` が exit 0
- [x] 上流 templates と diff 0 (workflow / policy 両方)
- [ ] merge 後、新規 issue を bug.yml フォームで作成 → `priority:medium` (default) ラベルが付与されることを確認
- [ ] feature.yml フォームでも同様に確認
- [ ] push 0s failure run が今後の commit で発生しないことを確認

## 関連

- Closes #69
- Upstream: thkt/github-labels#5
- ADR-0059 (shared template governance)