### PR TITLE
ci(actions): workflow hardening と label workflow 整備

### DIFF
--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -7,11 +7,13 @@ on:
       - edited
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ["**"]
+    branches: [main]
 
 permissions: {}
 


### PR DESCRIPTION
## 概要

- workflow hardening (zizmor findings 対応): `persist-credentials: false` 等
- zizmor-action 導入 (security analysis workflow)
- label workflow 整備: `contents: read` + `timeout-minutes: 5` 追加、zizmor.yml の PR branches narrow

3 リポ (scout / rurico / guardrails) の zizmor / workflow golden master に追従。

Closes #90

## テスト計画

- [x] `zizmor .github/workflows/` で `No findings to report`
- [ ] CI green