### PR TITLE
sysexits 終了コード分類: GitHub 401 / schema fail / ParseJson の誤分類修正

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -49,9 +49,9 @@ impl BraveError {
     /// Returns `true` when the error is a transient infrastructure failure that callers
     /// may legitimately surface as a degraded result instead of propagating.
     ///
-    /// Configuration errors (`ApiKeyNotSet`, `Unauthorized`, `ParseUrl`) and data
-    /// errors (`ParseJson`, `Api` 4xx) require user action and must not be silently
-    /// swallowed.
+    /// Configuration errors (`ApiKeyNotSet`, `Unauthorized`, `ParseUrl`,
+    /// `InsecureBaseUrl`), the scout-side invariant `ParseJson`, and 4xx `Api`
+    /// codes stay propagated — they require user action or signal a scout bug.
     pub(crate) fn is_degradable(&self) -> bool {
         match self {
             Self::ApiKeyNotSet

--- a/src/github.rs
+++ b/src/github.rs
@@ -148,14 +148,16 @@ impl GitHubClient {
         let status = response.status();
         debug!(path, status = %status, "github API response");
         match status.as_u16() {
-            // 2xx body decode failure is a scout-side invariant violation (the API
-            // returned an unexpected schema). Route through `Decode` so it maps to
-            // Internal(70) retryable=false instead of Network → TempFailure(75)
-            // retryable=true (per issue #101).
-            200..=299 => Ok(response
-                .json()
-                .await
-                .map_err(|e| GitHubError::Decode(e.to_string()))?),
+            // Schema mismatch is a scout-side invariant — non-retryable.
+            // Transport errors (timeout, connect) fall through to Network so
+            // the retry loop can recover.
+            200..=299 => response.json().await.map_err(|e| {
+                if e.is_decode() {
+                    GitHubError::Decode(e.to_string())
+                } else {
+                    e.into()
+                }
+            }),
             404 => Err(GitHubError::NotFound(path.to_owned())),
             429 => {
                 let retry_after = parse_retry_after(response.headers());

--- a/src/github.rs
+++ b/src/github.rs
@@ -148,7 +148,14 @@ impl GitHubClient {
         let status = response.status();
         debug!(path, status = %status, "github API response");
         match status.as_u16() {
-            200..=299 => Ok(response.json().await?),
+            // 2xx body decode failure is a scout-side invariant violation (the API
+            // returned an unexpected schema). Route through `Decode` so it maps to
+            // Internal(70) retryable=false instead of Network → TempFailure(75)
+            // retryable=true (per issue #101).
+            200..=299 => Ok(response
+                .json()
+                .await
+                .map_err(|e| GitHubError::Decode(e.to_string()))?),
             404 => Err(GitHubError::NotFound(path.to_owned())),
             429 => {
                 let retry_after = parse_retry_after(response.headers());
@@ -584,5 +591,30 @@ mod http_tests {
                 retry_after: Some(_)
             })
         ));
+    }
+
+    /// [T-GH012] 2xx response with malformed JSON classifies as Decode (issue #101).
+    ///
+    /// Before this fix, `Ok(response.json().await?)` routed schema failures through
+    /// `#[from] reqwest::Error` to `GitHubError::Network`, surfacing as TempFailure(75)
+    /// retryable=true. Schema fail is a scout-side invariant violation that retry
+    /// cannot resolve — must classify as Decode → Internal(70) retryable=false.
+    #[tokio::test]
+    async fn get_json_2xx_malformed_body_returns_decode() {
+        let Some(server) = try_spawn_mock_server("github::http").await else {
+            return;
+        };
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{not valid json"))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base_url(Client::new(), &server.uri());
+        let result: Result<RepoInfo, _> = client.get_json("/repos/owner/repo").await;
+        assert!(
+            matches!(result, Err(GitHubError::Decode(_))),
+            "expected GitHubError::Decode for 2xx malformed JSON, got: {result:?}"
+        );
     }
 }

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -177,6 +177,11 @@ impl From<github::GitHubError> for ScoutError {
             // Priority 1: USAGE_ERROR
             github::GitHubError::Forbidden(_) => Self::user_error(e.to_string())
                 .with_next_step("Check that your GITHUB_TOKEN has the required scopes"),
+            // 401 must be checked before the generic 4xx arm below; otherwise it
+            // would fall through to DataError(65). Auth failure is a misconfigured
+            // credential, not a malformed payload (issue #101).
+            github::GitHubError::Api { code: 401, .. } => Self::user_error(e.to_string())
+                .with_next_step("Set GITHUB_TOKEN or run `gh auth login` to authenticate"),
             // Priority 2: DATA_ERROR
             github::GitHubError::InvalidRepo(_) => Self::data_error(e.to_string())
                 .with_next_step("Use 'owner/repo' format, e.g., 'facebook/react'"),
@@ -611,6 +616,29 @@ mod tests {
             assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70): {err}");
             assert!(!err.retryable(), "Internal must not be retryable: {err}");
         }
+    }
+
+    /// [T-ER030] GitHub `Api { code: 401 }` classifies as UsageError(64) with auth hint
+    /// (issue #101).
+    ///
+    /// Prior to this fix, 401 fell through the generic `(400..500)` DataError arm
+    /// (exit 65) because the GitHubClient surfaces every non-special 4xx as
+    /// `GitHubError::Api`. 401 is an auth-class failure — the user must set
+    /// `GITHUB_TOKEN` or run `gh auth login` — so ADR-0065 priority 1 (USAGE_ERROR)
+    /// is the correct landing, peer to `GitHubError::Forbidden`.
+    #[test]
+    fn github_401_classifies_as_usage_error_with_auth_hint() {
+        let err = ScoutError::from(github::GitHubError::Api {
+            code: 401,
+            message: "Bad credentials".into(),
+        });
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+        assert_eq!(err.exit_code(), 64, "expected EX_USAGE (64)");
+        assert!(
+            err.next_step().is_some_and(|h| h.contains("GITHUB_TOKEN")),
+            "expected auth hint mentioning GITHUB_TOKEN, got: {:?}",
+            err.next_step()
+        );
     }
 
     /// [T-ER029] BraveError::ParseJson classifies as Internal(70) (issue #101).

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -318,8 +318,8 @@ impl From<BraveError> for ScoutError {
             BraveError::Unauthorized => Self::user_error(e.to_string()).with_next_step(
                 "Verify BRAVE_SEARCH_API_KEY at https://api-dashboard.search.brave.com/",
             ),
-            // Priority 2: DATA_ERROR (4xx body, response parse failure, or insecure base URL)
-            BraveError::ParseJson(_) | BraveError::ParseUrl(_) | BraveError::InsecureBaseUrl => {
+            // Priority 2: DATA_ERROR (4xx body, URL parse failure, or insecure base URL)
+            BraveError::ParseUrl(_) | BraveError::InsecureBaseUrl => {
                 Self::data_error(e.to_string())
             }
             BraveError::Api { code, .. } if (400..500).contains(code) => {
@@ -334,6 +334,11 @@ impl From<BraveError> for ScoutError {
             BraveError::Api { code, .. } if (500..=599).contains(code) => {
                 transient_with_retry_hint(&e)
             }
+            // Priority 5: INTERNAL — scout-side bug (unexpected response schema).
+            // Peer to `GitHubError::Decode` / `SlackError::Decode`; retry cannot
+            // resolve schema drift, so `internal_bug` (Internal/70/non-retryable)
+            // is the correct landing per ADR-0065 (issue #101).
+            BraveError::ParseJson(_) => Self::internal_bug(e.to_string()),
             // Unknown — Api codes that did not match 4xx or 5xx
             BraveError::Api { .. } => Self::unknown(e.to_string()),
         }
@@ -606,6 +611,23 @@ mod tests {
             assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70): {err}");
             assert!(!err.retryable(), "Internal must not be retryable: {err}");
         }
+    }
+
+    /// [T-ER029] BraveError::ParseJson classifies as Internal(70) (issue #101).
+    ///
+    /// 2xx body schema mismatch is a scout-side invariant violation (the Brave API
+    /// returned an unexpected payload shape), not a user-fixable data error. Prior
+    /// to this fix the variant routed through the `DataError(65)` arm alongside
+    /// `ParseUrl` and `InsecureBaseUrl`. ADR-0065 priority 5 places it under
+    /// Internal, peer to `GitHubError::Decode` and `SlackError::Decode`.
+    #[test]
+    fn brave_parse_json_classifies_as_internal_exit_70() {
+        let serde_err =
+            serde_json::from_str::<serde_json::Value>("{not valid").expect_err("malformed json");
+        let err = ScoutError::from(BraveError::ParseJson(serde_err));
+        assert_eq!(err.error_kind(), ErrorCode::Internal);
+        assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70)");
+        assert!(!err.retryable(), "ParseJson must not be retryable");
     }
 
     /// [T-ER026] UNKNOWN (104) is the escape hatch for Api codes that match

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -177,9 +177,7 @@ impl From<github::GitHubError> for ScoutError {
             // Priority 1: USAGE_ERROR
             github::GitHubError::Forbidden(_) => Self::user_error(e.to_string())
                 .with_next_step("Check that your GITHUB_TOKEN has the required scopes"),
-            // 401 must be checked before the generic 4xx arm below; otherwise it
-            // would fall through to DataError(65). Auth failure is a misconfigured
-            // credential, not a malformed payload (issue #101).
+            // 401 must precede the 4xx arm below to avoid falling into DataError.
             github::GitHubError::Api { code: 401, .. } => Self::user_error(e.to_string())
                 .with_next_step("Set GITHUB_TOKEN or run `gh auth login` to authenticate"),
             // Priority 2: DATA_ERROR
@@ -339,10 +337,8 @@ impl From<BraveError> for ScoutError {
             BraveError::Api { code, .. } if (500..=599).contains(code) => {
                 transient_with_retry_hint(&e)
             }
-            // Priority 5: INTERNAL — scout-side bug (unexpected response schema).
-            // Peer to `GitHubError::Decode` / `SlackError::Decode`; retry cannot
-            // resolve schema drift, so `internal_bug` (Internal/70/non-retryable)
-            // is the correct landing per ADR-0065 (issue #101).
+            // Priority 5: INTERNAL — schema drift is a scout-side invariant;
+            // peer to `GitHubError::Decode` / `SlackError::Decode`.
             BraveError::ParseJson(_) => Self::internal_bug(e.to_string()),
             // Unknown — Api codes that did not match 4xx or 5xx
             BraveError::Api { .. } => Self::unknown(e.to_string()),
@@ -602,14 +598,17 @@ mod tests {
     }
 
     /// [T-ER025] INTERNAL (70) reserved for scout-side schema bugs.
-    /// `Decode` variants from GitHub and Slack APIs indicate an unexpected
-    /// response shape — by ADR-0065 priority 5 these are scout's invariant
-    /// violation, not external IO failure (which maps to IoError 74).
+    /// `Decode` / `ParseJson` variants from GitHub, Slack, and Brave APIs signal
+    /// an unexpected response shape — by ADR-0065 priority 5 these are scout's
+    /// invariant violation, not external IO failure (which maps to IoError 74).
     #[test]
     fn schema_decode_classifies_as_internal_exit_70() {
+        let serde_err =
+            serde_json::from_str::<serde_json::Value>("{not valid").expect_err("malformed json");
         let cases: Vec<ScoutError> = vec![
             github::GitHubError::Decode("decode error".into()).into(),
             SlackError::Decode("err".into()).into(),
+            BraveError::ParseJson(serde_err).into(),
         ];
         for err in &cases {
             assert_eq!(err.error_kind(), ErrorCode::Internal, "{err}");
@@ -639,23 +638,6 @@ mod tests {
             "expected auth hint mentioning GITHUB_TOKEN, got: {:?}",
             err.next_step()
         );
-    }
-
-    /// [T-ER029] BraveError::ParseJson classifies as Internal(70) (issue #101).
-    ///
-    /// 2xx body schema mismatch is a scout-side invariant violation (the Brave API
-    /// returned an unexpected payload shape), not a user-fixable data error. Prior
-    /// to this fix the variant routed through the `DataError(65)` arm alongside
-    /// `ParseUrl` and `InsecureBaseUrl`. ADR-0065 priority 5 places it under
-    /// Internal, peer to `GitHubError::Decode` and `SlackError::Decode`.
-    #[test]
-    fn brave_parse_json_classifies_as_internal_exit_70() {
-        let serde_err =
-            serde_json::from_str::<serde_json::Value>("{not valid").expect_err("malformed json");
-        let err = ScoutError::from(BraveError::ParseJson(serde_err));
-        assert_eq!(err.error_kind(), ErrorCode::Internal);
-        assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70)");
-        assert!(!err.retryable(), "ParseJson must not be retryable");
     }
 
     /// [T-ER026] UNKNOWN (104) is the escape hatch for Api codes that match


### PR DESCRIPTION
## What & Why

issue #101 の sysexits.h 終了コード分類 6 項目のうち、OUTCOME 直結度の高い 3 項目を修正。AI エージェントが retry/abort を誤判断しないよう、誤分類された exit code を ADR-0065 priority ルールに揃える。

スコープ調整の経緯は [issue コメント](https://github.com/thkt/scout/issues/101#issuecomment-4469369096) 参照。

## Changes

- **GitHub 2xx schema fail → Internal(70)**: `response.json().await?` を `map_err` 経由で `GitHubError::Decode` に振り替え。transport error は `#[from] reqwest::Error` で `Network` に保持
- **Brave `ParseJson` → Internal(70)**: DataError(65) から priority 5 (`internal_bug`) へ移動。`Decode` peer と整合
- **GitHub `Api { code: 401 }` → UsageError(64)**: 401 専用 arm を priority 1 に追加。`Set GITHUB_TOKEN or run gh auth login` の auth hint 付与

## Scope

**Not included**:
- 受け入れ条件 1 (`is_body()`) — reqwest 0.13 では mid-stream body drop は `is_decode()` 経路で観測される。`is_decode()` 単純追加は schema fail (本 PR 条件 2) と衝突するため、別 issue で source-chain 判別を検討
- 受け入れ条件 4, 5 (Slack `message not found` / `ok:false` 欠落) — OUTCOME 副次経路。typed variant 化検討含め別 issue 候補

## Design Decisions

- **`is_decode()` 分岐で transport error を Network 保持**: 当初 `map_err` で全 reqwest::Error を Decode に集約していたが、timeout / connect drop も Internal(70) retryable=false になり retry 経路を失う問題が Codex polish で判明。`is_decode()` true のみ Decode、それ以外は `#[from]` で Network へ
- **`T-ER025` の vec に `BraveError::ParseJson` を統合**: 当初 `T-ER029` として別 test を切り出していたが、Decode-class の Internal 確認は 1 ループでカバーするほうが将来の新 variant 追加が 1 行で済む

## How to Test

```bash
cargo test --offline                                # 346 unit + 11 integration pass
cargo clippy --offline --all-targets -- -D warnings # clean
```

新規 regression テスト:
- `T-GH012` — github mock 200 + malformed JSON → `GitHubError::Decode`
- `T-ER030` — `GitHubError::Api { code: 401 }` → UsageError(64) + `GITHUB_TOKEN` を含む next_step
- `T-ER025` (拡張) — `BraveError::ParseJson` を `Decode`/`SlackError::Decode` と同じ Internal(70) vec に追加

## Related

- Refs #101 (部分対応)
- ADR-0065 priority 1 (USAGE_ERROR for auth) + priority 5 (INTERNAL for schema drift) 整合適用
