### PR TITLE
v1.1.2 をリリース

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "base64",
  "chardetng 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scout"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 rust-version = "1.95"
 description = "CLI tool for web search (Gemini Grounding), page fetching, and GitHub repository exploration"


### PR DESCRIPTION
## What & Why

scout `1.1.1` → `1.1.2` の PATCH リリース。直近マージされた #98 (README と `--help` の実装ズレ修正) を tag 付きで配布するため version を bump する。Releases ページと Homebrew tap (`thkt/homebrew-tap`) への反映が tag push で自動的に走る。

## Changes

- `Cargo.toml` / `Cargo.lock` の `scout` version を `1.1.1` → `1.1.2`

## Scope

- **Not included**: 機能・ロジック・依存パッケージの変更なし。bump 専用

## Release Contents (since v1.1.1)

- #98 docs(readme): align README and --help with current implementation
  - Exit codes 表記を `sysexits.h + GNU coreutils + PJ extension` に統一
  - README.ja.md の欠落終了コード (70 / 124 / 104) を追加、74 の説明を訂正
  - `--json` の stdout/stderr 振り分けを明記
  - `scout --version` / `-V` を README に追加
  - `fetch --js` の `--help` 出力に `js-rendering` build feature + Chrome/Chromium 要件を反映

## How to Test

1. このPRをマージ
2. main で `git tag -a v1.1.2 -m "..."` → `git push origin v1.1.2`
3. `.github/workflows/release.yml` が 4 ターゲットを build → GitHub Release 作成 → `thkt/homebrew-tap` の Formula 自動更新まで通る
4. `brew upgrade scout` でローカルが `1.1.2` になる / `scout --version` が `scout 1.1.2`
