### PR TITLE
docs(adr): ADR-0002/0003 を PR #94 の 9-code policy に追従

### DIFF
--- a/docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md
+++ b/docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md
@@ -28,14 +28,17 @@ Chosen option: Option A (sysexits.h), because POSIX 慣習として浸透して�
 
 採用する code:
 
-| Code | Name        | scout での意味                                |
-| ---- | ----------- | --------------------------------------------- |
-| 0    | EX_OK       | 成功                                          |
-| 64   | EX_USAGE    | コマンドラインの使い方が誤り                  |
-| 65   | EX_DATAERR  | 入力データが invalid (URL invalid 等)         |
-| 66   | EX_NOINPUT  | 入力ファイルやリソースが見つからない          |
-| 74   | EX_IOERR    | I/O エラー (network, disk)                    |
-| 75   | EX_TEMPFAIL | 一時的失敗 (rate limit, transient API error)  |
+| Code | Name                | scout での意味                                                |
+| ---- | ------------------- | ------------------------------------------------------------- |
+| 0    | EX_OK               | 成功                                                          |
+| 64   | EX_USAGE            | コマンドラインの使い方が誤り                                  |
+| 65   | EX_DATAERR          | 入力データが invalid (URL invalid 等)                         |
+| 66   | EX_NOINPUT          | 入力ファイルやリソースが見つからない                          |
+| 70   | EX_SOFTWARE         | scout-side invariant violation (deserialize 想定外 schema 等) |
+| 74   | EX_IOERR            | I/O エラー (network, disk, external tool failure)             |
+| 75   | EX_TEMPFAIL         | 一時的失敗 (rate limit, transient API error)                  |
+| 104  | PJ extension        | 分類不能 (priority 1-5 のどれにも該当しない退避)              |
+| 124  | GNU coreutils       | Timeout (request-level / transport-level)                     |
 
 ### Consequences
 
@@ -46,12 +49,12 @@ Chosen option: Option A (sysexits.h), because POSIX 慣習として浸透して�
 
 ### Confirmation
 
-`src/lib.rs:220-254` の T-H000 test が以下を check:
+`src/lib.rs:224-270` の T-H000 test が以下を check:
 
 * `--help` 出力に "Exit codes" section が存在
 * "sysexits.h" の文字列を含む
-* 採用した全 code (64, 65, 66, 74, 75) が `--help` に列挙
-* "Usage error", "Temporary failure" 等の説明文字列を含む
+* 採用した全 non-zero code (64, 65, 66, 70, 74, 75, 104, 124) が `--help` に列挙
+* "Usage error", "Temporary failure", "Internal", "Timeout", "Unknown" 等の説明文字列を含む
 
 新規 exit code 追加時は本 test を update する。test 削除は本 ADR を supersede してから行う。
 
@@ -87,31 +90,37 @@ scout 独自の意味づけ (例: 10 = network, 20 = parse, 30 = auth)。
 
 ### Supersedes (sysexits portion)
 
-This ADR supersedes the **sysexits portion** of `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (dotclaude meta ADR). The exit-code mapping table (64/65/66/74/75) was originally defined there as part of the agent-friendly CLI policy (ADR-0060 → ADR-0065 chain). It is now scout-local under this ADR.
+This ADR supersedes the **sysexits portion** of `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (dotclaude meta ADR). The exit-code mapping table (64/65/66/74/75) was originally defined there as part of the agent-friendly CLI policy (ADR-0060 → ADR-0065 chain). It is now scout-local under this ADR. PR #94 で ADR-0065 9-code policy 採用に伴って追加された `70 EX_SOFTWARE` / `104 PJ extension` / `124 GNU coreutils` も本 ADR の scout-local 管理対象に含まれる (詳細は本 ADR 末尾の Note 2026-05-14 を参照)。
 
 The **JSON output schema portion** of ADR-0065 (`error.code` field, `--json` mode, error envelope structure) is **not** included in this ADR and remains active in ADR-0065 until a scout-local ADR is promoted to capture it. Until then, code that maps `ErrorCode` → exit code is governed by this ADR; code that maps domain errors → `ErrorCode` JSON tags is governed by ADR-0065.
 
 ### 採用 code 詳細
 
-| Code | 利用箇所 (例)                       |
-| ---- | ----------------------------------- |
-| 64   | clap parse 失敗                     |
-| 65   | URL parse 失敗、JSON parse 失敗     |
-| 66   | repo not found、page 404            |
-| 74   | network error、TLS error            |
-| 75   | rate limit、Gemini API 503          |
+| Code | 利用箇所 (例)                                                |
+| ---- | ------------------------------------------------------------ |
+| 64   | clap parse 失敗、auth misconfig (401/403)                    |
+| 65   | URL parse 失敗、JSON parse 失敗、API 4xx (other)             |
+| 66   | repo not found、page 404                                     |
+| 70   | API schema mismatch (deserialize bug)、scout 内部不変条件違反 |
+| 74   | network error、TLS error、headless browser CDP error         |
+| 75   | rate limit (429)、Gemini API 503、5xx (500-599)              |
+| 104  | priority 1-5 のどれにも fall through しなかった unclassifiable |
+| 124  | reqwest request timeout、transport-level timeout             |
 
 ### Reassessment Triggers
 
-| Trigger                                      | アクション                                    |
-| -------------------------------------------- | --------------------------------------------- |
-| Windows 環境がサポート対象に加わる           | exit code 規約を再評価 (Windows convention 検討) |
-| 新規 error mode で 6 つの code に収まらない | code 追加 + T-H000 test update                |
-| sysexits.h 互換性違反 incident 発生          | 本 ADR supersede + 移行 ADR 起票              |
+| Trigger                                                | アクション                                    |
+| ------------------------------------------------------ | --------------------------------------------- |
+| Windows 環境がサポート対象に加わる                     | exit code 規約を再評価 (Windows convention 検討) |
+| 新規 error mode で現行 9 codes (0 + 8 non-zero) に収まらない | code 追加 + T-H000 test update                |
+| sysexits.h 互換性違反 incident 発生                    | 本 ADR supersede + 移行 ADR 起票              |
 
 ### 参照
 
 * `<sysexits.h>` man page: https://man.openbsd.org/sysexits
-* `src/lib.rs:220-254` (T-H000 enforcement test)
+* `src/lib.rs:224-270` (T-H000 enforcement test)
 * `README.ja.md:232` ("sysexits.h 規約に準拠")
 * `docs/audit/2026-05-13-undocumented-decisions.md` (本 ADR の根拠 audit)
+* `docs/audit/2026-05-14-adr-drift.md` (PR #94 後の追従 audit)
+
+> **Note (2026-05-14, post-implementation update)**: PR #94 で 5 non-zero codes (64/65/66/74/75) → 8 non-zero codes に拡張。`70 EX_SOFTWARE` (scout-side schema bug、`ScoutError::internal_bug`)、`104 PJ extension` (unclassifiable 退避、`ScoutError::unknown`)、`124 GNU coreutils` (timeout 専用 retry path、`ScoutError::timeout`) を追加。`~/.claude/docs/decisions/0065-...` の 9-code policy 採用に合わせ、本 ADR の Decision table と "採用 code 詳細" を同期し、T-H000 ref line range を最新化。実装側 (`src/tools/errors.rs:57-89`, `src/lib.rs:224-270`, `tests/cli_integration.rs`) は本更新前から ADR-0065 と整合済みで、本更新は ADR-0002 文言のみの追従。

--- a/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
+++ b/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
@@ -97,9 +97,9 @@ Chosen option: Option A, because public CLI contract として一貫した class
 ### Implementation Guidelines
 
 * 各 `ErrorCode` バリアントの construction site で本 ADR の mapping table を参照
-* `unwrap_or_note` は `unwrap_or_degraded` (仮称) に rename し、`Result<T, DegradedReason>` を返す形に refactor
-* `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (4-6 variant 程度を想定)
-* ADR-0065 §Classification Priority の 5 段ルール (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN 退避) を各 `From<...>` 実装の match arm 順序と `// Priority N` コメントで明示する。`*Error::Api { code }` の 4xx は priority 2 (DataError) に集約し、`internal()` への fold off は priority 5 (scout-side invariant violation) と Unknown 退避にのみ使用する
+* `unwrap_or_note` を `unwrap_or_degraded` に rename 済み (`src/tools/errors.rs` `unwrap_or_degraded`)。`DegradedReason` を受け取り、`Degradation::push` 経由で `(notes[i], reasons[i])` の pair invariant を保ったまま統一的に蓄積する形に refactor 済み
+* `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (実装後 8 variants、上記 Note 2026-05-13 follow-up implementation を参照)
+* ADR-0065 §Classification Priority の 5 段ルール (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN 退避) を各 `From<...>` 実装の match arm 順序と `// Priority N` コメントで明示する。`*Error::Api { code }` の 4xx は priority 2 (DataError) に集約する。Priority 5 (INTERNAL) 以下は 3 つの sibling constructor に分離する: `internal_bug()` は scout-side invariant violation (例: deserialize 想定外 schema) を `ErrorCode::Internal` (exit 70 EX_SOFTWARE) で表し、`io_error()` は scout の不変条件外にある external tool / IO failure (例: headless browser CDP error) を `ErrorCode::IoError` (exit 74 EX_IOERR) で表し、`unknown()` は priority 1-5 のどれにも該当しない unclassifiable failure を `ErrorCode::Unknown` (exit 104 PJ extension) で退避する。3 つの分離により caller script / agent は scout 側 bug (70) と外部要因 (74) と分類欠落 (104) を programmatic 判別できる
 
 ### Reassessment Triggers
 
@@ -114,4 +114,5 @@ Chosen option: Option A, because public CLI contract として一貫した class
 * `docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md` (exit code 値の source)
 * `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (JSON schema 部分は依然 ADR-0065 active)
 * `docs/audit/2026-05-13-undocumented-decisions-part2.md` (本 ADR の根拠 audit、Candidate #7 + #8)
-* `src/tools/errors.rs:225` (SlackError::Api 違反箇所), `src/tools/errors.rs:266` (unwrap_or_note 違反箇所)
+* `src/tools/errors.rs` (`From<SlackError>` priority-2 集約 + `unwrap_or_degraded` 実装), `src/envelope.rs` (`Degradation` / `DegradedReason` typed enum) — implementation sites (audit 時点の違反は resolved 済み、historical record は `docs/audit/2026-05-13-undocumented-decisions-part2.md` を参照)
+* `docs/audit/2026-05-14-adr-drift.md` (PR #94 後の追従 audit)


### PR DESCRIPTION
## 概要

- ADR-0002 / ADR-0003 を PR #94 (ADR-0065 9-code exit-code policy 採用) に追従させる文言更新。
- code-fix なし、純粋に ADR 文書のみの drift 解消。実装と `--help` と T-H000 / T-ER025-027 は PR #94 時点で内部整合済み。
- `/audit-adr-drift` (2026-05-14, `docs/audit/2026-05-14-adr-drift.md`) で検出された H × 2 / M × 1 / L × 1 を全部反映。

Closes #95

## 変更内容

### ADR-0002 の更新

- Decision table を 5 → 8 non-zero codes に拡張 (`70 EX_SOFTWARE` / `104 PJ extension` / `124 GNU coreutils` 追加)
- Confirmation の T-H000 ref を `src/lib.rs:224-270` に更新、8 non-zero codes 全部と Internal / Timeout / Unknown 説明文字列の check を同期
- "採用 code 詳細" table を 8 non-zero codes に同期
- Reassessment Trigger "6 つの code" を "現行 9 codes (0 + 8 non-zero)" に書き換え
- Supersession paragraph に 70/104/124 が scout-local 管理対象である旨を 1 文追記
- 末尾に 2026-05-14 post-implementation Note (PR #94 ref) と audit ref を追加

### ADR-0003 の更新

- Implementation Guidelines の `internal()` ref を `internal_bug()` に置換し、`io_error()` (74 EX_IOERR) / `unknown()` (104 PJ extension) との 3-way sibling split を 1 段落で追記
- `unwrap_or_note` rename 文言を future tense から実装済み記述に更新
- `DegradedReason` の "4-6 variant 程度を想定" を "実装後 8 variants" に最新化
- 参照を historical line refs (`src/tools/errors.rs:225` / `:266`) から implementation site + audit ref に変更

## 動作確認

- [x] `cargo test --test cli_integration` → 10 passed
- [x] T-H000 `root_help_contains_exit_codes_and_environment` → 1 passed
- [x] code-fix なし (実装は PR #94 時点で ADR-0065 9-code policy と整合)
- [ ] reviewer 確認後 merge

## スコープ外

- ADR-0065 (`~/.claude/docs/decisions/`, global) 側の更新
- ADR-0001 / ADR-0004 (drift なし)
- 新規 ADR