### PR TITLE
workflow を強化して zizmor セキュリティ解析を導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -57,6 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -13,18 +13,20 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Parse bug.yml
         id: parse-bug
-        uses: stefanbuck/github-issue-parser@v3
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
         with:
           template-path: .github/ISSUE_TEMPLATE/bug.yml
         continue-on-error: true
 
       - name: Apply labels for bug
         if: steps.parse-bug.outcome == 'success'
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@9e55064634b67244f7deb4211452b4a7217b93de # v2
         with:
           issue-form: ${{ steps.parse-bug.outputs.jsonString }}
           template: bug.yml
@@ -33,14 +35,14 @@ jobs:
 
       - name: Parse feature.yml
         id: parse-feature
-        uses: stefanbuck/github-issue-parser@v3
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
         with:
           template-path: .github/ISSUE_TEMPLATE/feature.yml
         continue-on-error: true
 
       - name: Apply labels for feature
         if: steps.parse-feature.outcome == 'success'
-        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@9e55064634b67244f7deb4211452b4a7217b93de # v2
         with:
           issue-form: ${{ steps.parse-feature.outputs.jsonString }}
           template: feature.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+rules:
+  artipacked:
+    ignore:
+      # update-homebrew job requires HOMEBREW_TAP_TOKEN to be persisted for git push
+      - release.yml:122
+  cache-poisoning:
+    ignore:
+      # Swatinem/rust-cache in build job; release workflow runs on tag push only,
+      # no PR-driven cache injection path exists for poisoning to reach release artifacts
+      - release.yml:47
+  superfluous-actions:
+    ignore:
+      # softprops/action-gh-release retained for generate_release_notes feature
+      # which gh CLI does not provide equivalently in script step
+      - release.yml:109


### PR DESCRIPTION
## 概要

GitHub Actions の supply-chain incident が頻発する中、scout の workflow 群を zizmor で静的解析した結果 9 件の security findings を検出。修正した上で CI 上で継続検出する基盤を導入する。

## 変更内容

- workflow hardening (`283081e`): SHA pinning 5 箇所、`persist-credentials: false` 4 箇所追加
- zizmor CI workflow (`a9bc93b`): `zizmorcore/zizmor-action@v0.5.3` + Advanced Security 統合
- `.github/zizmor.yml`: 3 件の unactionable findings を justification 付きで ignore

## スコープ

- **含まない**: 23 リポへの一括展開 (本 PR は scout 単体での baseline 構築のみ)

## 設計判断

- 独立 workflow \`.github/workflows/zizmor.yml\` を採用 (ci.yml 統合より関心の分離、SARIF/Code Scanning 用 permissions が独立)
- Advanced Security 統合モード採用 (public repo 無料、Code Scanning UI で stateful triage 可)
- \`.github/zizmor.yml\` での集中 ignore (inline comment より justification の追跡性が高い)

## 動作確認

1. PR 上で \`zizmor\` workflow が初回 run、\`No findings to report\` を確認
2. Security tab > Code scanning で zizmor findings が空であることを確認
3. ローカルで \`zizmor .github/workflows/\` を実行し同じ結果

## 関連

- 後続: 残り 22 リポへの zizmor 展開 (別 Issue 起票予定)