### PR TITLE
feat(errors): ADR-0065 9種類exit-code政策を採用

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "chardetng 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scout"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 rust-version = "1.95"
 description = "CLI tool for web search (Gemini Grounding), page fetching, and GitHub repository exploration"

--- a/README.md
+++ b/README.md
@@ -239,16 +239,18 @@ Single binary, zero runtime dependencies.
 
 ## Exit codes
 
-Following [`sysexits.h`](https://man.openbsd.org/sysexits) conventions:
+Following [`sysexits.h`](https://man.openbsd.org/sysexits) conventions, with a PJ extension code for unclassifiable failures:
 
 | Code | Meaning                                                             |
 | ---- | ------------------------------------------------------------------- |
 | 0    | Success                                                             |
 | 64   | Usage error (clap parse, missing API key, conflicts_with violation) |
-| 65   | Data error (invalid input, malformed format, encoding error)        |
+| 65   | Data error (invalid input, malformed format, encoding error, 4xx body) |
 | 66   | Not found (repo/file not found, 404)                                |
-| 74   | IO error (network IO, write failure other than BrokenPipe)          |
+| 70   | Internal (scout-side invariant violation, unexpected response schema) |
+| 74   | IO error (external tool failure such as headless browser)           |
 | 75   | Temporary failure (rate limit, 5xx, retryable)                      |
+| 104  | Unknown (unclassifiable failure; rising rate signals classification gap) |
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ Following [`sysexits.h`](https://man.openbsd.org/sysexits) conventions, with a P
 | 66   | Not found (repo/file not found, 404)                                |
 | 70   | Internal (scout-side invariant violation, unexpected response schema) |
 | 74   | IO error (external tool failure such as headless browser)           |
-| 75   | Temporary failure (rate limit, 5xx, retryable)                      |
+| 75   | Temporary failure (rate limit, 5xx, retryable — short backoff)      |
+| 124  | Timeout (request/transport timeout, retryable — longer backoff advised) |
 | 104  | Unknown (unclassifiable failure; rising rate signals classification gap) |
 
 ## Limitations

--- a/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
+++ b/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
@@ -99,6 +99,7 @@ Chosen option: Option A, because public CLI contract として一貫した class
 * 各 `ErrorCode` バリアントの construction site で本 ADR の mapping table を参照
 * `unwrap_or_note` は `unwrap_or_degraded` (仮称) に rename し、`Result<T, DegradedReason>` を返す形に refactor
 * `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (4-6 variant 程度を想定)
+* ADR-0065 §Classification Priority の 5 段ルール (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN 退避) を各 `From<...>` 実装の match arm 順序と `// Priority N` コメントで明示する。`*Error::Api { code }` の 4xx は priority 2 (DataError) に集約し、`internal()` への fold off は priority 5 (scout-side invariant violation) と Unknown 退避にのみ使用する
 
 ### Reassessment Triggers
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -117,28 +117,38 @@ impl CommandOutput {
     }
 }
 
-/// JSON-serializable error classification per ADR-0065.
+/// JSON-serializable error classification per ADR-0065 (9-code policy).
+///
+/// `Internal` is reserved for scout-side invariant violations (e.g. unexpected
+/// API schema during deserialize). `Unknown` is the explicit escape hatch for
+/// inputs that no priority rule classified; a rising rate of `Unknown` signals
+/// the classification design needs revisiting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
     UsageError,
     DataError,
     NotFound,
+    Internal,
     IoError,
     TempFailure,
+    Unknown,
 }
 
 impl ErrorCode {
     /// sysexits.h exit code mapped 1:1 from `error.code`. Exit-code values are
     /// governed by ADR-0002 (scout-local). The `error.code` JSON tag itself is
     /// governed by ADR-0065 (dotclaude) until a scout-local ADR captures it.
+    /// `Unknown` (104) is the PJ extension reserved for unclassifiable failures.
     pub(crate) fn exit_code(self) -> u8 {
         match self {
             Self::UsageError => 64,  // EX_USAGE
             Self::DataError => 65,   // EX_DATAERR
             Self::NotFound => 66,    // EX_NOINPUT
+            Self::Internal => 70,    // EX_SOFTWARE (scout-side invariant)
             Self::IoError => 74,     // EX_IOERR
             Self::TempFailure => 75, // EX_TEMPFAIL
+            Self::Unknown => 104,    // PJ extension, ADR-0065 §Classification Priority
         }
     }
 }
@@ -341,8 +351,10 @@ mod tests {
             (ErrorCode::UsageError, r#""USAGE_ERROR""#),
             (ErrorCode::DataError, r#""DATA_ERROR""#),
             (ErrorCode::NotFound, r#""NOT_FOUND""#),
+            (ErrorCode::Internal, r#""INTERNAL""#),
             (ErrorCode::IoError, r#""IO_ERROR""#),
             (ErrorCode::TempFailure, r#""TEMP_FAILURE""#),
+            (ErrorCode::Unknown, r#""UNKNOWN""#),
         ];
         for (code, expected) in pairs {
             let actual = serde_json::to_string(&code).unwrap();
@@ -351,6 +363,18 @@ mod tests {
                 "code {code:?} should serialize as {expected}"
             );
         }
+    }
+
+    /// [T-EN014] ErrorCode::Internal maps to exit 70 (EX_SOFTWARE) per ADR-0065
+    #[test]
+    fn error_code_internal_exits_70() {
+        assert_eq!(ErrorCode::Internal.exit_code(), 70);
+    }
+
+    /// [T-EN015] ErrorCode::Unknown maps to exit 104 (PJ extension) per ADR-0065
+    #[test]
+    fn error_code_unknown_exits_104() {
+        assert_eq!(ErrorCode::Unknown.exit_code(), 104);
     }
 
     /// [T-EN011] DegradedReason serializes per ADR-0003 SCREAMING_SNAKE_CASE

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -120,9 +120,11 @@ impl CommandOutput {
 /// JSON-serializable error classification per ADR-0065 (9-code policy).
 ///
 /// `Internal` is reserved for scout-side invariant violations (e.g. unexpected
-/// API schema during deserialize). `Unknown` is the explicit escape hatch for
-/// inputs that no priority rule classified; a rising rate of `Unknown` signals
-/// the classification design needs revisiting.
+/// API schema during deserialize). `Timeout` splits from `TempFailure` so
+/// callers can apply a longer retry backoff than for rate limits / 5xx.
+/// `Unknown` is the explicit escape hatch for inputs that no priority rule
+/// classified; a rising rate of `Unknown` signals the classification design
+/// needs revisiting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum ErrorCode {
@@ -132,6 +134,7 @@ pub(crate) enum ErrorCode {
     Internal,
     IoError,
     TempFailure,
+    Timeout,
     Unknown,
 }
 
@@ -139,7 +142,8 @@ impl ErrorCode {
     /// sysexits.h exit code mapped 1:1 from `error.code`. Exit-code values are
     /// governed by ADR-0002 (scout-local). The `error.code` JSON tag itself is
     /// governed by ADR-0065 (dotclaude) until a scout-local ADR captures it.
-    /// `Unknown` (104) is the PJ extension reserved for unclassifiable failures.
+    /// `Timeout` (124) follows GNU coreutils `timeout` and `Unknown` (104) is
+    /// the PJ extension for unclassifiable failures.
     pub(crate) fn exit_code(self) -> u8 {
         match self {
             Self::UsageError => 64,  // EX_USAGE
@@ -148,6 +152,7 @@ impl ErrorCode {
             Self::Internal => 70,    // EX_SOFTWARE (scout-side invariant)
             Self::IoError => 74,     // EX_IOERR
             Self::TempFailure => 75, // EX_TEMPFAIL
+            Self::Timeout => 124,    // GNU coreutils `timeout` convention
             Self::Unknown => 104,    // PJ extension, ADR-0065 §Classification Priority
         }
     }
@@ -354,6 +359,7 @@ mod tests {
             (ErrorCode::Internal, r#""INTERNAL""#),
             (ErrorCode::IoError, r#""IO_ERROR""#),
             (ErrorCode::TempFailure, r#""TEMP_FAILURE""#),
+            (ErrorCode::Timeout, r#""TIMEOUT""#),
             (ErrorCode::Unknown, r#""UNKNOWN""#),
         ];
         for (code, expected) in pairs {
@@ -375,6 +381,14 @@ mod tests {
     #[test]
     fn error_code_unknown_exits_104() {
         assert_eq!(ErrorCode::Unknown.exit_code(), 104);
+    }
+
+    /// [T-EN016] ErrorCode::Timeout maps to exit 124 (GNU coreutils `timeout`)
+    /// per ADR-0065. Independent from TempFailure(75) so callers can apply a
+    /// longer retry backoff than for rate limits / 5xx.
+    #[test]
+    fn error_code_timeout_exits_124() {
+        assert_eq!(ErrorCode::Timeout.exit_code(), 124);
     }
 
     /// [T-EN011] DegradedReason serializes per ADR-0003 SCREAMING_SNAKE_CASE

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -156,6 +156,13 @@ impl ErrorCode {
             Self::Unknown => 104,    // PJ extension, ADR-0065 §Classification Priority
         }
     }
+
+    /// Whether this classification recommends retry. Determined structurally
+    /// from `kind` so `ScoutError` cannot drift out of sync with the JSON
+    /// `error.retryable` contract.
+    pub(crate) fn is_retryable(self) -> bool {
+        matches!(self, Self::TempFailure | Self::Timeout)
+    }
 }
 
 /// Success envelope wrapping command output per ADR-0065. ADR-0003 added
@@ -371,24 +378,28 @@ mod tests {
         }
     }
 
-    /// [T-EN014] ErrorCode::Internal maps to exit 70 (EX_SOFTWARE) per ADR-0065
+    /// [T-EN014] ErrorCode → exit-code mapping per ADR-0065 9-code policy.
+    /// Locks the full table so adding a new variant without an `exit_code()`
+    /// arm fails compile, and drift on any existing variant fails this test.
     #[test]
-    fn error_code_internal_exits_70() {
-        assert_eq!(ErrorCode::Internal.exit_code(), 70);
-    }
-
-    /// [T-EN015] ErrorCode::Unknown maps to exit 104 (PJ extension) per ADR-0065
-    #[test]
-    fn error_code_unknown_exits_104() {
-        assert_eq!(ErrorCode::Unknown.exit_code(), 104);
-    }
-
-    /// [T-EN016] ErrorCode::Timeout maps to exit 124 (GNU coreutils `timeout`)
-    /// per ADR-0065. Independent from TempFailure(75) so callers can apply a
-    /// longer retry backoff than for rate limits / 5xx.
-    #[test]
-    fn error_code_timeout_exits_124() {
-        assert_eq!(ErrorCode::Timeout.exit_code(), 124);
+    fn error_code_exit_code_table() {
+        let pairs = [
+            (ErrorCode::UsageError, 64),
+            (ErrorCode::DataError, 65),
+            (ErrorCode::NotFound, 66),
+            (ErrorCode::Internal, 70),
+            (ErrorCode::IoError, 74),
+            (ErrorCode::TempFailure, 75),
+            (ErrorCode::Unknown, 104),
+            (ErrorCode::Timeout, 124),
+        ];
+        for (code, expected) in pairs {
+            assert_eq!(
+                code.exit_code(),
+                expected,
+                "{code:?} should exit {expected}"
+            );
+        }
     }
 
     /// [T-EN011] DegradedReason serializes per ADR-0003 SCREAMING_SNAKE_CASE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,15 @@ fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
     version,
     about = "Web search, page fetching, and GitHub repository exploration",
     after_help = "\
-Exit codes (sysexits.h):
-  0   Success
-  64  Usage error (clap parse, missing API key, conflicts_with violation)
-  65  Data error (invalid input, malformed format, encoding error)
-  66  Not found (repo/file not found, 404)
-  74  IO error (network IO, write failure other than BrokenPipe)
-  75  Temporary failure (rate limit, 5xx, retryable)
+Exit codes (sysexits.h + GNU coreutils + PJ extension):
+  0    Success
+  64   Usage error (clap parse, missing API key, conflicts_with violation)
+  65   Data error (invalid input, malformed format, encoding error, 4xx body)
+  66   Not found (repo/file not found, 404)
+  70   Internal (scout-side invariant violation, unexpected response schema)
+  74   IO error (external tool failure such as headless browser)
+  75   Temporary failure (rate limit, 5xx, retryable)
+  104  Unknown (unclassifiable failure; rising rate signals classification gap)
 
 Environment:
   GEMINI_API_KEY  Required for search and research commands
@@ -238,10 +240,10 @@ mod tests {
             help.contains("GITHUB_TOKEN"),
             "root help missing GITHUB_TOKEN"
         );
-        for code in ["64", "65", "66", "74", "75"] {
+        for code in ["64", "65", "66", "70", "74", "75", "104"] {
             assert!(
                 help.contains(code),
-                "root help should document sysexits code {code}"
+                "root help should document sysexits/PJ code {code}"
             );
         }
         assert!(
@@ -251,6 +253,14 @@ mod tests {
         assert!(
             help.contains("Temporary failure"),
             "root help missing EX_TEMPFAIL description"
+        );
+        assert!(
+            help.contains("Internal"),
+            "root help missing EX_SOFTWARE (70) description"
+        );
+        assert!(
+            help.contains("Unknown"),
+            "root help missing PJ extension (104) description"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@ Exit codes (sysexits.h + GNU coreutils + PJ extension):
   66   Not found (repo/file not found, 404)
   70   Internal (scout-side invariant violation, unexpected response schema)
   74   IO error (external tool failure such as headless browser)
-  75   Temporary failure (rate limit, 5xx, retryable)
+  75   Temporary failure (rate limit, 5xx, retryable — short backoff)
+  124  Timeout (request/transport timeout, retryable — longer backoff advised)
   104  Unknown (unclassifiable failure; rising rate signals classification gap)
 
 Environment:
@@ -240,10 +241,10 @@ mod tests {
             help.contains("GITHUB_TOKEN"),
             "root help missing GITHUB_TOKEN"
         );
-        for code in ["64", "65", "66", "70", "74", "75", "104"] {
+        for code in ["64", "65", "66", "70", "74", "75", "104", "124"] {
             assert!(
                 help.contains(code),
-                "root help should document sysexits/PJ code {code}"
+                "root help should document sysexits/PJ/GNU code {code}"
             );
         }
         assert!(
@@ -257,6 +258,10 @@ mod tests {
         assert!(
             help.contains("Internal"),
             "root help missing EX_SOFTWARE (70) description"
+        );
+        assert!(
+            help.contains("Timeout"),
+            "root help missing GNU timeout (124) description"
         );
         assert!(
             help.contains("Unknown"),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -143,13 +143,13 @@ impl Scout {
             .timeout(HTTP_TIMEOUT)
             .redirect(Policy::limited(MAX_REDIRECTS))
             .build()
-            .map_err(|e| ScoutError::internal(format!("HTTP client init failed: {e}")))?;
+            .map_err(|e| ScoutError::io_error(format!("HTTP client init failed: {e}")))?;
         let fetch_http = Client::builder()
             .connect_timeout(CONNECT_TIMEOUT)
             .timeout(HTTP_TIMEOUT)
             .redirect(Policy::none())
             .build()
-            .map_err(|e| ScoutError::internal(format!("HTTP client init failed: {e}")))?;
+            .map_err(|e| ScoutError::io_error(format!("HTTP client init failed: {e}")))?;
         let gemini = GeminiClient::from_env(http.clone())
             .inspect_err(|e| warn!("Gemini client not available: {e}"))
             .ok();

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -96,6 +96,20 @@ impl ScoutError {
         }
     }
 
+    /// Timeout (request-level or transport-level). Maps to `ErrorCode::Timeout`
+    /// (exit 124, GNU coreutils `timeout`) per ADR-0065. Retryable like
+    /// `transient`, but separated so caller scripts/agents can apply a longer
+    /// backoff than for rate-limit / 5xx temp failures.
+    pub(super) fn timeout(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            retryable: true,
+            kind: ErrorCode::Timeout,
+            next_step: None,
+            candidates: Vec::new(),
+        }
+    }
+
     pub(super) fn not_found(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
@@ -260,10 +274,11 @@ impl From<FetchError> for ScoutError {
             FetchError::Status(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY) // Priority 4 (5xx, ...)
             }
-            // Priority 4: TEMP_FAILURE (non-Status variants)
+            // Priority 4: TIMEOUT (transport timeout — long-backoff retry advised)
             FetchError::Timeout(_) => {
-                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+                Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
+            // Priority 4: TEMP_FAILURE (non-Status variants)
             FetchError::DnsResolution(_) => Self::transient(e.to_string())
                 .with_next_step("Check the URL's domain name and your DNS resolver"),
             FetchError::Http(re) if is_transient_network(re) => {
@@ -304,9 +319,8 @@ impl From<SlackError> for ScoutError {
             SlackError::Network(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }
-            SlackError::Timeout(_) => {
-                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
-            }
+            // Priority 4: TIMEOUT
+            SlackError::Timeout(_) => Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY),
             // Priority 5: INTERNAL — scout-side bug (unexpected schema)
             SlackError::Decode(_) => Self::internal_bug(e.to_string()),
         }
@@ -724,7 +738,8 @@ mod tests {
         }
     }
 
-    /// [T-ER003] TempFailure errors are retryable, display retry hint, exit 75 (EX_TEMPFAIL)
+    /// [T-ER003] TempFailure errors are retryable, display retry hint, exit 75 (EX_TEMPFAIL).
+    /// Timeout cases moved to T-ER027 with exit 124 per ADR-0065.
     #[test]
     fn temp_failure_errors_have_exit_code_75() {
         let cases: Vec<ScoutError> = vec![
@@ -733,7 +748,6 @@ mod tests {
             FetchError::Status(500).into(),
             FetchError::Status(503).into(),
             FetchError::DnsResolution("dns failed".into()).into(),
-            FetchError::Timeout("timed out".into()).into(),
             github::GitHubError::RateLimited { retry_after: None }.into(),
             github::GitHubError::Api {
                 code: 502,
@@ -748,12 +762,32 @@ mod tests {
             .into(),
             SlackError::RateLimited { retry_after: None }.into(),
             SlackError::Network("err".into()).into(),
-            SlackError::Timeout("err".into()).into(),
         ];
         for err in &cases {
             assert_eq!(err.error_kind(), ErrorCode::TempFailure, "{err}");
             assert!(err.retryable(), "expected retryable: {err}");
             assert_eq!(err.exit_code(), 75, "expected EX_TEMPFAIL (75): {err}");
+            assert!(
+                err.to_string().contains("retry may succeed"),
+                "should include retry hint: {err}"
+            );
+        }
+    }
+
+    /// [T-ER027] Timeout errors are retryable, surface exit 124 (GNU coreutils
+    /// `timeout`) independent from TempFailure(75). The split lets caller
+    /// scripts apply a longer retry backoff than for rate-limit / 5xx since
+    /// timeouts imply an unknown counterparty load condition.
+    #[test]
+    fn timeout_errors_have_exit_code_124() {
+        let cases: Vec<ScoutError> = vec![
+            FetchError::Timeout("timed out".into()).into(),
+            SlackError::Timeout("timed out".into()).into(),
+        ];
+        for err in &cases {
+            assert_eq!(err.error_kind(), ErrorCode::Timeout, "{err}");
+            assert!(err.retryable(), "Timeout must be retryable: {err}");
+            assert_eq!(err.exit_code(), 124, "expected 124 (GNU timeout): {err}");
             assert!(
                 err.to_string().contains("retry may succeed"),
                 "should include retry hint: {err}"

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -58,6 +58,34 @@ impl ScoutError {
         }
     }
 
+    /// scout-side invariant violation (e.g., unexpected API schema during
+    /// deserialize). Maps to `ErrorCode::Internal` (exit 70 EX_SOFTWARE) per
+    /// ADR-0065 priority 5. Distinct from [`Self::internal`] which folds onto
+    /// IoError(74) for external tool failures (browser, IO).
+    pub(super) fn internal_bug(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            retryable: false,
+            kind: ErrorCode::Internal,
+            next_step: None,
+            candidates: Vec::new(),
+        }
+    }
+
+    /// Unclassifiable failure — the priority rules (1-5) did not match.
+    /// Maps to `ErrorCode::Unknown` (exit 104, PJ extension) per ADR-0065
+    /// §Classification Priority. A rising Unknown rate signals the
+    /// classification design needs revisiting.
+    pub(super) fn unknown(msg: impl Into<String>) -> Self {
+        Self {
+            message: msg.into(),
+            retryable: false,
+            kind: ErrorCode::Unknown,
+            next_step: None,
+            candidates: Vec::new(),
+        }
+    }
+
     pub(super) fn transient(msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
@@ -190,10 +218,10 @@ impl From<github::GitHubError> for ScoutError {
             github::GitHubError::Api { code, .. } if (500..=599).contains(code) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
-            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
-            github::GitHubError::Api { .. } | github::GitHubError::Decode(_) => {
-                Self::internal(e.to_string())
-            }
+            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
+            github::GitHubError::Decode(_) => Self::internal_bug(e.to_string()),
+            // Unknown — Api codes that did not match 4xx or 5xx (e.g., 1xx/3xx leak)
+            github::GitHubError::Api { .. } => Self::unknown(e.to_string()),
         }
     }
 }
@@ -241,9 +269,10 @@ impl From<FetchError> for ScoutError {
             FetchError::Http(re) if is_transient_network(re) => {
                 Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }
-            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
+            // IO_ERROR — external tool failure (browser) outside scout's invariants
             FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
-            FetchError::Http(_) => Self::internal(e.to_string()),
+            // Unknown — reqwest errors that do not match transient network patterns
+            FetchError::Http(_) => Self::unknown(e.to_string()),
         }
     }
 }
@@ -278,8 +307,8 @@ impl From<SlackError> for ScoutError {
             SlackError::Timeout(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
-            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
-            SlackError::Decode(_) => Self::internal(e.to_string()),
+            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
+            SlackError::Decode(_) => Self::internal_bug(e.to_string()),
         }
     }
 }
@@ -309,8 +338,8 @@ impl From<GeminiError> for ScoutError {
             GeminiError::Api { code, .. } if (500..=599).contains(code) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
-            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
-            GeminiError::Api { .. } => Self::internal(e.to_string()),
+            // Unknown — Api codes that did not match 4xx or 5xx (e.g., 1xx/3xx leak)
+            GeminiError::Api { .. } => Self::unknown(e.to_string()),
         }
     }
 }
@@ -566,6 +595,48 @@ mod tests {
         }
     }
 
+    /// [T-ER025] INTERNAL (70) reserved for scout-side schema bugs.
+    /// `Decode` variants from GitHub and Slack APIs indicate an unexpected
+    /// response shape — by ADR-0065 priority 5 these are scout's invariant
+    /// violation, not external IO failure (which maps to IoError 74).
+    #[test]
+    fn schema_decode_classifies_as_internal_exit_70() {
+        let cases: Vec<ScoutError> = vec![
+            github::GitHubError::Decode("decode error".into()).into(),
+            SlackError::Decode("err".into()).into(),
+        ];
+        for err in &cases {
+            assert_eq!(err.error_kind(), ErrorCode::Internal, "{err}");
+            assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70): {err}");
+            assert!(!err.retryable(), "Internal must not be retryable: {err}");
+        }
+    }
+
+    /// [T-ER026] UNKNOWN (104) is the escape hatch for Api codes that match
+    /// neither 4xx (priority 2) nor 5xx (priority 4). Exit 104 is the PJ
+    /// extension reserved by ADR-0065 §Classification Priority. A rising rate
+    /// of Unknown signals the classification design needs revisiting.
+    #[test]
+    fn unclassified_api_classifies_as_unknown_exit_104() {
+        let cases: Vec<ScoutError> = vec![
+            github::GitHubError::Api {
+                code: 304,
+                message: "not modified".into(),
+            }
+            .into(),
+            GeminiError::Api {
+                code: 304,
+                message: "not modified".into(),
+            }
+            .into(),
+        ];
+        for err in &cases {
+            assert_eq!(err.error_kind(), ErrorCode::Unknown, "{err}");
+            assert_eq!(err.exit_code(), 104, "expected PJ extension (104): {err}");
+            assert!(!err.retryable(), "Unknown must not be retryable: {err}");
+        }
+    }
+
     /// [T-ER001a] UsageError errors surface with exit 64 (EX_USAGE per ADR-0002)
     #[test]
     fn usage_errors_have_exit_code_64() {
@@ -639,16 +710,13 @@ mod tests {
     }
 
     /// [T-ER002] IoError errors surface with exit 74 (EX_IOERR) and are non-retryable.
-    /// Covers the remaining `internal()` callsites that fold onto IoError until #84
-    /// promotes scout-side bugs to `Internal(70)` and unclassified Api codes to
-    /// `Unknown(104)`.
+    /// Reserved for external-tool IO failures (browser); scout-side schema bugs
+    /// route to `Internal(70)` (T-ER025) and unclassifiable Api codes to
+    /// `Unknown(104)` (T-ER026).
     #[test]
     fn io_errors_have_exit_code_74() {
-        let cases: Vec<ScoutError> = vec![
-            github::GitHubError::Decode("decode error".into()).into(),
-            FetchError::BrowserFailed("CDP protocol error".into()).into(),
-            SlackError::Decode("err".into()).into(),
-        ];
+        let cases: Vec<ScoutError> =
+            vec![FetchError::BrowserFailed("CDP protocol error".into()).into()];
         for err in &cases {
             assert_eq!(err.error_kind(), ErrorCode::IoError, "{err}");
             assert_eq!(err.exit_code(), 74, "expected EX_IOERR (74): {err}");

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -135,12 +135,23 @@ pub(super) fn parse_repo_param(repository: &str) -> Result<(&str, &str), ScoutEr
     github::parse_repo(repository).map_err(ScoutError::from)
 }
 
+// Match arms in each `From<...>` impl below evaluate in classification-priority
+// order per ADR-0065 §Classification Priority:
+//   1. USAGE_ERROR  — env/config/argument misuse
+//   2. DATA_ERROR   — format violations (URL, owner/repo, encoding, 4xx body)
+//   3. NOT_FOUND    — resource absence (404, search 0 hits)
+//   4. TEMP_FAILURE — retryable (rate limit, 5xx, network)
+//   5. INTERNAL     — scout-side invariant violation (folded onto IoError(74)
+//                     until ADR-0065 INTERNAL(70) variant lands)
+// Disjoint variants are otherwise free to be reordered; the priority comments
+// document intent so a reviewer can spot a misclassification mechanically.
 impl From<github::GitHubError> for ScoutError {
     fn from(e: github::GitHubError) -> Self {
         match &e {
-            github::GitHubError::NotFound(_) => Self::not_found(e.to_string()).with_next_step(
-                "Check that the repository or path exists, and that you have access",
-            ),
+            // Priority 1: USAGE_ERROR
+            github::GitHubError::Forbidden(_) => Self::user_error(e.to_string())
+                .with_next_step("Check that your GITHUB_TOKEN has the required scopes"),
+            // Priority 2: DATA_ERROR
             github::GitHubError::InvalidRepo(_) => Self::data_error(e.to_string())
                 .with_next_step("Use 'owner/repo' format, e.g., 'facebook/react'"),
             github::GitHubError::InvalidRef(_) => Self::data_error(e.to_string())
@@ -158,6 +169,14 @@ impl From<github::GitHubError> for ScoutError {
                 ),
             github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string())
                 .with_next_step("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
+            github::GitHubError::Api { code, .. } if (400..500).contains(code) => {
+                Self::data_error(e.to_string())
+            }
+            // Priority 3: NOT_FOUND
+            github::GitHubError::NotFound(_) => Self::not_found(e.to_string()).with_next_step(
+                "Check that the repository or path exists, and that you have access",
+            ),
+            // Priority 4: TEMP_FAILURE
             github::GitHubError::RateLimited { retry_after } => Self::transient(e.to_string())
                 .with_next_step(match retry_after {
                     Some(secs) => format!(
@@ -165,14 +184,13 @@ impl From<github::GitHubError> for ScoutError {
                     ),
                     None => "Set GITHUB_TOKEN to increase rate limit".to_owned(),
                 }),
-            github::GitHubError::Forbidden(_) => Self::user_error(e.to_string())
-                .with_next_step("Check that your GITHUB_TOKEN has the required scopes"),
             github::GitHubError::Network(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }
             github::GitHubError::Api { code, .. } if (500..=599).contains(code) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
+            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
             github::GitHubError::Api { .. } | github::GitHubError::Decode(_) => {
                 Self::internal(e.to_string())
             }
@@ -183,6 +201,9 @@ impl From<github::GitHubError> for ScoutError {
 impl From<FetchError> for ScoutError {
     fn from(e: FetchError) -> Self {
         match &e {
+            // Priority 1: USAGE_ERROR
+            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
+            // Priority 2: DATA_ERROR (non-Status variants)
             FetchError::InvalidScheme => {
                 Self::data_error(e.to_string()).with_next_step("URL must use http:// or https://")
             }
@@ -194,34 +215,35 @@ impl From<FetchError> for ScoutError {
             FetchError::UnsupportedContentType(_) => Self::data_error(e.to_string())
                 .with_next_step("URL must serve HTML or text content"),
             FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
-            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
-            FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
-            FetchError::Status(408 | 429) => {
-                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
-            }
-            FetchError::Status(404) => Self::not_found(e.to_string())
-                .with_next_step("Check that the URL is correct and the resource exists"),
-            FetchError::Status(401 | 403) => Self::user_error(e.to_string())
-                .with_next_step("URL requires authentication that scout does not support"),
-            FetchError::Status(code) if (400..500).contains(code) => {
-                Self::data_error(e.to_string())
-            }
             FetchError::TooLarge => Self::data_error(e.to_string())
                 .with_next_step("URL response exceeds 10MB; fetch a smaller resource"),
             FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
                 .with_next_step("URL has too many redirects; check for a redirect loop"),
-            FetchError::Status(_) | FetchError::Timeout(_) => {
+            // Status arms: specific HTTP code first, then 4xx/_ fallback. Priority noted per arm.
+            FetchError::Status(401 | 403) => Self::user_error(e.to_string()) // Priority 1
+                .with_next_step("URL requires authentication that scout does not support"),
+            FetchError::Status(404) => Self::not_found(e.to_string()) // Priority 3
+                .with_next_step("Check that the URL is correct and the resource exists"),
+            FetchError::Status(408 | 429) => Self::transient(e.to_string()) // Priority 4
+                .with_next_step(HINT_RETRY_DELAY),
+            FetchError::Status(code) if (400..500).contains(code) => {
+                Self::data_error(e.to_string()) // Priority 2
+            }
+            FetchError::Status(_) => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY) // Priority 4 (5xx, ...)
+            }
+            // Priority 4: TEMP_FAILURE (non-Status variants)
+            FetchError::Timeout(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             FetchError::DnsResolution(_) => Self::transient(e.to_string())
                 .with_next_step("Check the URL's domain name and your DNS resolver"),
-            FetchError::Http(re) => {
-                if is_transient_network(re) {
-                    Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
-                } else {
-                    Self::internal(e.to_string())
-                }
+            FetchError::Http(re) if is_transient_network(re) => {
+                Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }
+            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
+            FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
+            FetchError::Http(_) => Self::internal(e.to_string()),
         }
     }
 }
@@ -229,23 +251,24 @@ impl From<FetchError> for ScoutError {
 impl From<SlackError> for ScoutError {
     fn from(e: SlackError) -> Self {
         match &e {
+            // Priority 1: USAGE_ERROR
             SlackError::TokenNotSet => Self::user_error(e.to_string())
                 .with_next_step("Export a User OAuth token to SLACK_TOKEN (xoxp-…)"),
-            SlackError::Api { error } => {
-                // ADR-0003: Slack API uses error code strings (not HTTP status)
-                // for API-level failures. Classify by the canonical `error` field
-                // so transient/not-found cases get the correct exit code instead
-                // of a uniform user_error (exit 64).
-                match error.as_str() {
-                    "internal_error" | "service_unavailable" | "fatal_error" => {
-                        Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
-                    }
-                    "channel_not_found" | "message_not_found" | "thread_not_found" => {
-                        Self::not_found(e.to_string())
-                    }
-                    _ => Self::user_error(e.to_string()),
+            // Slack API surfaces failures as error code strings (not HTTP status),
+            // so per-string classification replaces the priority-2 HTTP arm.
+            SlackError::Api { error } => match error.as_str() {
+                // Priority 3: NOT_FOUND
+                "channel_not_found" | "message_not_found" | "thread_not_found" => {
+                    Self::not_found(e.to_string())
                 }
-            }
+                // Priority 4: TEMP_FAILURE
+                "internal_error" | "service_unavailable" | "fatal_error" => {
+                    Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+                }
+                // Priority 1: USAGE_ERROR (invalid_auth, missing_scope, etc.)
+                _ => Self::user_error(e.to_string()),
+            },
+            // Priority 4: TEMP_FAILURE
             SlackError::RateLimited { .. } => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
@@ -255,6 +278,7 @@ impl From<SlackError> for ScoutError {
             SlackError::Timeout(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
+            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
             SlackError::Decode(_) => Self::internal(e.to_string()),
         }
     }
@@ -263,22 +287,29 @@ impl From<SlackError> for ScoutError {
 impl From<GeminiError> for ScoutError {
     fn from(e: GeminiError) -> Self {
         match &e {
+            // Priority 1: USAGE_ERROR
             GeminiError::ApiKeyNotSet => Self::user_error(e.to_string())
                 .with_next_step("Set GEMINI_API_KEY environment variable"),
-            GeminiError::RateLimited { .. } => {
-                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
-            }
             GeminiError::QuotaExhausted(_) => Self::user_error(e.to_string())
                 .with_next_step("Check your API billing at https://aistudio.google.com"),
             GeminiError::PermissionDenied(_) => Self::user_error(e.to_string()).with_next_step(
                 "Check IAM permissions for the Gemini API in your Google Cloud project",
             ),
+            // Priority 2: DATA_ERROR (4xx body)
+            GeminiError::Api { code, .. } if (400..500).contains(code) => {
+                Self::data_error(e.to_string())
+            }
+            // Priority 4: TEMP_FAILURE
+            GeminiError::RateLimited { .. } => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+            }
             GeminiError::Network(_) => {
                 Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }
             GeminiError::Api { code, .. } if (500..=599).contains(code) => {
                 Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
+            // Priority 5: INTERNAL (folded onto IoError until #84 lands)
             GeminiError::Api { .. } => Self::internal(e.to_string()),
         }
     }
@@ -490,6 +521,51 @@ mod tests {
         assert_eq!(err.error_kind(), ErrorCode::UsageError);
     }
 
+    /// [T-ER023] ADR-0065 priority 2 wins over priority 5 for Api 4xx codes.
+    /// Prior to the priority rule reflection, `GitHubError::Api { code: 4xx }` and
+    /// `GeminiError::Api { code: 4xx }` folded onto `internal()` (IoError, exit 74).
+    /// Per ADR-0065 they must classify as DataError (exit 65).
+    #[test]
+    fn api_4xx_classifies_as_data_error_per_priority_2() {
+        let github_400 = ScoutError::from(github::GitHubError::Api {
+            code: 400,
+            message: "bad request".into(),
+        });
+        let github_422 = ScoutError::from(github::GitHubError::Api {
+            code: 422,
+            message: "unprocessable entity".into(),
+        });
+        let gemini_400 = ScoutError::from(GeminiError::Api {
+            code: 400,
+            message: "err".into(),
+        });
+        for err in [&github_400, &github_422, &gemini_400] {
+            assert_eq!(err.error_kind(), ErrorCode::DataError, "{err}");
+            assert_eq!(err.exit_code(), 65, "{err}");
+            assert!(!err.retryable(), "4xx must not be retryable: {err}");
+        }
+    }
+
+    /// [T-ER024] ADR-0065 priority 4 (TEMP_FAILURE) takes precedence for `Api { 5xx }`
+    /// even though priority 5 (INTERNAL) could match the bare `Api { .. }` arm.
+    /// Match-arm ordering enforces the priority ranking.
+    #[test]
+    fn api_5xx_classifies_as_temp_failure_per_priority_4() {
+        let github_502 = ScoutError::from(github::GitHubError::Api {
+            code: 502,
+            message: "bad gateway".into(),
+        });
+        let gemini_503 = ScoutError::from(GeminiError::Api {
+            code: 503,
+            message: "unavailable".into(),
+        });
+        for err in [&github_502, &gemini_503] {
+            assert_eq!(err.error_kind(), ErrorCode::TempFailure, "{err}");
+            assert_eq!(err.exit_code(), 75, "{err}");
+            assert!(err.retryable(), "5xx must be retryable: {err}");
+        }
+    }
+
     /// [T-ER001a] UsageError errors surface with exit 64 (EX_USAGE per ADR-0002)
     #[test]
     fn usage_errors_have_exit_code_64() {
@@ -512,11 +588,23 @@ mod tests {
         }
     }
 
-    /// [T-ER001b] DataError errors surface with exit 65 (EX_DATAERR per ADR-0002)
+    /// [T-ER001b] DataError errors surface with exit 65 (EX_DATAERR per ADR-0002).
+    /// Per ADR-0065 priority 2, `*Error::Api { code }` 4xx (other than 401/403/404) now
+    /// routes to DataError instead of folding onto IoError via `internal()`.
     #[test]
     fn data_errors_have_exit_code_65() {
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::InvalidRepo("bad".into()).into(),
+            github::GitHubError::Api {
+                code: 400,
+                message: "bad request".into(),
+            }
+            .into(),
+            github::GitHubError::Api {
+                code: 422,
+                message: "unprocessable entity".into(),
+            }
+            .into(),
             FetchError::InvalidScheme.into(),
             FetchError::InternalHost.into(),
             FetchError::UnsupportedContentType("image/png".into()).into(),
@@ -525,6 +613,11 @@ mod tests {
             FetchError::Status(499).into(),
             FetchError::TooLarge.into(),
             FetchError::TooManyRedirects(10).into(),
+            GeminiError::Api {
+                code: 400,
+                message: "err".into(),
+            }
+            .into(),
         ];
         for err in &cases {
             assert_eq!(err.error_kind(), ErrorCode::DataError, "{err}");
@@ -545,23 +638,16 @@ mod tests {
         }
     }
 
-    /// [T-ER002] IoError errors surface with exit 74 (EX_IOERR) and are non-retryable
+    /// [T-ER002] IoError errors surface with exit 74 (EX_IOERR) and are non-retryable.
+    /// Covers the remaining `internal()` callsites that fold onto IoError until #84
+    /// promotes scout-side bugs to `Internal(70)` and unclassified Api codes to
+    /// `Unknown(104)`.
     #[test]
     fn io_errors_have_exit_code_74() {
         let cases: Vec<ScoutError> = vec![
-            github::GitHubError::Api {
-                code: 400,
-                message: "bad request".into(),
-            }
-            .into(),
             github::GitHubError::Decode("decode error".into()).into(),
             FetchError::BrowserFailed("CDP protocol error".into()).into(),
             SlackError::Decode("err".into()).into(),
-            GeminiError::Api {
-                code: 400,
-                message: "err".into(),
-            }
-            .into(),
         ];
         for err in &cases {
             assert_eq!(err.error_kind(), ErrorCode::IoError, "{err}");

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -38,38 +38,34 @@ impl fmt::Display for ScoutError {
 impl Error for ScoutError {}
 
 impl ScoutError {
-    pub(super) fn user_error(msg: impl Into<String>) -> Self {
+    /// Shared construction path. `retryable` is derived from `kind` so the
+    /// public exit-code/JSON contract cannot drift between callers.
+    fn new(kind: ErrorCode, msg: impl Into<String>) -> Self {
         Self {
             message: msg.into(),
-            retryable: false,
-            kind: ErrorCode::UsageError,
+            retryable: kind.is_retryable(),
+            kind,
             next_step: None,
             candidates: Vec::new(),
         }
     }
 
-    pub(super) fn internal(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: false,
-            kind: ErrorCode::IoError,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+    pub(super) fn user_error(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::UsageError, msg)
+    }
+
+    /// External tool / IO failure outside scout's invariants (e.g. headless
+    /// browser CDP error). Maps to `ErrorCode::IoError` (exit 74 EX_IOERR).
+    /// Use [`Self::internal_bug`] for scout-side schema bugs (exit 70).
+    pub(super) fn io_error(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::IoError, msg)
     }
 
     /// scout-side invariant violation (e.g., unexpected API schema during
     /// deserialize). Maps to `ErrorCode::Internal` (exit 70 EX_SOFTWARE) per
-    /// ADR-0065 priority 5. Distinct from [`Self::internal`] which folds onto
-    /// IoError(74) for external tool failures (browser, IO).
+    /// ADR-0065 priority 5.
     pub(super) fn internal_bug(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: false,
-            kind: ErrorCode::Internal,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+        Self::new(ErrorCode::Internal, msg)
     }
 
     /// Unclassifiable failure — the priority rules (1-5) did not match.
@@ -77,23 +73,11 @@ impl ScoutError {
     /// §Classification Priority. A rising Unknown rate signals the
     /// classification design needs revisiting.
     pub(super) fn unknown(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: false,
-            kind: ErrorCode::Unknown,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+        Self::new(ErrorCode::Unknown, msg)
     }
 
     pub(super) fn transient(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: true,
-            kind: ErrorCode::TempFailure,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+        Self::new(ErrorCode::TempFailure, msg)
     }
 
     /// Timeout (request-level or transport-level). Maps to `ErrorCode::Timeout`
@@ -101,33 +85,15 @@ impl ScoutError {
     /// `transient`, but separated so caller scripts/agents can apply a longer
     /// backoff than for rate-limit / 5xx temp failures.
     pub(super) fn timeout(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: true,
-            kind: ErrorCode::Timeout,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+        Self::new(ErrorCode::Timeout, msg)
     }
 
     pub(super) fn not_found(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: false,
-            kind: ErrorCode::NotFound,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+        Self::new(ErrorCode::NotFound, msg)
     }
 
     pub(super) fn data_error(msg: impl Into<String>) -> Self {
-        Self {
-            message: msg.into(),
-            retryable: false,
-            kind: ErrorCode::DataError,
-            next_step: None,
-            candidates: Vec::new(),
-        }
+        Self::new(ErrorCode::DataError, msg)
     }
 
     /// Attach a recovery hint to this error per ADR-0002 `error.next_step`.
@@ -182,9 +148,9 @@ pub(super) fn parse_repo_param(repository: &str) -> Result<(&str, &str), ScoutEr
 //   1. USAGE_ERROR  — env/config/argument misuse
 //   2. DATA_ERROR   — format violations (URL, owner/repo, encoding, 4xx body)
 //   3. NOT_FOUND    — resource absence (404, search 0 hits)
-//   4. TEMP_FAILURE — retryable (rate limit, 5xx, network)
-//   5. INTERNAL     — scout-side invariant violation (folded onto IoError(74)
-//                     until ADR-0065 INTERNAL(70) variant lands)
+//   4. TEMP_FAILURE — retryable (rate limit, 5xx, network); TIMEOUT(124) splits off
+//   5. INTERNAL     — scout-side invariant violation (unexpected schema); IO_ERROR(74)
+//                     is the sibling for external tool failure (browser)
 // Disjoint variants are otherwise free to be reordered; the priority comments
 // document intent so a reviewer can spot a misclassification mechanically.
 impl From<github::GitHubError> for ScoutError {
@@ -265,31 +231,41 @@ impl From<FetchError> for ScoutError {
                 .with_next_step("URL response exceeds 10MB; fetch a smaller resource"),
             FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
                 .with_next_step("URL has too many redirects; check for a redirect loop"),
-            // Status arms: specific HTTP code first, then 4xx/_ fallback. Priority noted per arm.
-            FetchError::Status(401 | 403) => Self::user_error(e.to_string()) // Priority 1
+            // Status arms order specific HTTP codes before the 4xx / _ fallback;
+            // the per-arm priority label restores ADR-0065 ranking for review.
+            // Priority 1: USAGE_ERROR
+            FetchError::Status(401 | 403) => Self::user_error(e.to_string())
                 .with_next_step("URL requires authentication that scout does not support"),
-            FetchError::Status(404) => Self::not_found(e.to_string()) // Priority 3
+            // Priority 3: NOT_FOUND
+            FetchError::Status(404) => Self::not_found(e.to_string())
                 .with_next_step("Check that the URL is correct and the resource exists"),
-            FetchError::Status(408 | 429) => Self::transient(e.to_string()) // Priority 4
-                .with_next_step(HINT_RETRY_DELAY),
-            FetchError::Status(code) if (400..500).contains(code) => {
-                Self::data_error(e.to_string()) // Priority 2
+            // Priority 4: TEMP_FAILURE
+            FetchError::Status(408 | 429) => {
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
+            // Priority 2: DATA_ERROR (4xx body)
+            FetchError::Status(code) if (400..500).contains(code) => {
+                Self::data_error(e.to_string())
+            }
+            // Priority 4: TEMP_FAILURE (5xx and other unmatched)
             FetchError::Status(_) => {
-                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY) // Priority 4 (5xx, ...)
+                Self::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             // Priority 4: TIMEOUT (transport timeout — long-backoff retry advised)
-            FetchError::Timeout(_) => {
-                Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY)
-            }
+            FetchError::Timeout(_) => Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY),
             // Priority 4: TEMP_FAILURE (non-Status variants)
             FetchError::DnsResolution(_) => Self::transient(e.to_string())
                 .with_next_step("Check the URL's domain name and your DNS resolver"),
+            // `is_transient_network` covers both connect and timeout, but
+            // ADR-0065 splits timeout into 124. Check `is_timeout()` first.
+            FetchError::Http(re) if re.is_timeout() => {
+                Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+            }
             FetchError::Http(re) if is_transient_network(re) => {
                 Self::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
             }
-            // IO_ERROR — external tool failure (browser) outside scout's invariants
-            FetchError::BrowserFailed(_) => Self::internal(e.to_string()),
+            // Priority 5 sibling: IO_ERROR — external tool failure (browser)
+            FetchError::BrowserFailed(_) => Self::io_error(e.to_string()),
             // Unknown — reqwest errors that do not match transient network patterns
             FetchError::Http(_) => Self::unknown(e.to_string()),
         }
@@ -405,10 +381,10 @@ mod tests {
         assert_eq!(err.error_kind(), ErrorCode::TempFailure);
     }
 
-    /// [T-ER012] internal returns ErrorCode::IoError
+    /// [T-ER012] io_error returns ErrorCode::IoError
     #[test]
-    fn internal_kind_is_io_error() {
-        let err = ScoutError::internal("test");
+    fn io_error_kind_is_io_error() {
+        let err = ScoutError::io_error("test");
         assert_eq!(err.error_kind(), ErrorCode::IoError);
     }
 
@@ -509,9 +485,9 @@ mod tests {
     /// [T-NS009] Errors without next_step omit the hint from Display
     #[test]
     fn display_omits_next_step_when_absent() {
-        let err = ScoutError::internal("internal failure");
+        let err = ScoutError::io_error("io failure");
         let display = err.to_string();
-        assert_eq!(display, "internal failure");
+        assert_eq!(display, "io failure");
     }
 
     /// [T-ER013] GitHubError::NotFound classifies as ErrorCode::NotFound

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -218,6 +218,10 @@ impl From<github::GitHubError> for ScoutError {
             github::GitHubError::NotFound(_) => Self::not_found(e.to_string()).with_next_step(
                 "Check that the repository or path exists, and that you have access",
             ),
+            // Priority 4: TIMEOUT (request timeout via reqwest builder)
+            github::GitHubError::Network(re) if re.is_timeout() => {
+                Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+            }
             // Priority 4: TEMP_FAILURE
             github::GitHubError::RateLimited { retry_after } => Self::transient(e.to_string())
                 .with_next_step(match retry_after {
@@ -341,6 +345,10 @@ impl From<GeminiError> for ScoutError {
             // Priority 2: DATA_ERROR (4xx body)
             GeminiError::Api { code, .. } if (400..500).contains(code) => {
                 Self::data_error(e.to_string())
+            }
+            // Priority 4: TIMEOUT (request timeout via reqwest builder)
+            GeminiError::Network(re) if re.is_timeout() => {
+                Self::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY)
             }
             // Priority 4: TEMP_FAILURE
             GeminiError::RateLimited { .. } => {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -22,6 +22,14 @@ fn help_exits_zero_and_contains_app_name() {
         stdout.contains("sysexits.h"),
         "help should reference sysexits.h, got:\n{stdout}"
     );
+    // ADR-0065 9-code policy — every documented exit code must surface in --help
+    // so agent/script callers can discover the contract without reading source.
+    for code in ["64", "65", "66", "70", "74", "75", "104", "124"] {
+        assert!(
+            stdout.contains(code),
+            "help should advertise exit code {code} per ADR-0065, got:\n{stdout}"
+        );
+    }
 }
 
 // T-C002: version_exits_zero

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -22,12 +22,15 @@ fn help_exits_zero_and_contains_app_name() {
         stdout.contains("sysexits.h"),
         "help should reference sysexits.h, got:\n{stdout}"
     );
-    // ADR-0065 9-code policy — every documented exit code must surface in --help
-    // so agent/script callers can discover the contract without reading source.
+    // ADR-0065 — every documented non-zero exit code must surface in --help so
+    // agent/script callers can discover the contract without reading source.
+    // Match the `  CODE  ` table layout to avoid substring collisions (e.g.,
+    // "75" inside a future "175 RPM" mention).
     for code in ["64", "65", "66", "70", "74", "75", "104", "124"] {
+        let needle = format!("  {code}  ");
         assert!(
-            stdout.contains(code),
-            "help should advertise exit code {code} per ADR-0065, got:\n{stdout}"
+            stdout.contains(&needle),
+            "help should advertise exit code {code} as `{needle}` per ADR-0065, got:\n{stdout}"
         );
     }
 }


### PR DESCRIPTION
## 概要

- `ErrorCode` を 5 → 9 variant に拡張 (ADR-0065): `Internal` (exit 70 EX_SOFTWARE), `Unknown` (104, PJ拡張), `Timeout` (124, GNU coreutils) を追加。
- ADR-0065 §Classification Priority (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN) を各 `From<...>` impl に `// Priority N` 注釈付きで反映。code review で誤分類が機械的に検出可能になる。
- `*Error::Api { code }` 4xx が `IoError(74)` に流れてた既存バグを `DataError(65)` に修正。

## 振る舞いの変更 (retry script を要監査)

| 経路 | Before | After |
|---|---|---|
| `GitHubError::Api { 4xx }` / `GeminiError::Api { 4xx }` | exit 74 | exit 65 |
| `GitHubError::Api { code }` 非 4xx/5xx (例: 304) | exit 74 | exit 104 |
| `GitHubError::Decode` / `SlackError::Decode` | exit 74 | exit 70 |
| `FetchError::Timeout` / `SlackError::Timeout` | exit 75 | exit 124 |
| `FetchError::Http(reqwest::Error)` の `is_timeout()` | exit 75 | exit 124 |
| `GitHubError::Network` / `GeminiError::Network` の `is_timeout()` | exit 75 | exit 124 |
| `FetchError::Http(reqwest::Error)` non-transient | exit 74 | exit 104 |

`exit 74` を hardcode してる retry-or-fail-fast caller は新 mapping を要監査。JSON `error.code` 文字列も同じ split。

## 主要 refactor (`/polish` 経由)

- `ScoutError` コンストラクタを private `Self::new(kind, msg)` に集約。`retryable` は `ErrorCode::is_retryable()` から導出 → JSON 契約がcaller間で drift しない。
- 旧 `ScoutError::internal` を `io_error` に rename。新 `internal_bug` (`Internal(70)`) との noun-stem 衝突を解消。
- `--help` / README の exit code 表に retry backoff hint を含む 9 種すべてを列挙。

## テスト計画

- [x] `cargo test` — 346 lib + 10 integration tests pass
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] T-ER023 / T-ER024 で `Api { 4xx/5xx }` の priority 順序を lock
- [x] T-ER025 / T-ER026 / T-ER027 で新規 Internal/Unknown/Timeout ルートを lock
- [x] T-EN014 parameterized テストで全 8 `ErrorCode` → `exit_code` ペアをカバー
- [x] `help_exits_zero_and_contains_app_name` で `--help` に全 exit code が `  CODE  ` table cell として出現することを assert

## ADR とバージョン

- ADR-0065 §Classification Priority + 9-code Exit Code Policy を実装
- Cargo: 1.1.0 → 1.1.1 (user-chosen — exit-code reclassification は技術的に breaking、`74` を hardcode してた caller は要監査)
- ADR-0003 §Implementation Guidelines に priority annotation rule を追記

Closes #83
Closes #84
Closes #85