### PR TITLE
feat(envelope): ADR-0003 残り実装 - DegradedReason typed enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64",
  "chardetng 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scout"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.95"
 description = "CLI tool for web search (Gemini Grounding), page fetching, and GitHub repository exploration"

--- a/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
+++ b/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
@@ -53,6 +53,10 @@ Chosen option: Option A, because public CLI contract として一貫した class
 * silent log-only fallback (`unwrap_or_note` 系) は廃止
 
 > **Note (2026-05-13, post-implementation audit)**: `degraded: bool` field は本 ADR 起票前から `src/envelope.rs` に既存。本 ADR は既存 behavior を canonical contract として formalize し、残り (`DegradedReason` typed enum + `unwrap_or_note` → `unwrap_or_degraded` refactor + JSON schema 拡張) を follow-up scope として明示する。
+>
+> **Note (2026-05-13, follow-up implementation)**: 残り scope を additive route で実装完了。実装した variants は callsite から逆算した 8 種類 (`IssuesFetchFailed`, `PullsFetchFailed`, `ReleasesFetchFailed`, `ReadmeFetchFailed`, `ReadmeBlobFetchFailed`, `ReadmeDecodeFailed`, `UrlFetchFailed`, `ReadabilityFallback`)。当初挙げた `ReadmeMissing` は `resolve_readme` 実装が 404 を silent 扱い (notes 追加なし) としていたため variant 化せず、README 系は failure mode で 3 種に分割。JSON schema 変更は additive (`degraded_reasons` field を `skip_serializing_if = "Vec::is_empty"` で追加) なので Cargo `version = "1.0.0"` → `"1.1.0"` の minor bump。既存 caller (`notes` の `Vec<String>` 構造を見る) は無影響。
+>
+> **README 404 silent の意図的選択**: 「README が存在しない repo」は scout として degraded ではない (overview は他フィールドだけで成立)。404 を silent にすることで `degraded` flag を「abnormal なときだけ立てる」契約に保つ。代わりに JSON consumer は `data.readme` が null か否かで「README の有無」を直接判別可能 (404 と fetch error の区別は `degraded_reasons` の `ReadmeFetchFailed` の有無で行う)。403 等の non-404 4xx は `ReadmeFetchFailed` で集約しており、status code 別の細分は当面 scope 外。
 
 ### Consequences
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,10 +1,78 @@
-//! Output envelopes per ADR-0065 (scout JSON output schema).
+//! Output envelopes per ADR-0065 (scout JSON output schema) and ADR-0003
+//! (degraded_reasons typed enum).
 //!
 //! `CommandOutput` is the internal shape produced by each command handler;
 //! `lib::run` then serializes it as Markdown (default) or as a `SuccessEnvelope`
 //! JSON line (when `--json` is set).
 
 use serde::Serialize;
+
+/// Typed reason for a degraded command output (partial failure) per ADR-0003.
+/// Exposed under `degraded_reasons` in JSON output so callers can detect
+/// specific failure modes programmatically rather than parsing free-form notes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum DegradedReason {
+    IssuesFetchFailed,
+    PullsFetchFailed,
+    ReleasesFetchFailed,
+    ReadmeFetchFailed,
+    ReadmeBlobFetchFailed,
+    ReadmeDecodeFailed,
+    UrlFetchFailed,
+    ReadabilityFallback,
+}
+
+impl DegradedReason {
+    /// Human-readable label used by [`crate::tools::errors::unwrap_or_degraded`]
+    /// to build the `"Could not fetch {label} ({e})"` message. Only the three
+    /// `*FetchFailed` variants that flow through that helper get a meaningful
+    /// label; other variants build bespoke messages at their callsite.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::IssuesFetchFailed => "issues",
+            Self::PullsFetchFailed => "pull requests",
+            Self::ReleasesFetchFailed => "releases",
+            Self::ReadmeFetchFailed
+            | Self::ReadmeBlobFetchFailed
+            | Self::ReadmeDecodeFailed
+            | Self::UrlFetchFailed
+            | Self::ReadabilityFallback => "resource",
+        }
+    }
+}
+
+/// Bundle of human-readable notes and typed reasons collected during a
+/// degraded command path. The `(notes[i], reasons[i])` pairing invariant is
+/// enforced by making the fields private and exposing [`Degradation::push`]
+/// as the sole mutator.
+#[derive(Debug, Default)]
+pub(crate) struct Degradation {
+    notes: Vec<String>,
+    reasons: Vec<DegradedReason>,
+}
+
+impl Degradation {
+    /// Push a human-readable message paired with its typed reason.
+    pub fn push(&mut self, message: String, reason: DegradedReason) {
+        self.notes.push(message);
+        self.reasons.push(reason);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.notes.is_empty() && self.reasons.is_empty()
+    }
+
+    /// Read access to the human-readable notes for Markdown rendering.
+    pub fn notes(&self) -> &[String] {
+        &self.notes
+    }
+
+    /// Consume and return the underlying vectors.
+    pub fn into_parts(self) -> (Vec<String>, Vec<DegradedReason>) {
+        (self.notes, self.reasons)
+    }
+}
 
 /// Internal command output: holds both the Markdown rendering and the
 /// structured `data` payload, plus degradation signals. Each handler builds
@@ -14,27 +82,36 @@ pub(crate) struct CommandOutput {
     pub markdown: String,
     pub data: serde_json::Value,
     pub notes: Vec<String>,
+    pub degraded_reasons: Vec<DegradedReason>,
     pub degraded: bool,
 }
 
 impl CommandOutput {
-    /// Construct an output with no degradation signal (notes empty, degraded=false).
+    /// Construct an output with no degradation signal.
     pub fn ok(markdown: String, data: serde_json::Value) -> Self {
         Self {
             markdown,
             data,
             notes: Vec::new(),
+            degraded_reasons: Vec::new(),
             degraded: false,
         }
     }
 
-    /// Construct an output with degradation notes; `degraded` is set iff `notes` is non-empty.
-    pub fn with_notes(markdown: String, data: serde_json::Value, notes: Vec<String>) -> Self {
-        let degraded = !notes.is_empty();
+    /// Construct an output from a [`Degradation`] bundle. `degraded` is set
+    /// when either `notes` or `reasons` is non-empty.
+    pub fn with_degradation(
+        markdown: String,
+        data: serde_json::Value,
+        degradation: Degradation,
+    ) -> Self {
+        let degraded = !degradation.is_empty();
+        let (notes, degraded_reasons) = degradation.into_parts();
         Self {
             markdown,
             data,
             notes,
+            degraded_reasons,
             degraded,
         }
     }
@@ -66,12 +143,15 @@ impl ErrorCode {
     }
 }
 
-/// Success envelope wrapping command output per ADR-0065.
+/// Success envelope wrapping command output per ADR-0065. ADR-0003 added
+/// `degraded_reasons` as an additive field (omitted from JSON when empty).
 #[derive(Debug, Serialize)]
 pub(crate) struct SuccessEnvelope {
     pub data: serde_json::Value,
     pub degraded: bool,
     pub notes: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub degraded_reasons: Vec<DegradedReason>,
 }
 
 /// Error envelope per ADR-0065. Wraps the payload under an `error` key so
@@ -182,6 +262,7 @@ mod tests {
             data: serde_json::json!({"markdown": "hello"}),
             degraded: false,
             notes: vec![],
+            degraded_reasons: vec![],
         };
         let json = serde_json::to_string(&env).unwrap();
         assert!(
@@ -190,6 +271,10 @@ mod tests {
         );
         assert!(json.contains(r#""degraded":false"#), "got: {json}");
         assert!(json.contains(r#""notes":[]"#), "got: {json}");
+        assert!(
+            !json.contains("degraded_reasons"),
+            "degraded_reasons should be omitted when empty per ADR-0003, got: {json}"
+        );
     }
 
     /// [T-EN006] SuccessEnvelope surfaces degraded=true with notes
@@ -199,6 +284,7 @@ mod tests {
             data: serde_json::json!(null),
             degraded: true,
             notes: vec![String::from("Could not fetch contributors")],
+            degraded_reasons: vec![],
         };
         let json = serde_json::to_string(&env).unwrap();
         assert!(json.contains(r#""degraded":true"#), "got: {json}");
@@ -215,27 +301,37 @@ mod tests {
         assert_eq!(out.markdown, "md");
         assert_eq!(out.data, serde_json::json!({"a": 1}));
         assert!(out.notes.is_empty());
+        assert!(out.degraded_reasons.is_empty());
         assert!(!out.degraded);
     }
 
-    /// [T-EN008] CommandOutput::with_notes sets degraded=true when notes non-empty
+    /// [T-EN008] CommandOutput::with_degradation sets degraded=true when degradation non-empty
     #[test]
-    fn command_output_with_notes_is_degraded() {
-        let out = CommandOutput::with_notes(
-            String::from("md"),
-            serde_json::Value::Null,
-            vec![String::from("partial fetch")],
+    fn command_output_with_degradation_is_degraded() {
+        let mut deg = Degradation::default();
+        deg.push(
+            String::from("partial fetch"),
+            DegradedReason::IssuesFetchFailed,
         );
+        let out = CommandOutput::with_degradation(String::from("md"), serde_json::Value::Null, deg);
         assert!(out.degraded);
         assert_eq!(out.notes, vec!["partial fetch"]);
+        assert_eq!(
+            out.degraded_reasons,
+            vec![DegradedReason::IssuesFetchFailed]
+        );
     }
 
-    /// [T-EN009] CommandOutput::with_notes sets degraded=false when notes empty
+    /// [T-EN009] CommandOutput::with_degradation sets degraded=false when degradation empty
     #[test]
-    fn command_output_with_empty_notes_is_not_degraded() {
-        let out =
-            CommandOutput::with_notes(String::from("md"), serde_json::Value::Null, Vec::new());
+    fn command_output_with_empty_degradation_is_not_degraded() {
+        let out = CommandOutput::with_degradation(
+            String::from("md"),
+            serde_json::Value::Null,
+            Degradation::default(),
+        );
         assert!(!out.degraded);
+        assert!(out.degraded_reasons.is_empty());
     }
 
     /// [T-EN010] ErrorCode serializes per ADR-0065 SCREAMING_SNAKE_CASE
@@ -255,5 +351,79 @@ mod tests {
                 "code {code:?} should serialize as {expected}"
             );
         }
+    }
+
+    /// [T-EN011] DegradedReason serializes per ADR-0003 SCREAMING_SNAKE_CASE
+    #[test]
+    fn degraded_reason_serializes_screaming_snake_case() {
+        let pairs = [
+            (
+                DegradedReason::IssuesFetchFailed,
+                r#""ISSUES_FETCH_FAILED""#,
+            ),
+            (DegradedReason::PullsFetchFailed, r#""PULLS_FETCH_FAILED""#),
+            (
+                DegradedReason::ReleasesFetchFailed,
+                r#""RELEASES_FETCH_FAILED""#,
+            ),
+            (
+                DegradedReason::ReadmeFetchFailed,
+                r#""README_FETCH_FAILED""#,
+            ),
+            (
+                DegradedReason::ReadmeBlobFetchFailed,
+                r#""README_BLOB_FETCH_FAILED""#,
+            ),
+            (
+                DegradedReason::ReadmeDecodeFailed,
+                r#""README_DECODE_FAILED""#,
+            ),
+            (DegradedReason::UrlFetchFailed, r#""URL_FETCH_FAILED""#),
+            (
+                DegradedReason::ReadabilityFallback,
+                r#""READABILITY_FALLBACK""#,
+            ),
+        ];
+        for (reason, expected) in pairs {
+            let actual = serde_json::to_string(&reason).unwrap();
+            assert_eq!(
+                actual, expected,
+                "reason {reason:?} should serialize as {expected}"
+            );
+        }
+    }
+
+    /// [T-EN012] Degradation::push pairs notes and reasons in order
+    #[test]
+    fn degradation_push_pairs_notes_and_reasons() {
+        let mut deg = Degradation::default();
+        deg.push(String::from("first"), DegradedReason::IssuesFetchFailed);
+        deg.push(String::from("second"), DegradedReason::PullsFetchFailed);
+        assert!(!deg.is_empty());
+        let (notes, reasons) = deg.into_parts();
+        assert_eq!(notes, vec!["first", "second"]);
+        assert_eq!(
+            reasons,
+            vec![
+                DegradedReason::IssuesFetchFailed,
+                DegradedReason::PullsFetchFailed,
+            ]
+        );
+    }
+
+    /// [T-EN013] SuccessEnvelope includes degraded_reasons when non-empty
+    #[test]
+    fn success_envelope_surfaces_degraded_reasons() {
+        let env = SuccessEnvelope {
+            data: serde_json::json!(null),
+            degraded: true,
+            notes: vec![String::from("Could not fetch issues")],
+            degraded_reasons: vec![DegradedReason::IssuesFetchFailed],
+        };
+        let json = serde_json::to_string(&env).unwrap();
+        assert!(
+            json.contains(r#""degraded_reasons":["ISSUES_FETCH_FAILED"]"#),
+            "got: {json}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ fn render_json_success(output: CommandOutput) -> String {
         data: output.data,
         degraded: output.degraded,
         notes: output.notes,
+        degraded_reasons: output.degraded_reasons,
     };
     serde_json::to_string(&envelope).expect("envelope is Serialize")
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -15,13 +15,13 @@ use tokio::sync::OnceCell;
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-use errors::{parse_repo_param, unwrap_or_note};
+use errors::{parse_repo_param, unwrap_or_degraded};
 use params::{
     FetchParams, RepoOverviewParams, RepoReadParams, RepoTreeParams, ResearchParams, SearchParams,
     resolve_input,
 };
 
-use crate::envelope::CommandOutput;
+use crate::envelope::{CommandOutput, Degradation, DegradedReason};
 use crate::fetch::converter::{FetchResult, RAW_FALLBACK_NOTE};
 use crate::fetch::{FetchError, FetchOptions, TokioDnsResolver, fetch_page};
 use crate::gemini::client::{GeminiClient, GeminiError, SearchClient as _};
@@ -247,14 +247,16 @@ impl Scout {
         info!(url = %url, "fetch complete");
         let markdown = format_fetch_output(&result);
         let data = serde_json::to_value(&result).expect("FetchResult is Serialize");
-        let notes = if result.used_raw_fallback {
-            vec![String::from(
-                "Readability extraction failed; raw page conversion was used instead.",
-            )]
-        } else {
-            Vec::new()
-        };
-        Ok(CommandOutput::with_notes(markdown, data, notes))
+        let mut degradation = Degradation::default();
+        if result.used_raw_fallback {
+            degradation.push(
+                String::from(
+                    "Readability extraction failed; raw page conversion was used instead.",
+                ),
+                DegradedReason::ReadabilityFallback,
+            );
+        }
+        Ok(CommandOutput::with_degradation(markdown, data, degradation))
     }
 
     async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<CommandOutput, ScoutError> {
@@ -306,11 +308,13 @@ impl Scout {
         if let Some(map) = data.as_object_mut() {
             map.insert("query".to_owned(), serde_json::Value::String(query.clone()));
         }
-        let mut notes: Vec<String> = report
-            .failed_urls
-            .iter()
-            .map(|f| format!("Failed to fetch {}: {}", f.url, f.reason))
-            .collect();
+        let mut degradation = Degradation::default();
+        for f in &report.failed_urls {
+            degradation.push(
+                format!("Failed to fetch {}: {}", f.url, f.reason),
+                DegradedReason::UrlFetchFailed,
+            );
+        }
         let raw_fallback_pages: Vec<&str> = report
             .fetched_pages
             .iter()
@@ -318,12 +322,15 @@ impl Scout {
             .map(|p| p.url.as_str())
             .collect();
         if !raw_fallback_pages.is_empty() {
-            notes.push(format!(
-                "Readability extraction failed for: {}",
-                raw_fallback_pages.join(", ")
-            ));
+            degradation.push(
+                format!(
+                    "Readability extraction failed for: {}",
+                    raw_fallback_pages.join(", ")
+                ),
+                DegradedReason::ReadabilityFallback,
+            );
         }
-        Ok(CommandOutput::with_notes(markdown, data, notes))
+        Ok(CommandOutput::with_degradation(markdown, data, degradation))
     }
 
     async fn repo_tree(&self, params: RepoTreeParams) -> Result<CommandOutput, ScoutError> {
@@ -470,11 +477,16 @@ impl Scout {
             github.get_releases(owner, repo, OVERVIEW_RELEASES),
         );
 
-        let mut notes = Vec::new();
-        let readme_content = resolve_readme(github, owner, repo, readme, &mut notes).await;
-        let issues = unwrap_or_note(issues, "issues", &mut notes);
-        let pulls = unwrap_or_note(pulls, "pull requests", &mut notes);
-        let releases = unwrap_or_note(releases, "releases", &mut notes);
+        let mut degradation = Degradation::default();
+        let readme_content = resolve_readme(github, owner, repo, readme, &mut degradation).await;
+        let issues =
+            unwrap_or_degraded(issues, DegradedReason::IssuesFetchFailed, &mut degradation);
+        let pulls = unwrap_or_degraded(pulls, DegradedReason::PullsFetchFailed, &mut degradation);
+        let releases = unwrap_or_degraded(
+            releases,
+            DegradedReason::ReleasesFetchFailed,
+            &mut degradation,
+        );
 
         let mut markdown = github::format::format_overview(
             &repo_info,
@@ -484,9 +496,9 @@ impl Scout {
             &releases,
         );
 
-        if !notes.is_empty() {
+        if !degradation.is_empty() {
             markdown.push_str("\n> **Note:** ");
-            markdown.push_str(&notes.join(". "));
+            markdown.push_str(&degradation.notes().join(". "));
             markdown.push_str(".\n");
         }
 
@@ -509,7 +521,7 @@ impl Scout {
             has_readme = readme_content.is_some(),
             "repo_overview complete"
         );
-        Ok(CommandOutput::with_notes(markdown, data, notes))
+        Ok(CommandOutput::with_degradation(markdown, data, degradation))
     }
 }
 
@@ -571,14 +583,17 @@ async fn resolve_readme(
     owner: &str,
     repo: &str,
     readme: Result<ContentsResponse, github::GitHubError>,
-    notes: &mut Vec<String>,
+    degradation: &mut Degradation,
 ) -> Option<String> {
     let entry = match readme {
         Ok(r) => Some(r),
         Err(e) => {
             if !matches!(e, github::GitHubError::NotFound(_)) {
                 warn!(%e, "failed to fetch README");
-                notes.push(format!("Could not fetch README ({e})"));
+                degradation.push(
+                    format!("Could not fetch README ({e})"),
+                    DegradedReason::ReadmeFetchFailed,
+                );
             }
             None
         }
@@ -591,7 +606,10 @@ async fn resolve_readme(
             Ok(blob) => Some(blob.content).filter(|c| !c.is_empty()),
             Err(e) => {
                 warn!(%e, "failed to fetch README blob");
-                notes.push(format!("README could not be fetched ({e})"));
+                degradation.push(
+                    format!("README could not be fetched ({e})"),
+                    DegradedReason::ReadmeBlobFetchFailed,
+                );
                 None
             }
         },
@@ -601,7 +619,10 @@ async fn resolve_readme(
         Ok(result) => Some(result.text),
         Err(e) => {
             warn!(%e, "failed to decode README");
-            notes.push(format!("README could not be decoded ({e})"));
+            degradation.push(
+                format!("README could not be decoded ({e})"),
+                DegradedReason::ReadmeDecodeFailed,
+            );
             None
         }
     })

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use tracing::warn;
 
-use crate::envelope::ErrorCode;
+use crate::envelope::{Degradation, DegradedReason, ErrorCode};
 use crate::fetch::FetchError;
 use crate::gemini::client::GeminiError;
 use crate::github;
@@ -284,16 +284,22 @@ impl From<GeminiError> for ScoutError {
     }
 }
 
-pub(super) fn unwrap_or_note<T>(
+/// Unwrap a `Result<Vec<T>, GitHubError>` returning the value on success, or
+/// push a degradation entry (paired `notes` message + typed `reason`) on
+/// failure and return an empty vec. Per ADR-0003, callers supply only the
+/// typed `reason`; the human-readable label is derived from the variant via
+/// [`DegradedReason::label`] so the `(label, reason)` pair stays in sync.
+pub(super) fn unwrap_or_degraded<T>(
     result: Result<Vec<T>, github::GitHubError>,
-    label: &str,
-    notes: &mut Vec<String>,
+    reason: DegradedReason,
+    degradation: &mut Degradation,
 ) -> Vec<T> {
     match result {
         Ok(v) => v,
         Err(e) => {
+            let label = reason.label();
             warn!(%e, "failed to fetch {}", label);
-            notes.push(format!("Could not fetch {label} ({e})"));
+            degradation.push(format!("Could not fetch {label} ({e})"), reason);
             vec![]
         }
     }


### PR DESCRIPTION
## 概要

PR #87 で「本 ADR 後の別 PR で実装」と明記した ADR-0003 残り scope を additive route で実装。`unwrap_or_note` の free-form note を typed reason 付きに refactor し、JSON consumer が partial failure を programmatic 検出できるようにした。

## 主な変更

- `DegradedReason` enum 8 variants (callsite から逆算): `IssuesFetchFailed` / `PullsFetchFailed` / `ReleasesFetchFailed` / `ReadmeFetchFailed` / `ReadmeBlobFetchFailed` / `ReadmeDecodeFailed` / `UrlFetchFailed` / `ReadabilityFallback`
- `Degradation` struct: field を private 化、`push` を sole mutator に、`into_parts` と `notes` accessor を公開して `(notes[i], reasons[i])` invariant を強制
- `DegradedReason::label` で variant から human-readable label を derive、`unwrap_or_degraded` の引数を 4 → 3 に削減
- `SuccessEnvelope.degraded_reasons` を additive で追加 (`skip_serializing_if = "Vec::is_empty"` で空時省略)
- Cargo `1.0.0` → `1.1.0` minor bump (additive)
- ADR-0003 に follow-up Note + README 404 silent の意図明示
- callsite 6 箇所更新 (fetch / research / repo_overview / resolve_readme)

## 設計判断

- Additive vs breaking schema: `notes: Vec<String>` 構造を維持し、`degraded_reasons` を空時省略の field として追加。既存 caller (`notes` の Vec 構造を見る script) は無影響で 2.0.0 ではなく 1.1.0
- `ReadmeMissing` variant 不採用: `resolve_readme` 実装が 404 を silent としており、ADR-0003 当初の `ReadmeMissing` は実体を持たない。README 系は failure mode で 3 variant に分割
- `DegradedReason::label` 設計: variant から label を derive することで caller 側の `(label, reason)` 2 重管理を回避。`unwrap_or_degraded` 経路で使う 3 variant 以外は `"resource"` fallback

## 検証

- `cargo test`: 340 lib + 10 integration = 350 全 pass (新規 T-EN011/012/013 追加)
- `cargo clippy --all-targets`: 0 warnings
- polish skill (simplify + enhancer-code) で 2 finding fix + test 整理済み

## ADR 参照

- `docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md` (本実装の根拠 ADR、本 PR で follow-up Note 追記)

## テスト計画

- [ ] CI: `cargo test --workspace` が全 pass
- [ ] CI: `cargo clippy --all-targets -- -D warnings` が clean
- [ ] `scout repo_overview thkt/scout --json` で `degraded_reasons` が空時省略、partial failure 時に variant 出力