### PR TITLE
refactor(tests): テスト関数を自己説明的に，T-NNN IDを去重化

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -95,9 +95,9 @@ pub(crate) struct ErrorPayload {
 mod tests {
     use super::*;
 
-    /// [T-EN002] ErrorPayload omits next_step when None
+    /// [T-EN001] ErrorPayload omits next_step when None
     #[test]
-    fn t_en002_error_payload_omits_optional_next_step() {
+    fn error_payload_omits_optional_next_step() {
         let payload = ErrorPayload {
             code: ErrorCode::UsageError,
             message: String::from("Missing query"),
@@ -112,9 +112,9 @@ mod tests {
         );
     }
 
-    /// [T-EN003] ErrorPayload omits candidates when empty
+    /// [T-EN002] ErrorPayload omits candidates when empty
     #[test]
-    fn t_en003_error_payload_omits_empty_candidates() {
+    fn error_payload_omits_empty_candidates() {
         let payload = ErrorPayload {
             code: ErrorCode::UsageError,
             message: String::from("invalid"),
@@ -129,9 +129,9 @@ mod tests {
         );
     }
 
-    /// [T-EN004] ErrorPayload includes next_step and candidates when present
+    /// [T-EN003] ErrorPayload includes next_step and candidates when present
     #[test]
-    fn t_en004_error_payload_includes_present_optional_fields() {
+    fn error_payload_includes_present_optional_fields() {
         let payload = ErrorPayload {
             code: ErrorCode::UsageError,
             message: String::from("did you mean"),
@@ -150,9 +150,9 @@ mod tests {
         );
     }
 
-    /// [T-EN007] ErrorEnvelope wraps payload under `error` key per ADR-0065
+    /// [T-EN004] ErrorEnvelope wraps payload under `error` key per ADR-0065
     #[test]
-    fn t_en007_error_envelope_wraps_payload_under_error_key() {
+    fn error_envelope_wraps_payload_under_error_key() {
         let env = ErrorEnvelope {
             error: ErrorPayload {
                 code: ErrorCode::UsageError,
@@ -175,7 +175,7 @@ mod tests {
 
     /// [T-EN005] SuccessEnvelope serializes data + degraded + notes
     #[test]
-    fn t_en005_success_envelope_serializes_required_fields() {
+    fn success_envelope_serializes_required_fields() {
         let env = SuccessEnvelope {
             data: serde_json::json!({"markdown": "hello"}),
             degraded: false,
@@ -192,7 +192,7 @@ mod tests {
 
     /// [T-EN006] SuccessEnvelope surfaces degraded=true with notes
     #[test]
-    fn t_en006_success_envelope_surfaces_degradation() {
+    fn success_envelope_surfaces_degradation() {
         let env = SuccessEnvelope {
             data: serde_json::json!(null),
             degraded: true,
@@ -206,9 +206,9 @@ mod tests {
         );
     }
 
-    /// [T-EN008] CommandOutput::ok produces non-degraded with empty notes
+    /// [T-EN007] CommandOutput::ok produces non-degraded with empty notes
     #[test]
-    fn t_en008_command_output_ok_is_not_degraded() {
+    fn command_output_ok_is_not_degraded() {
         let out = CommandOutput::ok(String::from("md"), serde_json::json!({"a": 1}));
         assert_eq!(out.markdown, "md");
         assert_eq!(out.data, serde_json::json!({"a": 1}));
@@ -216,9 +216,9 @@ mod tests {
         assert!(!out.degraded);
     }
 
-    /// [T-EN009] CommandOutput::with_notes sets degraded=true when notes non-empty
+    /// [T-EN008] CommandOutput::with_notes sets degraded=true when notes non-empty
     #[test]
-    fn t_en009_command_output_with_notes_is_degraded() {
+    fn command_output_with_notes_is_degraded() {
         let out = CommandOutput::with_notes(
             String::from("md"),
             serde_json::Value::Null,
@@ -228,17 +228,17 @@ mod tests {
         assert_eq!(out.notes, vec!["partial fetch"]);
     }
 
-    /// [T-EN010] CommandOutput::with_notes sets degraded=false when notes empty
+    /// [T-EN009] CommandOutput::with_notes sets degraded=false when notes empty
     #[test]
-    fn t_en010_command_output_with_empty_notes_is_not_degraded() {
+    fn command_output_with_empty_notes_is_not_degraded() {
         let out =
             CommandOutput::with_notes(String::from("md"), serde_json::Value::Null, Vec::new());
         assert!(!out.degraded);
     }
 
-    /// [T-EN001] ErrorCode serializes per ADR-0065 SCREAMING_SNAKE_CASE
+    /// [T-EN010] ErrorCode serializes per ADR-0065 SCREAMING_SNAKE_CASE
     #[test]
-    fn t_en001_error_code_serializes_screaming_snake_case() {
+    fn error_code_serializes_screaming_snake_case() {
         let pairs = [
             (ErrorCode::UsageError, r#""USAGE_ERROR""#),
             (ErrorCode::DataError, r#""DATA_ERROR""#),

--- a/src/github/encoding.rs
+++ b/src/github/encoding.rs
@@ -166,12 +166,12 @@ fn decode_detect(bytes: &[u8]) -> Result<DecodeResult, GitHubError> {
 mod tests {
     use super::*;
 
-    // ── T-001: Explicit Shift_JIS decoding ──
+    // ── Explicit Shift_JIS decoding ──
 
     /// [T-GE001] decode_bytes with shift_jis hint returns Explicit DecodeResult
     #[test]
-    fn t_001_decode_bytes_with_shift_jis_hint_returns_explicit_result() {
-        // [T-001] FR-001, BR-003
+    fn decode_bytes_with_shift_jis_hint_returns_explicit_result() {
+        // FR-001, BR-003
         // "テスト" in Shift_JIS
         let bytes: &[u8] = &[0x83, 0x65, 0x83, 0x58, 0x83, 0x67];
 
@@ -182,12 +182,12 @@ mod tests {
         assert_eq!(result.source, DetectionSource::Explicit);
     }
 
-    // ── T-002: Explicit EUC-JP decoding ──
+    // ── Explicit EUC-JP decoding ──
 
     /// [T-GE002] decode_bytes with euc-jp hint returns Explicit DecodeResult
     #[test]
-    fn t_002_decode_bytes_with_euc_jp_hint_returns_explicit_result() {
-        // [T-002] FR-001, BR-003
+    fn decode_bytes_with_euc_jp_hint_returns_explicit_result() {
+        // FR-001, BR-003
         // "日本語" in EUC-JP
         let bytes: &[u8] = &[0xC6, 0xFC, 0xCB, 0xDC, 0xB8, 0xEC];
 
@@ -198,12 +198,12 @@ mod tests {
         assert_eq!(result.source, DetectionSource::Explicit);
     }
 
-    // ── T-003: Invalid encoding hint ──
+    // ── Invalid encoding hint ──
 
     /// [T-GE003] decode_bytes with unknown encoding hint returns NonUtf8 error with retry guidance
     #[test]
-    fn t_003_decode_bytes_with_invalid_hint_returns_non_utf8_error() {
-        // [T-003] FR-002
+    fn decode_bytes_with_invalid_hint_returns_non_utf8_error() {
+        // FR-002
         let result = decode_bytes(b"any", Some("zzz-invalid-encoding"));
 
         let err = result.unwrap_err();
@@ -222,12 +222,12 @@ mod tests {
         );
     }
 
-    // ── T-004: Auto-detect Shift_JIS (chardetng) ──
+    // ── Auto-detect Shift_JIS (chardetng) ──
 
     /// [T-GE004] decode_bytes without hint auto-detects Shift_JIS via chardetng
     #[test]
-    fn t_004_decode_bytes_without_hint_detects_shift_jis() {
-        // [T-004] FR-004, FR-005
+    fn decode_bytes_without_hint_detects_shift_jis() {
+        // FR-004, FR-005
         // "テスト" in Shift_JIS — enough Japanese bytes for chardetng to detect
         let bytes: &[u8] = &[0x83, 0x65, 0x83, 0x58, 0x83, 0x67];
 
@@ -238,12 +238,12 @@ mod tests {
         assert_eq!(result.source, DetectionSource::Detected);
     }
 
-    // ── T-005: ASCII-heavy Shift_JIS detected before UTF-8 (BR-001) ──
+    // ── ASCII-heavy Shift_JIS detected before UTF-8 (BR-001) ──
 
     /// [T-GE005] decode_bytes runs chardetng before UTF-8 fallback on ASCII-heavy Shift_JIS
     #[test]
-    fn t_005_decode_bytes_ascii_heavy_shift_jis_detected_before_utf8() {
-        // [T-005] BR-001: chardetng runs BEFORE UTF-8 check
+    fn decode_bytes_ascii_heavy_shift_jis_detected_before_utf8() {
+        // BR-001: chardetng runs BEFORE UTF-8 check
         // Simulate a source file with English comments and Japanese string literals.
         // The ASCII portion is valid UTF-8, but the Shift_JIS bytes are not.
         // chardetng must detect Shift_JIS before UTF-8 is tried.
@@ -275,12 +275,12 @@ mod tests {
         );
     }
 
-    // ── T-006: UTF-16 BE BOM detection ──
+    // ── UTF-16 BE BOM detection ──
 
     /// [T-GE006] decode_bytes recognizes UTF-16 BE BOM and reports Bom detection source
     #[test]
-    fn t_006_decode_bytes_with_utf16be_bom_returns_bom_source() {
-        // [T-006] FR-003, BR-002
+    fn decode_bytes_with_utf16be_bom_returns_bom_source() {
+        // FR-003, BR-002
         // UTF-16 BE BOM (FE FF) followed by "AB" in UTF-16 BE
         let bytes: &[u8] = &[
             0xFE, 0xFF, // BOM
@@ -299,7 +299,7 @@ mod tests {
         );
     }
 
-    // ── T-007: Bytes invalid in the specified encoding produce NonUtf8 error ──
+    // ── Bytes invalid in the specified encoding produce NonUtf8 error ──
     // Spec Evolution: original design tested auto-detect failure, but chardetng always
     // falls back to windows-1252 which encoding_rs decodes without errors (maps undefined
     // bytes to C1 control characters, not U+FFFD). The NonUtf8 path is reliably reached
@@ -307,8 +307,8 @@ mod tests {
 
     /// [T-GE007] decode_bytes returns NonUtf8 with --encoding hint when explicit encoding fails
     #[test]
-    fn t_007_decode_bytes_random_bytes_returns_non_utf8_with_encoding_hint() {
-        // [T-007] FR-002 (bytes invalid for specified encoding → NonUtf8 with retry hint)
+    fn decode_bytes_random_bytes_returns_non_utf8_with_encoding_hint() {
+        // FR-002: bytes invalid for specified encoding → NonUtf8 with retry hint
         // 0x83 is a valid Shift_JIS lead byte; 0x3F ('?') is NOT a valid trail byte
         // (trail must be 0x40-0x7E or 0x80-0xFC; 0x3F < 0x40).
         // Every pair is an invalid Shift_JIS 2-byte sequence → had_errors=true.
@@ -331,12 +331,12 @@ mod tests {
         );
     }
 
-    // ── T-008: Binary file (null bytes) returns NonUtf8 error ──
+    // ── Binary file (null bytes) returns NonUtf8 error ──
 
     /// [T-GE008] decode_bytes treats null-byte content as binary and returns NonUtf8 error
     #[test]
-    fn t_008_decode_bytes_with_null_bytes_returns_non_utf8_error() {
-        // [T-008] Binary heuristic: null bytes indicate non-text content
+    fn decode_bytes_with_null_bytes_returns_non_utf8_error() {
+        // Binary heuristic: null bytes indicate non-text content
         // chardetng would otherwise guess windows-1252 and return Detected with garbage text
         let bytes: &[u8] = &[0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00];
 
@@ -354,12 +354,12 @@ mod tests {
         );
     }
 
-    // ── T-009: Non-NUL random bytes (windows-1252 fallback) return NonUtf8 error ──
+    // ── Non-NUL random bytes (windows-1252 fallback) return NonUtf8 error ──
 
     /// [T-GE009] decode_bytes rejects non-NUL random bytes that chardetng would guess as single-byte encoding
     #[test]
-    fn t_009_decode_bytes_non_nul_random_bytes_return_non_utf8_error() {
-        // [T-009] Single-byte encoding guard: chardetng can return windows-1251, windows-1252,
+    fn decode_bytes_non_nul_random_bytes_return_non_utf8_error() {
+        // Single-byte encoding guard: chardetng can return windows-1251, windows-1252,
         // or other single-byte encodings for arbitrary non-NUL bytes. Those encodings accept
         // every byte without error, so `had_errors == false` is meaningless as a quality signal.
         // The `is_reliable_detection` guard must reject single-byte encodings and fall through
@@ -390,14 +390,14 @@ mod tests {
         );
     }
 
-    // ── T-011: NonUtf8 maps to exit code 1 (user_error) ──
+    // ── NonUtf8 Display output ──
     // Note: This test validates the error variant exists and its Display output.
-    // The ScoutError mapping test belongs in tools/errors.rs (Phase 2).
+    // The ScoutError mapping test belongs in tools/errors.rs.
 
     /// [T-GE010] GitHubError::NonUtf8 Display output contains the inner descriptive message
     #[test]
-    fn t_011_non_utf8_error_contains_descriptive_message() {
-        // [T-011] FR-011
+    fn non_utf8_error_contains_descriptive_message() {
+        // FR-011
         let err = GitHubError::NonUtf8("shift_jis not forced".into());
         let msg = err.to_string();
         assert!(
@@ -406,12 +406,12 @@ mod tests {
         );
     }
 
-    // ── T-012: Decode (base64) error remains distinct ──
+    // ── Decode (base64) error remains distinct ──
 
     /// [T-GE011] GitHubError::Decode and NonUtf8 variants produce distinct Display output
     #[test]
-    fn t_012_decode_error_is_distinct_from_non_utf8() {
-        // [T-012] FR-012
+    fn decode_error_is_distinct_from_non_utf8() {
+        // FR-012
         let decode_err = GitHubError::Decode("bad base64".into());
         let non_utf8_err = GitHubError::NonUtf8("encoding failed".into());
 

--- a/src/github/format.rs
+++ b/src/github/format.rs
@@ -678,12 +678,12 @@ mod tests {
         );
     }
 
-    // ── T-001 through T-008: format_file_content / lang_for_path / fence_delimiter ──
+    // ── format_file_content / lang_for_path / fence_delimiter ──
 
     /// [T-GF026] format_file_content wraps a Rust file in a ```rust fenced block
     #[test]
-    fn t_001_format_file_content_wraps_rust_file_in_fenced_code_block() {
-        // [T-001] FR-001, FR-002
+    fn format_file_content_wraps_rust_file_in_fenced_code_block() {
+        // FR-001, FR-002
         let output = format_file_content("src/main.rs", 3, "    1\tfn main() {}\n", None);
         assert!(
             output.starts_with("src/main.rs (3 lines)\n\n```rust\n"),
@@ -697,8 +697,8 @@ mod tests {
 
     /// [T-GF027] lang_for_path returns the canonical identifier for known extensions
     #[test]
-    fn t_002_lang_for_path_returns_canonical_identifier_for_known_extensions() {
-        // [T-002] FR-002
+    fn lang_for_path_returns_canonical_identifier_for_known_extensions() {
+        // FR-002
         let cases: &[(&str, &str)] = &[
             ("main.rs", "rust"),
             ("app.ts", "typescript"),
@@ -735,16 +735,16 @@ mod tests {
 
     /// [T-GF028] lang_for_path returns empty string for missing or unknown extensions
     #[test]
-    fn t_003_lang_for_path_returns_empty_for_no_extension_and_unknown() {
-        // [T-003] FR-002
+    fn lang_for_path_returns_empty_for_no_extension_and_unknown() {
+        // FR-002
         assert_eq!(lang_for_path("Makefile"), "", "no dot in path");
         assert_eq!(lang_for_path("file.xyz"), "", "unknown extension");
     }
 
     /// [T-GF029] fence_delimiter grows past three backticks when content contains a triple-backtick run
     #[test]
-    fn t_004_fence_delimiter_returns_longer_fence_when_content_has_triple_backticks() {
-        // [T-004] FR-003
+    fn fence_delimiter_returns_longer_fence_when_content_has_triple_backticks() {
+        // FR-003
         let content = "some\n```\ncode\n```\n";
         let delim = fence_delimiter(content);
         assert!(
@@ -760,15 +760,15 @@ mod tests {
 
     /// [T-GF030] fence_delimiter defaults to triple backticks for content without backticks
     #[test]
-    fn t_005_fence_delimiter_returns_triple_backtick_for_plain_content() {
-        // [T-005] FR-003, FR-004
+    fn fence_delimiter_returns_triple_backtick_for_plain_content() {
+        // FR-003, FR-004
         assert_eq!(fence_delimiter("hello world"), "```");
     }
 
     /// [T-GF031] fence_delimiter grows past five backticks when content has a five-backtick run
     #[test]
-    fn t_006_fence_delimiter_returns_longer_fence_when_content_has_five_backticks() {
-        // [T-006] FR-003
+    fn fence_delimiter_returns_longer_fence_when_content_has_five_backticks() {
+        // FR-003
         let content = "text `````more";
         let delim = fence_delimiter(content);
         assert!(
@@ -784,8 +784,8 @@ mod tests {
 
     /// [T-GF032] format_file_content picks a fence longer than any inner backtick run
     #[test]
-    fn t_007_format_file_content_fence_does_not_collide_with_inner_backticks() {
-        // [T-007] FR-001, FR-003
+    fn format_file_content_fence_does_not_collide_with_inner_backticks() {
+        // FR-001, FR-003
         let inner = "    1\t```\n    2\tsome code\n    3\t```\n";
         let output = format_file_content("doc.md", 3, inner, None);
 
@@ -809,8 +809,8 @@ mod tests {
 
     /// [T-GF033] format_file_content emits a bare triple-backtick fence for paths without extensions
     #[test]
-    fn t_008_format_file_content_uses_empty_lang_for_extensionless_path() {
-        // [T-008] FR-001, FR-002
+    fn format_file_content_uses_empty_lang_for_extensionless_path() {
+        // FR-001, FR-002
         let output = format_file_content("config", 1, "    1\tkey=val", None);
         let lines: Vec<&str> = output.lines().collect();
         // line 2 is the opening fence
@@ -822,8 +822,8 @@ mod tests {
 
     /// [T-GF034] format_file_content appends the encoding label to the header when provided
     #[test]
-    fn t_009_format_file_content_includes_encoding_label_in_header() {
-        // [T-009] FR-009: encoding label appended to header when provided
+    fn format_file_content_includes_encoding_label_in_header() {
+        // FR-009: encoding label appended to header when provided
         let output = format_file_content("file.txt", 2, "    1\thello\n", Some("shift_jis"));
         assert!(
             output.starts_with("file.txt (2 lines) [encoding: shift_jis]\n\n"),
@@ -833,8 +833,8 @@ mod tests {
 
     /// [T-GF035] format_file_content omits the encoding label when none is given
     #[test]
-    fn t_010_format_file_content_omits_encoding_when_none() {
-        // [T-010] FR-009: no encoding label when None
+    fn format_file_content_omits_encoding_when_none() {
+        // FR-009: no encoding label when None
         let output = format_file_content("file.txt", 1, "    1\thello\n", None);
         assert!(
             output.starts_with("file.txt (1 lines)\n\n"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ mod tests {
 
     /// [T-W001] write_output appends newline when output lacks trailing newline
     #[test]
-    fn t_w001_write_output_appends_newline_when_missing() {
+    fn write_output_appends_newline_when_missing() {
         let mut buf = Vec::new();
         write_output(&mut buf, "hello").unwrap();
         assert_eq!(&buf, b"hello\n");
@@ -194,7 +194,7 @@ mod tests {
 
     /// [T-W002] write_output preserves single trailing newline
     #[test]
-    fn t_w002_write_output_preserves_existing_newline() {
+    fn write_output_preserves_existing_newline() {
         let mut buf = Vec::new();
         write_output(&mut buf, "hello\n").unwrap();
         assert_eq!(&buf, b"hello\n");
@@ -202,7 +202,7 @@ mod tests {
 
     /// [T-W003] write_output propagates BrokenPipe error from writer
     #[test]
-    fn t_w003_write_output_propagates_broken_pipe() {
+    fn write_output_propagates_broken_pipe() {
         struct BrokenPipeWriter;
         impl Write for BrokenPipeWriter {
             fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
@@ -219,7 +219,7 @@ mod tests {
 
     /// [T-H000] root --help contains sysexits Exit codes and Environment sections
     #[test]
-    fn t_h000_root_help_contains_exit_codes_and_environment() {
+    fn root_help_contains_exit_codes_and_environment() {
         let help = super::Cli::command().render_long_help().to_string();
         assert!(
             help.contains("Exit codes"),

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(shift_headings(input, 3), input);
     }
 
-    /// [T-005] Non-ATX-heading `#` lines must not be shifted.
+    /// [T-MD013] Non-ATX-heading `#` lines must not be shifted.
     #[test]
     fn shift_headings_skips_non_atx_lines() {
         let input = "#include <stdio.h>\n# Real heading\n#123 issue ref\n## Also real";

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -408,9 +408,9 @@ mod tests {
         );
     }
 
-    /// [T-002] research report: answer with headings should have them shifted by 2
+    /// [T-SE012] research report: answer with headings should have them shifted by 2
     #[test]
-    fn t_002_research_report_shifts_headings_in_answer() {
+    fn research_report_shifts_headings_in_answer() {
         let result = GroundedResult {
             answer: Some("# Title\n\nSome text\n\n## Details".into()),
             sources: vec![Source {
@@ -439,9 +439,9 @@ mod tests {
         );
     }
 
-    /// [T-004] research report: answer with no headings passes through unchanged
+    /// [T-SE013] research report: answer with no headings passes through unchanged
     #[test]
-    fn t_004_research_report_no_headings_unchanged() {
+    fn research_report_no_headings_unchanged() {
         let body = "This is plain text without any headings.\n\nJust paragraphs.";
         let result = GroundedResult {
             answer: Some(body.into()),

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -43,8 +43,8 @@ mod tests {
     use tracing_test::traced_test;
 
     #[tokio::test]
-    async fn t001_try_spawn_mock_server_returns_some_in_normal_env() {
-        let Some(server) = try_spawn_mock_server("t001_normal_env").await else {
+    async fn try_spawn_mock_server_returns_some_in_normal_env() {
+        let Some(server) = try_spawn_mock_server("normal_env").await else {
             return; // bind unavailable — can't verify happy path
         };
 
@@ -57,29 +57,29 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
-    async fn t004_bind_failure_without_force_returns_none_and_warns() {
+    async fn bind_failure_without_force_returns_none_and_warns() {
         let bind_err: io::Result<TcpListener> = Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "mock bind failure",
         ));
 
-        let result = try_spawn_with_bind("t004_permission_denied", bind_err, false).await;
+        let result = try_spawn_with_bind("permission_denied", bind_err, false).await;
 
         assert!(
             result.is_none(),
             "try_spawn_with_bind should return None on bind failure"
         );
-        assert!(logs_contain("t004_permission_denied"));
+        assert!(logs_contain("permission_denied"));
     }
 
     #[tokio::test]
-    #[should_panic(expected = "t005_forced_panic")]
-    async fn t005_bind_failure_with_force_panics() {
+    #[should_panic(expected = "forced_panic")]
+    async fn bind_failure_with_force_panics() {
         let bind_err: io::Result<TcpListener> = Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "mock bind failure",
         ));
 
-        let _result = try_spawn_with_bind("t005_forced_panic", bind_err, true).await;
+        let _result = try_spawn_with_bind("forced_panic", bind_err, true).await;
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -767,7 +767,7 @@ mod tests {
         assert!(output.contains("### Raw Title"), "h1 should shift to h3");
     }
 
-    /// [TC-5] search standalone: empty answer text becomes None via
+    /// [T-TS006] search standalone: empty answer text becomes None via
     /// `extract_grounded_result` (.filter(|t| !t.is_empty())), triggering
     /// the fallback message path in `search()`.
     #[tokio::test]
@@ -804,9 +804,9 @@ mod tests {
         );
     }
 
-    /// [T-001] search standalone: answer with headings should have them shifted by 2
+    /// [T-TS007] search standalone: answer with headings should have them shifted by 2
     #[tokio::test]
-    async fn t_001_search_shifts_headings_in_answer() {
+    async fn search_shifts_headings_in_answer() {
         let Some(server) = try_spawn_mock_server("tools::integration").await else {
             return;
         };
@@ -843,9 +843,9 @@ mod tests {
         );
     }
 
-    /// [T-003] search standalone: # inside fenced code block should NOT be shifted
+    /// [T-TS008] search standalone: # inside fenced code block should NOT be shifted
     #[tokio::test]
-    async fn t_003_search_preserves_headings_in_code_blocks() {
+    async fn search_preserves_headings_in_code_blocks() {
         let answer = "# Real heading\n\n```bash\n# comment in script\n```\n\n## Another heading";
         let Some(server) = try_spawn_mock_server("tools::integration").await else {
             return;
@@ -936,10 +936,10 @@ mod tests {
         }
     }
 
-    /// [T-001] repo_overview: get_repo 404 -> readme/issues/pulls/releases
+    /// [T-TS009] repo_overview: get_repo 404 -> readme/issues/pulls/releases
     /// APIs receive 0 requests.
     #[tokio::test]
-    async fn t_001_repo_overview_404_skips_remaining_apis() {
+    async fn repo_overview_404_skips_remaining_apis() {
         let Some(server) = try_spawn_mock_server("tools::t_001").await else {
             return;
         };
@@ -993,14 +993,14 @@ mod tests {
         // wiremock verifies expect(0) on server drop
     }
 
-    /// [T-002] repo_overview: after get_repo succeeds, readme/issues/pulls/
+    /// [T-TS010] repo_overview: after get_repo succeeds, readme/issues/pulls/
     /// releases run in parallel.
     ///
     /// Proof: a barrier-synchronized TCP server requires all 4 API requests to
     /// arrive before any response is sent. If requests are sequential, only one
     /// arrives at a time and the barrier never releases → deadlock → timeout.
     #[tokio::test(flavor = "multi_thread")]
-    async fn t_002_repo_overview_parallel_after_get_repo() {
+    async fn repo_overview_parallel_after_get_repo() {
         use std::sync::Arc;
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
@@ -1074,10 +1074,10 @@ mod tests {
         server.abort();
     }
 
-    /// [T-003] scout_lazy: github OnceCell is None immediately after
+    /// [T-TS011] scout_lazy: github OnceCell is None immediately after
     /// construction.
     #[test]
-    fn t_003_scout_lazy_github_initially_none() {
+    fn scout_lazy_github_initially_none() {
         let s = scout_lazy("http://localhost:0");
         assert!(
             s.github.get().is_none(),
@@ -1085,9 +1085,9 @@ mod tests {
         );
     }
 
-    /// [T-004] search command does not initialize the GitHub client.
+    /// [T-TS012] search command does not initialize the GitHub client.
     #[tokio::test]
-    async fn t_004_search_leaves_github_uninitialized() {
+    async fn search_leaves_github_uninitialized() {
         let Some(server) = try_spawn_mock_server("tools::t_004").await else {
             return;
         };
@@ -1121,9 +1121,9 @@ mod tests {
         );
     }
 
-    /// [T-005] fetch command does not initialize the GitHub client.
+    /// [T-TS013] fetch command does not initialize the GitHub client.
     #[tokio::test]
-    async fn t_005_fetch_leaves_github_uninitialized() {
+    async fn fetch_leaves_github_uninitialized() {
         let Some(server) = try_spawn_mock_server("tools::t_005").await else {
             return;
         };
@@ -1153,9 +1153,9 @@ mod tests {
         );
     }
 
-    /// [T-006] research command does not initialize the GitHub client.
+    /// [T-TS014] research command does not initialize the GitHub client.
     #[tokio::test]
-    async fn t_006_research_leaves_github_uninitialized() {
+    async fn research_leaves_github_uninitialized() {
         let Some(server) = try_spawn_mock_server("tools::t_006").await else {
             return;
         };
@@ -1195,10 +1195,10 @@ mod tests {
         );
     }
 
-    /// [T-007] github() called twice returns the same reference
+    /// [T-TS015] github() called twice returns the same reference
     /// (OnceCell caching verified via std::ptr::eq).
     #[tokio::test]
-    async fn t_007_github_returns_same_reference() {
+    async fn github_returns_same_reference() {
         use std::ptr;
         // Use pre-set OnceCell to avoid triggering real `gh auth token` subprocess.
         let s = scout_with_github("http://localhost:0", "http://localhost:0");
@@ -1210,14 +1210,14 @@ mod tests {
         );
     }
 
-    /// [T-007b] github() initializes an empty OnceCell via from_env and caches
+    /// [T-TS016] github() initializes an empty OnceCell via from_env and caches
     /// the result. Exercises the lazy-init code path at mod.rs:80-84.
     ///
     /// from_env is infallible: it resolves token from env vars or `gh auth token`
     /// (with TOKEN_RESOLVE_TIMEOUT = 5s), then returns a client. No timeout
     /// wrapper — a hang here is a real bug, not a flaky environment.
     #[tokio::test]
-    async fn t_007b_github_lazy_init_from_empty_cell() {
+    async fn github_lazy_init_from_empty_cell() {
         use std::ptr;
         let s = scout_lazy("http://localhost:0");
         assert!(s.github.get().is_none(), "starts empty");
@@ -1235,10 +1235,10 @@ mod tests {
         );
     }
 
-    /// [T-008] repo_read: --encoding hint is passed to decode_content and
+    /// [T-TS017] repo_read: --encoding hint is passed to decode_content and
     /// used to decode non-UTF-8 content correctly.
     #[tokio::test]
-    async fn t_008_repo_read_decodes_with_encoding_hint() {
+    async fn repo_read_decodes_with_encoding_hint() {
         let Some(server) = try_spawn_mock_server("tools::t_008").await else {
             return;
         };
@@ -1277,10 +1277,10 @@ mod tests {
         );
     }
 
-    /// [T-009] repo_tree: --path filter is wired through RepoTreeParams to
+    /// [T-TS018] repo_tree: --path filter is wired through RepoTreeParams to
     /// filter_tree_entries; files outside the prefix are excluded from output.
     #[tokio::test]
-    async fn t_009_repo_tree_path_filter_excludes_non_matching_files() {
+    async fn repo_tree_path_filter_excludes_non_matching_files() {
         let Some(server) = try_spawn_mock_server("tools::t_009").await else {
             return;
         };
@@ -1341,7 +1341,7 @@ mod tests {
 
     /// [T-R001] StdinResolver: first arg consumes stdin, second uses its own value
     #[test]
-    fn t_r001_stdin_resolver_first_consumes_second_uses_arg() {
+    fn stdin_resolver_first_consumes_second_uses_arg() {
         let mut r = super::StdinResolver::with_content(false, Some("from_stdin".into()));
         let first = r.resolve(None, "repository", "<OWNER/REPO>").unwrap();
         assert_eq!(first, "from_stdin");
@@ -1353,7 +1353,7 @@ mod tests {
 
     /// [T-R002] StdinResolver: arg wins over stdin, stdin preserved for next resolve
     #[test]
-    fn t_r002_stdin_resolver_arg_wins_stdin_preserved() {
+    fn stdin_resolver_arg_wins_stdin_preserved() {
         let mut r = super::StdinResolver::with_content(false, Some("from_stdin".into()));
         let first = r
             .resolve(Some("owner/repo".into()), "repository", "<OWNER/REPO>")
@@ -1365,7 +1365,7 @@ mod tests {
 
     /// [T-R003] StdinResolver: second arg fails when stdin already consumed
     #[test]
-    fn t_r003_stdin_resolver_consumed_stdin_fails_second() {
+    fn stdin_resolver_consumed_stdin_fails_second() {
         let mut r = super::StdinResolver::with_content(false, Some("from_stdin".into()));
         r.resolve(None, "repository", "<OWNER/REPO>").unwrap();
         let result = r.resolve(None, "path", "<FILE_PATH>");
@@ -1377,7 +1377,7 @@ mod tests {
 
     /// [T-R005] StdinResolver: error message hints stdin was consumed, not missing
     #[test]
-    fn t_r005_stdin_resolver_consumed_error_hints_stdin_exhausted() {
+    fn stdin_resolver_consumed_error_hints_stdin_exhausted() {
         let mut r = super::StdinResolver::with_content(false, Some("from_stdin".into()));
         r.resolve(None, "repository", "<OWNER/REPO>").unwrap();
         let err = r
@@ -1396,7 +1396,7 @@ mod tests {
 
     /// [T-R004] StdinResolver: both args provided, stdin unused
     #[test]
-    fn t_r004_stdin_resolver_both_args_stdin_unused() {
+    fn stdin_resolver_both_args_stdin_unused() {
         let mut r = super::StdinResolver::with_content(false, Some("from_stdin".into()));
         let first = r
             .resolve(Some("owner/repo".into()), "repository", "<OWNER/REPO>")

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -284,35 +284,35 @@ mod tests {
 
     /// [T-ER010] user_error returns ErrorCode::UsageError
     #[test]
-    fn t_er010_user_error_kind_is_usage() {
+    fn user_error_kind_is_usage() {
         let err = ScoutError::user_error("test");
         assert_eq!(err.error_kind(), ErrorCode::UsageError);
     }
 
     /// [T-ER011] transient returns ErrorCode::TempFailure
     #[test]
-    fn t_er011_transient_kind_is_temp_failure() {
+    fn transient_kind_is_temp_failure() {
         let err = ScoutError::transient("test");
         assert_eq!(err.error_kind(), ErrorCode::TempFailure);
     }
 
     /// [T-ER012] internal returns ErrorCode::IoError
     #[test]
-    fn t_er012_internal_kind_is_io_error() {
+    fn internal_kind_is_io_error() {
         let err = ScoutError::internal("test");
         assert_eq!(err.error_kind(), ErrorCode::IoError);
     }
 
     /// [T-CD001] Errors default to empty candidates list
     #[test]
-    fn t_cd001_default_candidates_empty() {
+    fn default_candidates_empty() {
         let err = ScoutError::not_found("test");
         assert!(err.candidates().is_empty());
     }
 
     /// [T-CD002] with_candidates attaches correction suggestions
     #[test]
-    fn t_cd002_with_candidates_attaches_list() {
+    fn with_candidates_attaches_list() {
         let err = ScoutError::not_found("path not found")
             .with_candidates(vec!["README.md".into(), "REDAME.md".into()]);
         assert_eq!(err.candidates(), &["README.md", "REDAME.md"]);
@@ -320,7 +320,7 @@ mod tests {
 
     /// [T-NS001] ApiKeyNotSet sets next_step pointing to GEMINI_API_KEY env var
     #[test]
-    fn t_ns001_gemini_api_key_not_set_has_next_step() {
+    fn gemini_api_key_not_set_has_next_step() {
         let err = ScoutError::from(GeminiError::ApiKeyNotSet);
         assert_eq!(
             err.next_step(),
@@ -330,7 +330,7 @@ mod tests {
 
     /// [T-NS002] GitHubError::Forbidden separates GITHUB_TOKEN hint into next_step (not message)
     #[test]
-    fn t_ns002_github_forbidden_separates_hint_into_next_step() {
+    fn github_forbidden_separates_hint_into_next_step() {
         let err = ScoutError::from(github::GitHubError::Forbidden("denied".into()));
         assert_eq!(
             err.next_step(),
@@ -340,7 +340,7 @@ mod tests {
 
     /// [T-NS003] GitHubError::NotFound has actionable next_step
     #[test]
-    fn t_ns003_github_not_found_has_next_step() {
+    fn github_not_found_has_next_step() {
         let err = ScoutError::from(github::GitHubError::NotFound("/test".into()));
         assert!(
             err.next_step()
@@ -350,7 +350,7 @@ mod tests {
 
     /// [T-NS004] FetchError::Status(404) has next_step about the URL
     #[test]
-    fn t_ns004_fetch_404_has_next_step() {
+    fn fetch_404_has_next_step() {
         let err = ScoutError::from(FetchError::Status(404));
         assert!(
             err.next_step()
@@ -360,7 +360,7 @@ mod tests {
 
     /// [T-NS005] GeminiError::QuotaExhausted separates billing URL hint into next_step
     #[test]
-    fn t_ns005_gemini_quota_exhausted_separates_billing_hint() {
+    fn gemini_quota_exhausted_separates_billing_hint() {
         let err = ScoutError::from(GeminiError::QuotaExhausted("limit".into()));
         assert!(
             err.next_step()
@@ -370,7 +370,7 @@ mod tests {
 
     /// [T-NS006] GitHubError::RateLimited with retry_after embeds the duration in next_step
     #[test]
-    fn t_ns006_github_rate_limited_with_retry_after_embeds_duration() {
+    fn github_rate_limited_with_retry_after_embeds_duration() {
         let err = ScoutError::from(github::GitHubError::RateLimited {
             retry_after: Some(42),
         });
@@ -383,14 +383,14 @@ mod tests {
 
     /// [T-NS007] GitHubError::RateLimited without retry_after still suggests setting GITHUB_TOKEN
     #[test]
-    fn t_ns007_github_rate_limited_without_retry_after_suggests_token() {
+    fn github_rate_limited_without_retry_after_suggests_token() {
         let err = ScoutError::from(github::GitHubError::RateLimited { retry_after: None });
         assert!(err.next_step().is_some_and(|h| h.contains("GITHUB_TOKEN")));
     }
 
     /// [T-NS008] Display includes next_step appended to message
     #[test]
-    fn t_ns008_display_includes_next_step() {
+    fn display_includes_next_step() {
         let err = ScoutError::user_error("Something is wrong").with_next_step("Try X");
         let display = err.to_string();
         assert!(display.contains("Something is wrong"));
@@ -399,7 +399,7 @@ mod tests {
 
     /// [T-NS009] Errors without next_step omit the hint from Display
     #[test]
-    fn t_ns009_display_omits_next_step_when_absent() {
+    fn display_omits_next_step_when_absent() {
         let err = ScoutError::internal("internal failure");
         let display = err.to_string();
         assert_eq!(display, "internal failure");
@@ -407,35 +407,35 @@ mod tests {
 
     /// [T-ER013] GitHubError::NotFound classifies as ErrorCode::NotFound
     #[test]
-    fn t_er013_github_not_found_classifies_as_not_found() {
+    fn github_not_found_classifies_as_not_found() {
         let err = ScoutError::from(github::GitHubError::NotFound("/test".into()));
         assert_eq!(err.error_kind(), ErrorCode::NotFound);
     }
 
     /// [T-ER014] GitHubError::InvalidRepo classifies as ErrorCode::DataError
     #[test]
-    fn t_er014_github_invalid_repo_classifies_as_data_error() {
+    fn github_invalid_repo_classifies_as_data_error() {
         let err = ScoutError::from(github::GitHubError::InvalidRepo("bad".into()));
         assert_eq!(err.error_kind(), ErrorCode::DataError);
     }
 
     /// [T-ER015] FetchError::InvalidScheme classifies as ErrorCode::DataError
     #[test]
-    fn t_er015_fetch_invalid_scheme_classifies_as_data_error() {
+    fn fetch_invalid_scheme_classifies_as_data_error() {
         let err = ScoutError::from(FetchError::InvalidScheme);
         assert_eq!(err.error_kind(), ErrorCode::DataError);
     }
 
     /// [T-ER016] FetchError::Status(404) classifies as ErrorCode::NotFound
     #[test]
-    fn t_er016_fetch_status_404_classifies_as_not_found() {
+    fn fetch_status_404_classifies_as_not_found() {
         let err = ScoutError::from(FetchError::Status(404));
         assert_eq!(err.error_kind(), ErrorCode::NotFound);
     }
 
     /// [T-ER001a] UsageError errors surface with exit 64 (EX_USAGE per ADR-0065)
     #[test]
-    fn t_er001a_usage_errors_have_exit_code_64() {
+    fn usage_errors_have_exit_code_64() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::Forbidden("denied".into()).into(),
             FetchError::BrowserNotFound("not installed".into()).into(),
@@ -457,7 +457,7 @@ mod tests {
 
     /// [T-ER001b] DataError errors surface with exit 65 (EX_DATAERR per ADR-0065)
     #[test]
-    fn t_er001b_data_errors_have_exit_code_65() {
+    fn data_errors_have_exit_code_65() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::InvalidRepo("bad".into()).into(),
             FetchError::InvalidScheme.into(),
@@ -477,7 +477,7 @@ mod tests {
 
     /// [T-ER001c] NotFound errors surface with exit 66 (EX_NOINPUT per ADR-0065)
     #[test]
-    fn t_er001c_not_found_errors_have_exit_code_66() {
+    fn not_found_errors_have_exit_code_66() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::NotFound("/test".into()).into(),
             FetchError::Status(404).into(),
@@ -490,7 +490,7 @@ mod tests {
 
     /// [T-ER002] IoError errors surface with exit 74 (EX_IOERR) and are non-retryable
     #[test]
-    fn t_er002_io_errors_have_exit_code_74() {
+    fn io_errors_have_exit_code_74() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::Api {
                 code: 400,
@@ -515,7 +515,7 @@ mod tests {
 
     /// [T-ER003] TempFailure errors are retryable, display retry hint, exit 75 (EX_TEMPFAIL)
     #[test]
-    fn t_er003_temp_failure_errors_have_exit_code_75() {
+    fn temp_failure_errors_have_exit_code_75() {
         let cases: Vec<ScoutError> = vec![
             FetchError::Status(408).into(),
             FetchError::Status(429).into(),
@@ -573,7 +573,7 @@ mod tests {
     // with no async shutdown race (unlike MockServer).
     /// [T-ER009] Connection-refused FetchError::Http maps to transient ScoutError
     #[tokio::test]
-    async fn t003_fetch_error_http_connection_refused_is_transient() {
+    async fn fetch_error_http_connection_refused_is_transient() {
         use reqwest::Client;
         use std::net::TcpListener;
 

--- a/src/tools/params.rs
+++ b/src/tools/params.rs
@@ -197,43 +197,43 @@ mod tests {
 
     /// [T-H001] search --help contains Examples: and Environment: sections
     #[test]
-    fn t_h001_search_help_contains_examples_and_environment() {
+    fn search_help_contains_examples_and_environment() {
         assert_help_sections::<super::SearchParams>(Some("GEMINI_API_KEY"));
     }
 
     /// [T-H002] fetch --help contains Examples: section
     #[test]
-    fn t_h002_fetch_help_contains_examples() {
+    fn fetch_help_contains_examples() {
         assert_help_sections::<super::FetchParams>(None);
     }
 
     /// [T-H003] research --help contains Examples: and Environment: sections
     #[test]
-    fn t_h003_research_help_contains_examples_and_environment() {
+    fn research_help_contains_examples_and_environment() {
         assert_help_sections::<super::ResearchParams>(Some("GEMINI_API_KEY"));
     }
 
     /// [T-H004] repo-tree --help contains Examples: and Environment: sections
     #[test]
-    fn t_h004_repo_tree_help_contains_examples_and_environment() {
+    fn repo_tree_help_contains_examples_and_environment() {
         assert_help_sections::<super::RepoTreeParams>(Some("GITHUB_TOKEN"));
     }
 
     /// [T-H005] repo-read --help contains Examples: and Environment: sections
     #[test]
-    fn t_h005_repo_read_help_contains_examples_and_environment() {
+    fn repo_read_help_contains_examples_and_environment() {
         assert_help_sections::<super::RepoReadParams>(Some("GITHUB_TOKEN"));
     }
 
     /// [T-H006] repo-overview --help contains Examples: and Environment: sections
     #[test]
-    fn t_h006_repo_overview_help_contains_examples_and_environment() {
+    fn repo_overview_help_contains_examples_and_environment() {
         assert_help_sections::<super::RepoOverviewParams>(Some("GITHUB_TOKEN"));
     }
 
     /// [T-H009] stdin-supporting subcommand help contains stdin usage examples
     #[test]
-    fn t_h009_subcommand_help_contains_stdin_examples() {
+    fn subcommand_help_contains_stdin_examples() {
         let cases: &[(&str, &str)] = &[
             ("search", "| scout search"),
             ("fetch", "| scout fetch"),
@@ -260,7 +260,7 @@ mod tests {
 
     /// [T-P001] research --depth accepts valid range 1..=10 and rejects out-of-range
     #[test]
-    fn t_p001_research_depth_valid_range() {
+    fn research_depth_valid_range() {
         use clap::Parser;
 
         #[derive(Parser)]
@@ -281,7 +281,7 @@ mod tests {
 
     /// [T-S001] optional positional arg is None when omitted from command line
     #[test]
-    fn t_s001_optional_positional_is_none_when_omitted() {
+    fn optional_positional_is_none_when_omitted() {
         use clap::Parser;
 
         #[derive(Parser)]
@@ -301,7 +301,7 @@ mod tests {
 
     /// [T-S002] ARG wins over piped stdin when both are present
     #[test]
-    fn t_s002_arg_wins_over_stdin() {
+    fn arg_wins_over_stdin() {
         let result = resolve_input(
             Some("from_arg".into()),
             Some("from_stdin"),
@@ -314,14 +314,14 @@ mod tests {
 
     /// [T-S003] ARG omitted + piped stdin → reads from stdin
     #[test]
-    fn t_s003_stdin_used_when_arg_omitted_and_piped() {
+    fn stdin_used_when_arg_omitted_and_piped() {
         let result = resolve_input(None, Some("from_stdin"), false, "query", "<QUERY>");
         assert_eq!(result.unwrap(), "from_stdin");
     }
 
     /// [T-S004] `-` reads from stdin even when terminal
     #[test]
-    fn t_s004_dash_reads_from_stdin() {
+    fn dash_reads_from_stdin() {
         let result = resolve_input(
             Some("-".into()),
             Some("from_stdin"),
@@ -334,7 +334,7 @@ mod tests {
 
     /// [T-S005] terminal + no arg → fail-fast error with canonical message
     #[test]
-    fn t_s005_terminal_no_arg_returns_fail_fast_error() {
+    fn terminal_no_arg_returns_fail_fast_error() {
         let result = resolve_input(None, None, true, "query", "<QUERY>");
         let err = result.unwrap_err().to_string();
         assert!(
@@ -357,7 +357,7 @@ mod tests {
 
     /// [T-S006] empty stdin → error with "No X provided" canonical message
     #[test]
-    fn t_s006_empty_stdin_returns_no_provided_error() {
+    fn empty_stdin_returns_no_provided_error() {
         let result = resolve_input(None, Some("   "), false, "query", "<QUERY>");
         let err = result.unwrap_err().to_string();
         assert!(
@@ -368,7 +368,7 @@ mod tests {
 
     /// [T-S007] `-` with empty stdin → same "No X provided" error
     #[test]
-    fn t_s007_dash_with_empty_stdin_returns_error() {
+    fn dash_with_empty_stdin_returns_error() {
         let result = resolve_input(Some("-".into()), Some(""), true, "url", "<URL>");
         let err = result.unwrap_err().to_string();
         assert!(
@@ -379,7 +379,7 @@ mod tests {
 
     /// [T-S008] stdin content is trimmed before use
     #[test]
-    fn t_s008_stdin_content_is_trimmed() {
+    fn stdin_content_is_trimmed() {
         let result = resolve_input(
             None,
             Some("  facebook/react\n"),

--- a/src/tools/typo.rs
+++ b/src/tools/typo.rs
@@ -78,40 +78,40 @@ mod tests {
 
     /// [T-TY001] osa_distance: identical strings have distance 0
     #[test]
-    fn t_ty001_identical_strings_have_distance_zero() {
+    fn identical_strings_have_distance_zero() {
         assert_eq!(osa_distance("README.md", "README.md"), 0);
         assert_eq!(osa_distance("", ""), 0);
     }
 
     /// [T-TY002] osa_distance: empty input returns the other's length
     #[test]
-    fn t_ty002_empty_input_returns_length() {
+    fn empty_input_returns_length() {
         assert_eq!(osa_distance("", "hello"), 5);
         assert_eq!(osa_distance("hello", ""), 5);
     }
 
     /// [T-TY003] osa_distance: single transposition counts as 1
     #[test]
-    fn t_ty003_transposition_counts_as_one() {
+    fn transposition_counts_as_one() {
         assert_eq!(osa_distance("REDAME", "README"), 1);
         assert_eq!(osa_distance("ab", "ba"), 1);
     }
 
     /// [T-TY004] osa_distance: substitution counts as 1
     #[test]
-    fn t_ty004_substitution_counts_as_one() {
+    fn substitution_counts_as_one() {
         assert_eq!(osa_distance("kitten", "sitten"), 1);
     }
 
     /// [T-TY005] osa_distance: classic kitten/sitting case is 3
     #[test]
-    fn t_ty005_kitten_sitting_distance_three() {
+    fn kitten_sitting_distance_three() {
         assert_eq!(osa_distance("kitten", "sitting"), 3);
     }
 
     /// [T-TY006] closest_matches: returns top-N filtered by max_distance
     #[test]
-    fn t_ty006_closest_matches_filters_by_distance() {
+    fn closest_matches_filters_by_distance() {
         let pool = ["README.md", "Cargo.toml", "src/main.rs", "REDAME.md"];
         let matches = closest_matches("REDME.md", pool.iter().copied(), 3, 3);
         assert!(matches.contains(&"REDAME.md".to_owned()));
@@ -122,7 +122,7 @@ mod tests {
 
     /// [T-TY007] closest_matches: empty pool returns empty
     #[test]
-    fn t_ty007_closest_matches_empty_pool_returns_empty() {
+    fn closest_matches_empty_pool_returns_empty() {
         let pool: Vec<&str> = vec![];
         let matches = closest_matches("REDAME.md", pool, 3, 3);
         assert!(matches.is_empty());
@@ -130,7 +130,7 @@ mod tests {
 
     /// [T-TY008] closest_matches: all-too-far returns empty
     #[test]
-    fn t_ty008_closest_matches_all_too_far_returns_empty() {
+    fn closest_matches_all_too_far_returns_empty() {
         let pool = ["totally-different.txt", "completely-unrelated.json"];
         let matches = closest_matches("REDAME.md", pool.iter().copied(), 3, 3);
         assert!(matches.is_empty());
@@ -138,7 +138,7 @@ mod tests {
 
     /// [T-TY009] closest_matches: respects top_n cap even with many in-range
     #[test]
-    fn t_ty009_closest_matches_respects_top_n_cap() {
+    fn closest_matches_respects_top_n_cap() {
         let pool = ["a", "ab", "abc", "abcd", "abcde"];
         let matches = closest_matches("a", pool.iter().copied(), 5, 2);
         assert_eq!(matches.len(), 2);

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -4,9 +4,9 @@ fn scout() -> Command {
     Command::new(env!("CARGO_BIN_EXE_scout"))
 }
 
-// T-C001
+// T-C001: help_exits_zero_and_contains_app_name
 #[test]
-fn t_c001_help_exits_zero_and_contains_app_name() {
+fn help_exits_zero_and_contains_app_name() {
     let output = scout().arg("--help").output().expect("scout --help failed");
     assert_eq!(output.status.code(), Some(0), "help should exit 0");
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -24,9 +24,9 @@ fn t_c001_help_exits_zero_and_contains_app_name() {
     );
 }
 
-// T-C002
+// T-C002: version_exits_zero
 #[test]
-fn t_c002_version_exits_zero() {
+fn version_exits_zero() {
     let output = scout()
         .arg("--version")
         .output()
@@ -39,9 +39,9 @@ fn t_c002_version_exits_zero() {
     );
 }
 
-// T-C003
+// T-C003: search_without_api_key_exits_64
 #[test]
-fn t_c003_search_without_api_key_exits_64() {
+fn search_without_api_key_exits_64() {
     let output = scout()
         .args(["search", "test query"])
         .env_remove("GEMINI_API_KEY")
@@ -59,9 +59,9 @@ fn t_c003_search_without_api_key_exits_64() {
     );
 }
 
-// T-C004
+// T-C004: fetch_invalid_url_exits_65
 #[test]
-fn t_c004_fetch_invalid_url_exits_65() {
+fn fetch_invalid_url_exits_65() {
     let output = scout()
         .args(["fetch", "not-a-valid-url"])
         .output()
@@ -78,9 +78,9 @@ fn t_c004_fetch_invalid_url_exits_65() {
     );
 }
 
-// T-C005
+// T-C005: repo_tree_bad_format_exits_65
 #[test]
-fn t_c005_repo_tree_bad_format_exits_65() {
+fn repo_tree_bad_format_exits_65() {
     let output = scout()
         .args(["repo-tree", "no-slash-here"])
         .output()
@@ -97,9 +97,9 @@ fn t_c005_repo_tree_bad_format_exits_65() {
     );
 }
 
-// T-C006: --json appears in --help under Options
+// T-C006: help_advertises_json_flag — --json appears in --help under Options
 #[test]
-fn t_c006_help_advertises_json_flag() {
+fn help_advertises_json_flag() {
     let output = scout().arg("--help").output().expect("scout --help failed");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -108,9 +108,9 @@ fn t_c006_help_advertises_json_flag() {
     );
 }
 
-// T-C007: --json with malformed repo emits a JSON envelope on stderr
+// T-C007: json_emits_envelope_on_error — --json with malformed repo emits a JSON envelope on stderr
 #[test]
-fn t_c007_json_emits_envelope_on_error() {
+fn json_emits_envelope_on_error() {
     let output = scout()
         .args(["--json", "repo-tree", "no-slash-here"])
         .output()
@@ -152,9 +152,9 @@ fn t_c007_json_emits_envelope_on_error() {
     );
 }
 
-// T-C008: --json missing API key surfaces a USAGE_ERROR envelope with next_step on stderr
+// T-C008: json_missing_api_key_emits_usage_error_with_next_step — --json missing API key surfaces a USAGE_ERROR envelope with next_step on stderr
 #[test]
-fn t_c008_json_missing_api_key_emits_usage_error_with_next_step() {
+fn json_missing_api_key_emits_usage_error_with_next_step() {
     let output = scout()
         .args(["--json", "search", "test query"])
         .env_remove("GEMINI_API_KEY")
@@ -183,9 +183,9 @@ fn t_c008_json_missing_api_key_emits_usage_error_with_next_step() {
     );
 }
 
-// T-C010: --json with a clap parse error (unknown flag) routes through JSON envelope
+// T-C010: json_clap_parse_error_emits_envelope — --json with a clap parse error (unknown flag) routes through JSON envelope
 #[test]
-fn t_c010_json_clap_parse_error_emits_envelope() {
+fn json_clap_parse_error_emits_envelope() {
     let output = scout()
         .args(["--json", "--definitely-not-a-flag"])
         .output()
@@ -207,9 +207,9 @@ fn t_c010_json_clap_parse_error_emits_envelope() {
     );
 }
 
-// T-C009: --json error envelope is exactly one line (single-line JSON contract)
+// T-C009: json_error_envelope_is_single_line — --json error envelope is exactly one line (single-line JSON contract)
 #[test]
-fn t_c009_json_error_envelope_is_single_line() {
+fn json_error_envelope_is_single_line() {
     let output = scout()
         .args(["--json", "repo-tree", "no-slash-here"])
         .output()


### PR DESCRIPTION
## 概要

LANG.md に基づいてテスト規約のリファクタリング Phase 1・Phase 2 を実施しました：

**Phase 1：T-NNN ID の去重化とプレフィックス付与**
- 複数ファイルにおける ID 衝突を解決（tools.rs, search/engine.rs, github/format.rs に同時に T-001 が存在）
- ファイル単位で ID をプレフィックス化：T-TS (tools.rs), T-SE (search/engine.rs), T-MD (markdown.rs), T-GF (github/format.rs), T-EN (envelope.rs) など
- envelope.rs の T-EN ID を宣言順に再整理（EN001～EN010）

**Phase 2：テスト関数名を自己説明的に改名**
- ~100 個のテスト関数を `t_NNN_*` プレフィックスから LANG.md の規約に準じた自己説明的な snake_case に改名
- すべての関数定義・ docstring 参照・コメントを更新
- github/format.rs の内部向け T-NNN セクションヘッダを削除（機能追跡用 FR-NNN, BR-NNN は保持）

## 変更ファイル

- src/tools.rs: T-TS ID 再番号付け + 17 個の関数改名
- src/search/engine.rs: T-SE ID プレフィックス化 + 2 個の関数改名
- src/markdown.rs: T-MD ID プレフィックス化
- src/envelope.rs: T-EN ID 再整理 + 10 個の関数改名
- src/github/encoding.rs: 11 個の関数改名 + セクションヘッダ削除
- src/github/format.rs: 内部向け T-NNN 参照削除，機能参照は保持
- src/lib.rs: write_output_* 系 4 個改名
- src/test_support.rs: try_spawn_mock_server_* 系 3 個改名
- src/tools/typo.rs: 9 個の関数改名
- src/tools/params.rs: 16 個の関数改名
- src/tools/errors.rs: 23 個の関数改名
- tests/cli_integration.rs: 10 個の関数改名

## テスト結果

- ✅ 全 338 テスト合格
- ✅ ロジック変更なし（リファクタのみ）
- ✅ 旧関数名への stale reference なし

## 注記

Phase 3（30 行超のテスト分割）は deferred — 大部分が JSON fixture のボイラープレートで，DRY gate（≥2 reuse）を満たさないため extraction 対象外。