### PR TITLE
README と --help の整合性同期、外向け ADR 参照を削除

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -54,7 +54,7 @@ LLMは介在せず、一次ソースを直接読んで何が重要かを自分�
 brew install thkt/tap/scout
 ```
 
-ソースからビルドする場合は、Rust 1.85+が必要です。
+ソースからビルドする場合は、Rust 1.95+が必要です。
 
 ```sh
 cargo install --path .
@@ -67,6 +67,7 @@ cargo install --path .
 ```sh
 export GEMINI_API_KEY="..."   # search/researchに必要（無料枠: https://aistudio.google.com/apikey）
 export GITHUB_TOKEN="..."     # 任意: 5,000回/時 vs 未設定60回/時
+export SLACK_TOKEN="..."      # 任意: Slackパーマリンクを `fetch` するときに必要（User OAuthトークン、xoxp-…）
 ```
 
 `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` の順で認証されます。
@@ -98,6 +99,10 @@ cargo install --path . --features js-rendering
 
 ## コマンド
 
+すべてのコマンドはクエリ/URL/リポジトリを位置引数・パイプ入力・対話的stdin（`-`）のいずれかで受け取れます（例: `echo "クエリ" | scout search`、`scout search -`）。
+
+任意のコマンドに `--json` を付けると、Markdownの代わりに1行JSONエンベロープが標準出力に出ます。`jq` パイプラインやAIエージェントへの構造化データ受け渡しに便利です。
+
 ### `scout research` — 複数ソース深掘り調査
 
 Gemini Groundingで検索し、上位Nページを取得してレポートにまとめます。回答・ページ全文・ソースリストを一括で返します。`search` がAI回答とURLリストを返すのに対し、`research` は実際にページを読みに行き全文を含めるため、一次ソースに基づいた判断ができます。
@@ -119,6 +124,10 @@ Gemini GroundingとGoogle検索で、リンク一覧ではなくソースURL付�
 scout search "Next.js server actions security"
 ```
 
+| フラグ       | 説明                                                                                  |
+| ------------ | ------------------------------------------------------------------------------------- |
+| `-l, --lang` | `ja`、`en`、または `auto`（デフォルト）— 日本語を検出すると日英両方のクエリに自動展開 |
+
 ### `scout fetch` — WebページをMarkdownに変換
 
 ページをダウンロードし、Readabilityで本文を抽出してMarkdownに変換します。`js-rendering` feature有効時、JS依存ページ（SPA）は自動検出しヘッドレスChrome（CDP）でレンダリングします。LLMは介在しません。
@@ -133,6 +142,8 @@ scout fetch https://react.dev/blog/2024/12/05/react-19
 | `--raw` | Readabilityをスキップしてページ全体を変換                            |
 
 ページのメタデータ（タイトル/著者/日付）はYAMLフロントマターとして付与されます。フロントマターブロックは常に出力され、各フィールドはページから取得できた場合に含まれます。
+
+**Slackパーマリンク** — `fetch` は `*.slack.com/archives/{channel}/p{ts}` 形式のURLを検出し、HTMLスクレイピングではなくSlack Web APIへルーティングします。スレッドの親メッセージとリプライが、著者・タイムスタンプのメタデータ付きで保持されます。`SLACK_TOKEN`（User OAuthトークン、`xoxp-…`）が必要です。
 
 ### `scout repo-tree` — リモートファイル一覧
 
@@ -208,12 +219,26 @@ src/
 ├── gemini/              Gemini APIクライアント、グラウンディングレスポンス解析
 ├── github/              GitHub APIクライアント（遅延初期化）、ツリーフィルタリング、出力整形
 ├── slack/               Slackメッセージ取得（スレッド、リプライパーマリンク）
+├── envelope.rs          JSON出力エンベロープ
 ├── markdown.rs          Markdownユーティリティ（見出しシフト、切り詰め、エスケープ）
 ├── retry.rs             バックオフ付きリトライ（一時エラー、レート制限）
 └── redacted.rs          トークン用秘匿ラッパー
 ```
 
 シングルバイナリで、ランタイム依存はありません。
+
+## 終了コード
+
+[`sysexits.h`](https://man.openbsd.org/sysexits) 規約に準拠。
+
+| コード | 意味                                                                                      |
+| ------ | ----------------------------------------------------------------------------------------- |
+| 0      | 成功                                                                                      |
+| 64     | 使い方エラー（clapパース失敗、APIキー未設定、`conflicts_with` 違反）                      |
+| 65     | データエラー（不正入力、フォーマット異常、エンコーディングエラー）                        |
+| 66     | Not Found（リポジトリ/ファイルが存在しない、404）                                         |
+| 74     | IOエラー（ネットワークIO、BrokenPipe以外の書き込み失敗）                                  |
+| 75     | 一時的失敗（レート制限、5xx、リトライ可能）                                               |
 
 ## 制限事項
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Japanese queries are handled automatically: "Next.js 認証 ベストプラク�
 brew install thkt/tap/scout
 ```
 
-Or build from source (requires Rust 1.85+):
+Or build from source (requires Rust 1.95+):
 
 ```sh
 cargo install --path .
@@ -78,6 +78,7 @@ Pre-built binaries in [Releases](https://github.com/thkt/scout/releases) — mac
 ```sh
 export GEMINI_API_KEY="..."   # Required for search/research (free tier: https://aistudio.google.com/apikey)
 export GITHUB_TOKEN="..."     # Optional: 5,000 req/hour vs 60/hour unauthenticated
+export SLACK_TOKEN="..."      # Optional: required for `fetch` on Slack permalinks (User OAuth token, xoxp-…)
 ```
 
 `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` are all supported, in that order.
@@ -109,6 +110,10 @@ Claude Code will pick up the commands naturally — no MCP configuration needed.
 
 ## Commands
 
+All commands accept the query/URL/repo as a positional argument, piped stdin, or `-` to read stdin interactively (e.g., `echo "query" | scout search`, `scout search -`).
+
+Add `--json` to any command for a one-line JSON envelope on stdout instead of Markdown — useful for `jq` pipelines and feeding structured data back to AI agents.
+
 ### `scout research` — Multi-source deep research
 
 Searches the web via Gemini Grounding, fetches the top N source pages, and compiles a report — grounded answer, full page content, and deduplicated source list. Unlike `search` which returns an AI answer with URLs, `research` actually reads those pages and includes the full content — so you (or your AI agent) can verify claims against primary sources.
@@ -130,6 +135,10 @@ Gemini Grounding with Google Search. Returns a synthesized answer with source UR
 scout search "Next.js server actions security"
 ```
 
+| Flag         | Description                                                                              |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| `-l, --lang` | `ja`, `en`, or `auto` (default) — auto-detects Japanese and expands to bilingual queries |
+
 ### `scout fetch` — Web page to Markdown
 
 Downloads a page, extracts main content via Readability, converts to Markdown. With `js-rendering` feature, JS-dependent pages (SPAs) are automatically detected and rendered via headless Chrome (CDP). No LLM round-trip.
@@ -144,6 +153,8 @@ scout fetch https://react.dev/blog/2024/12/05/react-19
 | `--raw` | Skip Readability, convert entire page                                 |
 
 Page metadata (title, author, date) is included as YAML frontmatter. The frontmatter block is always present; individual fields appear when the page provides them.
+
+**Slack permalinks** — `fetch` detects `*.slack.com/archives/{channel}/p{ts}` URLs and routes them to the Slack Web API instead of HTML scraping. Thread parent + replies are preserved with author/timestamp metadata. Requires `SLACK_TOKEN` (User OAuth token, `xoxp-…`).
 
 ### `scout repo-tree` — Remote file listing
 
@@ -218,12 +229,26 @@ src/
 ├── gemini/              Gemini API client, grounding response parsing
 ├── github/              GitHub API client (lazy-init), tree filtering, formatting
 ├── slack/               Slack message fetching (thread, reply permalink)
+├── envelope.rs          JSON output envelope
 ├── markdown.rs          Markdown utilities (heading shift, truncation, escaping)
 ├── retry.rs             Retry with backoff (transient error, rate limit)
 └── redacted.rs          Secret-safe wrapper for tokens
 ```
 
 Single binary, zero runtime dependencies.
+
+## Exit codes
+
+Following [`sysexits.h`](https://man.openbsd.org/sysexits) conventions:
+
+| Code | Meaning                                                             |
+| ---- | ------------------------------------------------------------------- |
+| 0    | Success                                                             |
+| 64   | Usage error (clap parse, missing API key, conflicts_with violation) |
+| 65   | Data error (invalid input, malformed format, encoding error)        |
+| 66   | Not found (repo/file not found, 404)                                |
+| 74   | IO error (network IO, write failure other than BrokenPipe)          |
+| 75   | Temporary failure (rate limit, 5xx, retryable)                      |
 
 ## Limitations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
     version,
     about = "Web search, page fetching, and GitHub repository exploration",
     after_help = "\
-Exit codes (sysexits.h, ADR-0065):
+Exit codes (sysexits.h):
   0   Success
   64  Usage error (clap parse, missing API key, conflicts_with violation)
   65  Data error (invalid input, malformed format, encoding error)
@@ -48,7 +48,7 @@ Environment:
   GITHUB_TOKEN    Optional for GitHub commands (higher rate limits)"
 )]
 pub(crate) struct Cli {
-    /// Emit output as a JSON envelope (one line per ADR-0065) on stdout
+    /// Emit output as a JSON envelope (one line) on stdout
     /// instead of Markdown. Errors print a JSON envelope on stderr.
     #[arg(long, global = true)]
     json: bool,
@@ -217,7 +217,7 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
     }
 
-    /// [T-H000] root --help contains sysexits Exit codes (ADR-0065) and Environment sections
+    /// [T-H000] root --help contains sysexits Exit codes and Environment sections
     #[test]
     fn t_h000_root_help_contains_exit_codes_and_environment() {
         let help = super::Cli::command().render_long_help().to_string();
@@ -226,8 +226,8 @@ mod tests {
             "root help missing Exit codes section"
         );
         assert!(
-            help.contains("ADR-0065"),
-            "root help should reference ADR-0065"
+            help.contains("sysexits.h"),
+            "root help should reference sysexits.h"
         );
         assert!(
             help.contains("GEMINI_API_KEY"),

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -19,8 +19,8 @@ fn t_c001_help_exits_zero_and_contains_app_name() {
         "help output should contain Exit codes section, got:\n{stdout}"
     );
     assert!(
-        stdout.contains("ADR-0065"),
-        "help should reference ADR-0065, got:\n{stdout}"
+        stdout.contains("sysexits.h"),
+        "help should reference sysexits.h, got:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
## What & Why

`scout --help` と README の記述に複数の機能差があり、利用者・AI エージェントの双方が「何ができるか」を正しく把握できない状態になっていた。実装と README/--help を一致させ、外部表示には不要な内部参照（ADR-0065）を取り除く。

## Changes

- **README 同期 (`02366c0`)** — README.md / README.ja.md に未記載だった以下を追記:
  - `--json` グローバルフラグ
  - `search --lang` フラグ
  - `fetch` の Slack permalink 対応 + `SLACK_TOKEN` 環境変数
  - 全コマンド共通の stdin / `-` 入力
  - Architecture に `envelope.rs`
  - Exit codes セクション（sysexits.h 準拠）
  - Rust MSRV を `Cargo.toml` の `rust-version = "1.95"` に合わせて `1.85+` → `1.95+`
- **--help から ADR 参照削除 (`4c407eb`)** — `--help` テキストから `ADR-0065` を除去し、外部参照として意味のある `sysexits.h` を残す。テスト（`t_h000` / `t_c001`）も同様に更新

## Design Decisions

- **ADR 参照の扱い**: `--help` は人間だけでなく AI エージェントも使い方を調べる窓口。リポ内部の ADR 番号は外部の読み手にとって意味を持たないため、ユーザー可視テキストからは除去し、内部 doc comment（`///`）と test failure message には残した
- **コミット分割**: 「README に追記」と「ADR 参照削除」は意図が異なるため 2 コミットに分割。レビュー時に責任境界が明確になる

## How to Test

1. `cargo build --release && ./target/release/scout --help` を実行
2. `Exit codes (sysexits.h):` セクションが出ていて、`ADR-0065` 文字列が含まれないこと
3. `./target/release/scout search --help` の `--json` 説明が `(one line)` で終わること
4. `cargo test --lib t_h` と `cargo test --test cli_integration t_c001` が pass すること

## Related

- 関連 Issue なし
