### PR TITLE
feat: ADR-0003 / ADR-0004 実装 + Gemini 403 IAM 分岐

### DIFF
--- a/docs/audit/2026-05-13-adr-drift-postimpl.md
+++ b/docs/audit/2026-05-13-adr-drift-postimpl.md
@@ -1,0 +1,127 @@
+# ADR Drift Scan (Post-Implementation): 2026-05-13
+
+`/audit-adr-drift` 2nd dogfooding。`feat/adr-implementation` branch で ADR-0003 (partial) + ADR-0004 (full) implementation 完了後の状態を verify。
+
+## Summary
+
+| Metric             | Value |
+| ------------------ | ----- |
+| ADRs scanned       | 4     |
+| Drift findings     | 2     |
+| H priority         | 0     |
+| M priority         | 1     |
+| L priority         | 1     |
+| Unverifiable ADRs  | 0     |
+| External ADR refs  | 1 (ADR-0065) |
+
+## Per-ADR Findings
+
+### ADR 0001: SSRF Defense Architecture and fetch.rs Module Structure
+
+Status: accepted
+
+**No drift detected.** ADR Decision の全シンボルが現コードと整合:
+
+| 言及シンボル | 検出箇所 | 整合 |
+| --- | --- | --- |
+| `fetch_http` / `http` dual client | `src/tools.rs:128-137, 233, 295` | OK |
+| `redirect::Policy::none()` | `src/fetch.rs` | OK (PR #86 で doc comment 拡充済み) |
+| `check_browser_request` (CDP) | `src/fetch.rs:381` | OK (PR #86 で scheme rationale 追加済み) |
+| `#[cfg(feature = "js-rendering")]` | 13 箇所 | OK (split trigger 未到達) |
+
+#### Reassessment Trigger 現状
+
+| Trigger | 現状 | 状態 |
+| --- | --- | --- |
+| `fetch.rs > 2000 行` | 1456 | OK |
+| 新規 command 計 9 以上 | 6 | OK |
+| SSRF contract 違反 incident | 未発生 | OK |
+
+### ADR 0002: Adopt sysexits.h Exit Code Convention for CLI
+
+Status: accepted
+
+**No drift detected.** 前回 part-1 audit で発見した ADR-0065 → ADR-0002 ref drift は merge 済み PR で 5 箇所 fix 完了:
+
+- `src/envelope.rs:55-57`: ADR-0002 (exit-code) + ADR-0065 (JSON tag) の責務分離 doc comment
+- `src/tools/errors.rs:91, 97, 103, 112, 123, 128, 487` 等: `per ADR-0002` で統一
+
+T-H000 enforcement test 健在 (lib.rs:220-254)。
+
+### ADR 0003: Error Classification Contract for sysexits and JSON Output
+
+Status: accepted
+
+**Partial implementation (scope-aware), 1 documentation drift.**
+
+#### 実装状況 (4 sub-decision)
+
+| Sub-decision | 実装状況 | コメント |
+| --- | --- | --- |
+| HTTP status → ErrorCode mapping table | ✅ Mostly implemented | GeminiError/GitHubError は既存実装で table 適合、SlackError は本 PR で追加 (T-ER020/021/022) |
+| `degraded: bool` field on result struct | ✅ Already existed | `src/envelope.rs:17` に既存 (ADR 起票前から!) |
+| `DegradedReason` typed enum | ❌ Not implemented | ADR 内で「本 ADR 後の別 PR で実装」と明記済み (scope-aware) |
+| silent log-only fallback 廃止 (`unwrap_or_note`) | ❌ Not implemented | 同上、ADR で明記済み |
+
+#### Findings
+
+| # | File:Line | Description | Direction | Priority |
+| - | --------- | ----------- | --------- | -------- |
+| 1 | `docs/decisions/0003-...md` | ADR Decision で「`degraded: bool` field 追加」と書いたが、実は `src/envelope.rs:17` に **ADR 起票前から既存**。ADR は post-hoc documentation だった | `adr-update` (Note 追記) | L |
+
+ADR-0003 Note 追記推奨:
+> `degraded: bool` field on result structs was already implemented in `src/envelope.rs` at the time of this ADR's authoring. This ADR formalizes the existing behavior as the canonical contract rather than introducing a new field. The remaining work (DegradedReason enum + unwrap_or_note refactor) is captured in a separate follow-up issue.
+
+### ADR 0004: GitHub Client Behavioral Limits
+
+Status: accepted
+
+**Full implementation, no drift.** 3 Rule すべて feat/adr-implementation branch で実装:
+
+| Rule | 実装箇所 | Test |
+| --- | --- | --- |
+| 1. 403 + missing header → RateLimited | `src/github.rs:157-181` | T-GH010 |
+| 2. per_page > 100 → InvalidPerPage | `src/github.rs:255, 268, 281` + `validate_per_page`:294 | T-GH011 |
+| 3. filter_tree_entries glob path-scope | `src/github/helpers.rs:171-177` | T-GHH023 |
+
+すべての test pass (98 → 98 + 3 = 101 tests)。
+
+## External ADR Dependencies
+
+improved skill の external ADR cross-check で検出:
+
+| # | File:Line | External ADR ref | Status |
+| - | --------- | ---------------- | ------ |
+| 1 | `src/lib.rs:109, 121` | ADR-0065 (JSON envelope) | Expected per ADR-0002 supersede note (JSON schema portion remains in ADR-0065) |
+| 2 | `src/envelope.rs:1, 43, 56-57, 69, 77, 84, 155, 170, 241` | ADR-0065 (JSON envelope structure) | Expected per ADR-0002 supersede note |
+
+**Action**: 現状維持 OK。ADR-0002 supersede note で明示済み:
+> The JSON output schema portion of ADR-0065 (`error.code` field, `--json` mode, error envelope structure) is not included in this ADR and remains active in ADR-0065 until a scout-local ADR is promoted to capture it.
+
+将来 scout-local ADR (ADR-0005?) を起票して JSON schema 部分を移植する場合、これらの ref を一括更新する。
+
+## Skill Validation (3rd dogfood)
+
+`/audit-adr-drift` の improved skill 機能を本 audit で verification:
+
+| 機能 | 結果 |
+| --- | --- |
+| External ADR cross-check (Step 4 拡張) | ✅ ADR-0065 ref を正しく検出 |
+| `verification: pending_spec_check` (reviewer-rust 改善) | N/A (本 audit は ugrep 中心) |
+| `Bug vs Invariant` gate (Step 6.2) | N/A (challenge step 省略、軽量試運転) |
+| Partial implementation 検出 | ✅ ADR-0003 partial を「scope-aware drift」として識別 |
+
+## Follow-up Issue Candidates
+
+### M priority
+
+- [ ] ADR-0003 に Note 追加: 「`degraded: bool` field は ADR 起票前から既存。ADR は post-hoc documentation」(`docs/decisions/0003-*.md` More Information section)
+
+### L priority (低優先度)
+
+- なし
+
+### 別 PR / follow-up issue 候補 (ADR-0003 scope-aware drift から派生)
+
+- [ ] **DegradedReason enum 導入 + unwrap_or_note → unwrap_or_degraded refactor**: ADR-0003 残り scope、複数 call sites + JSON schema 変更で semver bump 検討
+- [ ] scout-local ADR-0005 起票検討: ADR-0065 JSON envelope schema portion を scout に移植 (envelope.rs / lib.rs / tools/errors.rs の `per ADR-0065` ref を `per ADR-0005` に更新)

--- a/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
+++ b/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
@@ -52,6 +52,8 @@ Chosen option: Option A, because public CLI contract として一貫した class
 * `DegradedReason` は `ReadmeMissing`, `IssuesFetchFailed`, `PullsFetchFailed`, `ReleasesFetchFailed` 等 enum で typed
 * silent log-only fallback (`unwrap_or_note` 系) は廃止
 
+> **Note (2026-05-13, post-implementation audit)**: `degraded: bool` field は本 ADR 起票前から `src/envelope.rs` に既存。本 ADR は既存 behavior を canonical contract として formalize し、残り (`DegradedReason` typed enum + `unwrap_or_note` → `unwrap_or_degraded` refactor + JSON schema 拡張) を follow-up scope として明示する。
+
 ### Consequences
 
 * Good, because CLI script が exit code で retry/fail-fast 判断可能、ADR-0002 contract が enforced される

--- a/src/gemini/client.rs
+++ b/src/gemini/client.rs
@@ -31,6 +31,9 @@ pub(crate) enum GeminiError {
     #[error("API quota exhausted: {0}")]
     QuotaExhausted(String),
 
+    #[error("Permission denied (IAM): {0}")]
+    PermissionDenied(String),
+
     #[error("API error ({code}): {message}")]
     Api { code: u16, message: String },
 
@@ -189,7 +192,25 @@ fn classify_api_error(err: &ApiError, retry_after: Option<u64>) -> GeminiError {
 
     match err.code {
         Some(429) => GeminiError::RateLimited { retry_after },
-        Some(403) => GeminiError::QuotaExhausted(message),
+        Some(403) => {
+            // Google API 403 covers both quota exhaustion (RESOURCE_EXHAUSTED)
+            // and IAM permission errors (PERMISSION_DENIED). Distinguish via
+            // the canonical `status` field; fall back to message heuristic
+            // when status is absent. See ADR-0003 (Error Classification).
+            let is_permission = err
+                .status
+                .as_deref()
+                .map(|s| s == "PERMISSION_DENIED")
+                .unwrap_or_else(|| {
+                    let m = message.to_ascii_lowercase();
+                    m.contains("permission") && m.contains("denied")
+                });
+            if is_permission {
+                GeminiError::PermissionDenied(message)
+            } else {
+                GeminiError::QuotaExhausted(message)
+            }
+        }
         Some(code) => GeminiError::Api { code, message },
         None => GeminiError::Api {
             code: 0,
@@ -208,6 +229,7 @@ mod tests {
         let err = ApiError {
             code: Some(429),
             message: Some("Resource exhausted".into()),
+            status: None,
         };
         assert!(matches!(
             classify_api_error(&err, None),
@@ -221,6 +243,7 @@ mod tests {
         let err = ApiError {
             code: Some(403),
             message: Some("Quota exceeded".into()),
+            status: None,
         };
         assert!(matches!(
             classify_api_error(&err, None),
@@ -234,6 +257,7 @@ mod tests {
         let err = ApiError {
             code: Some(500),
             message: Some("Internal server error".into()),
+            status: None,
         };
         match classify_api_error(&err, None) {
             GeminiError::Api { code, message } => {
@@ -242,6 +266,48 @@ mod tests {
             }
             other => panic!("expected Api error, got: {other:?}"),
         }
+    }
+
+    /// [T-GC010] classify_api_error maps 403 with status=PERMISSION_DENIED to PermissionDenied (ADR-0003)
+    #[test]
+    fn classify_403_permission_denied_via_status() {
+        let err = ApiError {
+            code: Some(403),
+            message: Some("The caller does not have permission".into()),
+            status: Some("PERMISSION_DENIED".into()),
+        };
+        assert!(matches!(
+            classify_api_error(&err, None),
+            GeminiError::PermissionDenied(_)
+        ));
+    }
+
+    /// [T-GC011] classify_api_error maps 403 with status=RESOURCE_EXHAUSTED to QuotaExhausted
+    #[test]
+    fn classify_403_quota_exhausted_via_status() {
+        let err = ApiError {
+            code: Some(403),
+            message: Some("Quota exceeded".into()),
+            status: Some("RESOURCE_EXHAUSTED".into()),
+        };
+        assert!(matches!(
+            classify_api_error(&err, None),
+            GeminiError::QuotaExhausted(_)
+        ));
+    }
+
+    /// [T-GC012] classify_api_error falls back to message heuristic when status is absent
+    #[test]
+    fn classify_403_message_heuristic_for_permission() {
+        let err = ApiError {
+            code: Some(403),
+            message: Some("Permission denied by IAM policy".into()),
+            status: None,
+        };
+        assert!(matches!(
+            classify_api_error(&err, None),
+            GeminiError::PermissionDenied(_)
+        ));
     }
 }
 

--- a/src/gemini/types.rs
+++ b/src/gemini/types.rs
@@ -61,6 +61,11 @@ pub(crate) struct WebChunk {
 pub(crate) struct ApiError {
     pub(crate) code: Option<u16>,
     pub(crate) message: Option<String>,
+    /// Google API canonical status string (e.g., "PERMISSION_DENIED",
+    /// "RESOURCE_EXHAUSTED"). Used to distinguish 403 IAM errors from
+    /// 403 quota exhaustion. See `classify_api_error` and ADR-0003.
+    #[serde(default)]
+    pub(crate) status: Option<String>,
 }
 
 /// LLM answer with grounding sources from Google Search.

--- a/src/github.rs
+++ b/src/github.rs
@@ -67,6 +67,9 @@ pub(crate) enum GitHubError {
     #[error("Invalid glob pattern: {0}")]
     InvalidPattern(String),
 
+    #[error("per_page must be <= 100 (GitHub API limit), got {0}")]
+    InvalidPerPage(u8),
+
     #[error("Content decode error: {0}")]
     Decode(String),
 
@@ -151,17 +154,30 @@ impl GitHubClient {
                 Err(GitHubError::RateLimited { retry_after })
             }
             403 => {
+                // ADR-0004 Rule 1: 403 + missing `x-ratelimit-remaining` defaults to
+                // RateLimited (retry) because GitHub does not guarantee this header
+                // on all 403 responses (e.g., secondary rate limits). Only treat as
+                // Forbidden when the header is present and remaining > 0 (genuine
+                // auth misconfig).
                 let remaining = response
                     .headers()
                     .get("x-ratelimit-remaining")
                     .and_then(|v| v.to_str().ok())
                     .and_then(|v| v.parse::<u64>().ok());
                 let retry_after = secs_until_ratelimit_reset(response.headers());
-                if remaining == Some(0) {
-                    Err(GitHubError::RateLimited { retry_after })
-                } else {
-                    let message = extract_error_message(&response.text().await.unwrap_or_default());
-                    Err(GitHubError::Forbidden(message))
+                match remaining {
+                    Some(r) if r > 0 => {
+                        let message =
+                            extract_error_message(&response.text().await.unwrap_or_default());
+                        Err(GitHubError::Forbidden(message))
+                    }
+                    _ => {
+                        warn!(
+                            retry_after_secs = retry_after,
+                            "GitHub 403 with missing or zero rate-limit-remaining, treating as RateLimited (ADR-0004)"
+                        );
+                        Err(GitHubError::RateLimited { retry_after })
+                    }
                 }
             }
             _ => {
@@ -236,7 +252,7 @@ impl GitHubClient {
         repo: &str,
         per_page: u8,
     ) -> Result<Vec<IssueInfo>, GitHubError> {
-        let per_page = per_page.min(100);
+        validate_per_page(per_page)?;
         self.get_json(&format!(
             "/repos/{owner}/{repo}/issues?state=open&sort=updated&direction=desc&per_page={per_page}"
         ))
@@ -249,7 +265,7 @@ impl GitHubClient {
         repo: &str,
         per_page: u8,
     ) -> Result<Vec<PullInfo>, GitHubError> {
-        let per_page = per_page.min(100);
+        validate_per_page(per_page)?;
         self.get_json(&format!(
             "/repos/{owner}/{repo}/pulls?state=open&sort=updated&direction=desc&per_page={per_page}"
         ))
@@ -262,11 +278,24 @@ impl GitHubClient {
         repo: &str,
         per_page: u8,
     ) -> Result<Vec<ReleaseInfo>, GitHubError> {
-        let per_page = per_page.min(100);
+        validate_per_page(per_page)?;
         self.get_json(&format!(
             "/repos/{owner}/{repo}/releases?per_page={per_page}"
         ))
         .await
+    }
+}
+
+/// ADR-0004 Rule 2: per_page > 100 returns explicit error rather than silent
+/// clamp. GitHub API caps per_page at 100; previously the code did
+/// `per_page.min(100)` silently, returning fewer results than requested with
+/// no diagnostic. Now callers receive `GitHubError::InvalidPerPage` (mapped
+/// to `data_error`, exit 65) and can correct the input.
+fn validate_per_page(per_page: u8) -> Result<(), GitHubError> {
+    if per_page > 100 {
+        Err(GitHubError::InvalidPerPage(per_page))
+    } else {
+        Ok(())
     }
 }
 
@@ -435,6 +464,41 @@ mod http_tests {
         let client = GitHubClient::with_base_url(Client::new(), &server.uri());
         let result: Result<RepoInfo, _> = client.get_json("/repos/owner/repo").await;
         assert!(matches!(result, Err(GitHubError::Forbidden(ref msg)) if msg == "access denied"));
+    }
+
+    /// [T-GH010] 403 without x-ratelimit-remaining header maps to RateLimited (ADR-0004 Rule 1)
+    #[tokio::test]
+    async fn get_json_403_with_missing_remaining_returns_rate_limited() {
+        let Some(server) = try_spawn_mock_server("github::http").await else {
+            return;
+        };
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo"))
+            .respond_with(
+                ResponseTemplate::new(403)
+                    .set_body_json(serde_json::json!({"message": "secondary rate limit"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base_url(Client::new(), &server.uri());
+        let result: Result<RepoInfo, _> = client.get_json("/repos/owner/repo").await;
+        assert!(matches!(result, Err(GitHubError::RateLimited { .. })));
+    }
+
+    /// [T-GH011] validate_per_page rejects values over 100 (ADR-0004 Rule 2)
+    #[test]
+    fn validate_per_page_rejects_over_100() {
+        assert!(matches!(
+            super::validate_per_page(101),
+            Err(GitHubError::InvalidPerPage(101))
+        ));
+        assert!(matches!(
+            super::validate_per_page(255),
+            Err(GitHubError::InvalidPerPage(255))
+        ));
+        assert!(super::validate_per_page(100).is_ok());
+        assert!(super::validate_per_page(1).is_ok());
     }
 
     /// [T-GH005] resolve_token_with reads token from GITHUB_TOKEN env var

--- a/src/github/helpers.rs
+++ b/src/github/helpers.rs
@@ -174,10 +174,11 @@ pub(crate) fn filter_tree_entries<'a>(
             })
         })
         .filter(|e| {
-            matcher.as_ref().is_none_or(|m| {
-                let filename = e.path.rsplit('/').next().unwrap_or(&e.path);
-                m.is_match(filename)
-            })
+            // ADR-0004 Rule 3: glob matches against the full repo-relative path
+            // (e.g., `src/*.rs` matches `src/main.rs`). Previously matched only
+            // the filename component, causing path-scoped patterns to silently
+            // produce zero results.
+            matcher.as_ref().is_none_or(|m| m.is_match(&e.path))
         })
         .collect())
 }
@@ -433,6 +434,21 @@ mod tests {
         let filtered = filter_tree_entries(&entries, None, Some("*.rs")).unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].path, "src/main.rs");
+    }
+
+    /// [T-GHH023] filter_tree_entries glob matches against full repo-relative path (ADR-0004 Rule 3)
+    #[test]
+    fn filter_by_glob_matches_full_path() {
+        let entries = vec![
+            blob("src/main.rs"),
+            blob("tests/integration.rs"),
+            blob("src/lib.rs"),
+        ];
+        let filtered = filter_tree_entries(&entries, None, Some("src/*.rs")).unwrap();
+        assert_eq!(filtered.len(), 2);
+        let paths: Vec<&str> = filtered.iter().map(|e| e.path.as_str()).collect();
+        assert!(paths.contains(&"src/main.rs"));
+        assert!(paths.contains(&"src/lib.rs"));
     }
 
     /// [T-GHH021] filter_tree_entries excludes directory tree entries

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -152,6 +152,10 @@ impl From<github::GitHubError> for ScoutError {
                 .with_next_step("Use format like '1-80', '50-', or '100' (first N lines)"),
             github::GitHubError::InvalidPattern(_) => Self::data_error(e.to_string())
                 .with_next_step("Use a glob pattern like '*.rs' or '*.{ts,tsx}'"),
+            github::GitHubError::InvalidPerPage(_) => Self::data_error(e.to_string())
+                .with_next_step(
+                    "GitHub API limits per_page to 100; pass a value between 1 and 100",
+                ),
             github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string())
                 .with_next_step("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
             github::GitHubError::RateLimited { retry_after } => Self::transient(e.to_string())

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -231,7 +231,21 @@ impl From<SlackError> for ScoutError {
         match &e {
             SlackError::TokenNotSet => Self::user_error(e.to_string())
                 .with_next_step("Export a User OAuth token to SLACK_TOKEN (xoxp-…)"),
-            SlackError::Api { .. } => Self::user_error(e.to_string()),
+            SlackError::Api { error } => {
+                // ADR-0003: Slack API uses error code strings (not HTTP status)
+                // for API-level failures. Classify by the canonical `error` field
+                // so transient/not-found cases get the correct exit code instead
+                // of a uniform user_error (exit 64).
+                match error.as_str() {
+                    "internal_error" | "service_unavailable" | "fatal_error" => {
+                        Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+                    }
+                    "channel_not_found" | "message_not_found" | "thread_not_found" => {
+                        Self::not_found(e.to_string())
+                    }
+                    _ => Self::user_error(e.to_string()),
+                }
+            }
             SlackError::RateLimited { .. } => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
@@ -438,6 +452,36 @@ mod tests {
     fn fetch_status_404_classifies_as_not_found() {
         let err = ScoutError::from(FetchError::Status(404));
         assert_eq!(err.error_kind(), ErrorCode::NotFound);
+    }
+
+    /// [T-ER020] SlackError::Api with internal_error classifies as TempFailure (ADR-0003)
+    #[test]
+    fn slack_internal_error_classifies_as_temp_failure() {
+        use crate::slack::SlackError;
+        let err = ScoutError::from(SlackError::Api {
+            error: "internal_error".to_owned(),
+        });
+        assert_eq!(err.error_kind(), ErrorCode::TempFailure);
+    }
+
+    /// [T-ER021] SlackError::Api with channel_not_found classifies as NotFound (ADR-0003)
+    #[test]
+    fn slack_channel_not_found_classifies_as_not_found() {
+        use crate::slack::SlackError;
+        let err = ScoutError::from(SlackError::Api {
+            error: "channel_not_found".to_owned(),
+        });
+        assert_eq!(err.error_kind(), ErrorCode::NotFound);
+    }
+
+    /// [T-ER022] SlackError::Api with other error codes (e.g., invalid_auth) classifies as UsageError
+    #[test]
+    fn slack_other_api_error_classifies_as_usage_error() {
+        use crate::slack::SlackError;
+        let err = ScoutError::from(SlackError::Api {
+            error: "invalid_auth".to_owned(),
+        });
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
     }
 
     /// [T-ER001a] UsageError errors surface with exit 64 (EX_USAGE per ADR-0002)

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -252,6 +252,9 @@ impl From<GeminiError> for ScoutError {
             }
             GeminiError::QuotaExhausted(_) => Self::user_error(e.to_string())
                 .with_next_step("Check your API billing at https://aistudio.google.com"),
+            GeminiError::PermissionDenied(_) => Self::user_error(e.to_string()).with_next_step(
+                "Check IAM permissions for the Gemini API in your Google Cloud project",
+            ),
             GeminiError::Network(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }


### PR DESCRIPTION
## 目的

ADR foundation PR (#86, merged) で起票した ADR-0001/0002/0003/0004 のうち、ADR-0003 (partial) と ADR-0004 (full) を実装し、audit-undocumented part-2 で発見した Gemini 403 IAM/quota 誤分類 bug を fix する。

## 変更内容

| Commit | 内容 | 新規 Test |
| --- | --- | --- |
| `fix(gemini)` | 403 IAM (PERMISSION_DENIED) vs quota (RESOURCE_EXHAUSTED) を canonical `status` field で分岐。`GeminiError::PermissionDenied` 新 variant 追加 | T-GC010/011/012 |
| `feat(github)` | ADR-0004 3 rule 全実装。403 + missing rate-limit-remaining → RateLimited / per_page > 100 → InvalidPerPage / filter_tree_entries glob を full path match に | T-GH010/011, T-GHH023 |
| `feat(slack)` | ADR-0003 SlackError 分類。internal_error/service_unavailable は transient、channel_not_found は not_found に分岐 | T-ER020/021/022 |
| `docs(audit)` | 本 branch に対する audit-adr-drift 結果記録 + ADR-0003 に「degraded field は pre-existing」Note 追加 | - |

## 設計判断

- **Gemini 403 を `status` field で分岐**: Google API は 403 に PERMISSION_DENIED と RESOURCE_EXHAUSTED の 2 種を返す。canonical status field を見る方が message heuristic より robust だが、status 欠落時の fallback として message ("permission" AND "denied") も実装
- **403 + missing rate-limit-remaining → RateLimited (retry default)**: GitHub は 403 で常に header を保証しないため、retry に倒す方が secondary rate limit の取りこぼし防止になる。false-positive retry は trade-off として受容
- **per_page silent clamp 廃止**: silent truncation は CLI 利用者の data integrity を損なう。`InvalidPerPage` で明示的に reject
- **glob filename-only behavior 廃止**: `src/*.rs` 等 path-scoped pattern の intuitive な動作を優先
- **SlackError 分類は error code string ベース**: Slack API は HTTP status を返さず、JSON `error` field が canonical。`internal_error` / `service_unavailable` は transient、`*_not_found` は not_found

## テスト手順

1. `cargo test --lib` で 337 test 全 pass を確認
2. 新規 test を個別実行:
   - `cargo test --lib gemini::client::tests::classify_403_permission_denied_via_status`
   - `cargo test --lib github::http_tests::get_json_403_with_missing_remaining_returns_rate_limited`
   - `cargo test --lib github::tests::validate_per_page_rejects_over_100`
   - `cargo test --lib github::helpers::tests::filter_by_glob_matches_full_path`
   - `cargo test --lib tools::errors::tests::slack_internal_error_classifies_as_temp_failure`
3. `docs/audit/2026-05-13-adr-drift-postimpl.md` で audit 結果確認 (drift 0 H / 1 M 本 PR で fix 済み / 1 L)

## スコープ

- **対象外**: ADR-0003 残り (DegradedReason enum + `unwrap_or_note` → `unwrap_or_degraded` refactor + JSON schema 拡張)。複数 call sites + JSON schema 変更で semver bump 検討、別 PR で実装 (ADR-0003 内で明記済み)
- **対象外**: ADR-0005 起票検討 (ADR-0065 JSON envelope schema portion の scout-local 移植)。`src/lib.rs` と `src/envelope.rs` に 12 ref 残るが、ADR-0002 supersede note で deferral 明示済み

## リスク

- behavior 変更 (semver bump 検討):
  - GitHub `per_page > 100` で `InvalidPerPage` error 返却 (以前は silent clamp で 100 件返却)
  - GitHub `filter_tree_entries` glob が full path に match (以前は filename only)
- `Bash(cargo:*)` 等の permission syntax 変更なし (前回 PR で対応済み)

## 関連

- 前 PR #86 (merged): ADR foundation
- audit report: `docs/audit/2026-05-13-undocumented-decisions-part2.md` (Candidate #7/#8/#14/#15/#16/#17 → 本 PR で fix)
- audit-adr-drift 2nd dogfood の skill validation 結果は `docs/audit/2026-05-13-adr-drift-postimpl.md`
