### PR TITLE
github/slack を validate_https + 個別 skip flag に移行 (RC-03)

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -147,7 +147,7 @@ impl BraveClient {
         search_lang: Option<&str>,
     ) -> Result<WebSearchResponse, BraveError> {
         if self.should_check_https() {
-            validate_https(&self.base_url)?;
+            validate_https(&self.base_url, || BraveError::InsecureBaseUrl)?;
         }
         let url = build_url(&self.base_url, query, search_lang)?;
 

--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -125,11 +125,7 @@ impl BraveClient {
         }
     }
 
-    /// Returns `true` when `send_request` should run [`validate_https`]
-    /// against `self.base_url`. Production builds always check; test
-    /// builds honor the per-client `skip_https_check` flag so wiremock
-    /// servers on `http://127.0.0.1` keep working without re-introducing
-    /// a global `cfg!(test)` bypass on the production codepath.
+    /// Test-only override of the production HTTPS gate. See [`validate_https`].
     fn should_check_https(&self) -> bool {
         #[cfg(test)]
         {

--- a/src/github.rs
+++ b/src/github.rs
@@ -125,10 +125,7 @@ impl GitHubClient {
         }
     }
 
-    /// Returns `true` when `request` should run [`validate_https`] against the
-    /// composed URL. Production builds always check; test builds honor the
-    /// per-client `skip_https_check` flag so wiremock servers on
-    /// `http://127.0.0.1` keep working without a global `cfg!(test)` bypass.
+    /// Test-only override of the production HTTPS gate. See [`validate_https`].
     fn should_check_https(&self) -> bool {
         #[cfg(test)]
         {
@@ -621,18 +618,6 @@ mod http_tests {
                 retry_after: Some(_)
             })
         ));
-    }
-
-    /// [T-GH013] HTTPS gating uses the generic validate_https with a github-owned
-    /// `InsecureUrl` variant. The closure is the only construction site for the
-    /// variant, so a successful URL never instantiates it.
-    #[test]
-    fn validate_https_with_insecure_url_yields_insecure_url_variant() {
-        let result = validate_https("http://insecure.example", || GitHubError::InsecureUrl);
-        assert!(
-            matches!(result, Err(GitHubError::InsecureUrl)),
-            "expected GitHubError::InsecureUrl for http URL, got: {result:?}"
-        );
     }
 
     /// [T-GH012] 2xx response with malformed JSON classifies as Decode (issue #101).

--- a/src/github.rs
+++ b/src/github.rs
@@ -19,7 +19,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
-use crate::redacted::{Redacted, assert_https};
+use crate::redacted::{Redacted, validate_https};
 
 use types::{
     BlobResponse, ContentsResponse, IssueInfo, PullInfo, ReleaseInfo, RepoInfo, TreeResponse,
@@ -74,6 +74,9 @@ pub(crate) enum GitHubError {
 
     #[error("{0}")]
     NonUtf8(String),
+
+    #[error("Insecure URL: HTTPS required for token-bearing request")]
+    InsecureUrl,
 }
 
 /// HTTP client for the GitHub REST API v3.
@@ -86,6 +89,11 @@ pub(crate) struct GitHubClient {
     http: Client,
     token: Option<Redacted>,
     base_url: String,
+    /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
+    /// Production constructors leave this `false` so `request` always runs
+    /// `validate_https`; only `with_base_url` opts in.
+    #[cfg(test)]
+    skip_https_check: bool,
 }
 
 impl GitHubClient {
@@ -102,6 +110,8 @@ impl GitHubClient {
             http,
             token,
             base_url: API_BASE.to_owned(),
+            #[cfg(test)]
+            skip_https_check: false,
         }
     }
 
@@ -111,11 +121,30 @@ impl GitHubClient {
             http,
             token: None,
             base_url: base_url.to_owned(),
+            skip_https_check: true,
         }
     }
 
-    fn request(&self, path: &str) -> reqwest::RequestBuilder {
+    /// Returns `true` when `request` should run [`validate_https`] against the
+    /// composed URL. Production builds always check; test builds honor the
+    /// per-client `skip_https_check` flag so wiremock servers on
+    /// `http://127.0.0.1` keep working without a global `cfg!(test)` bypass.
+    fn should_check_https(&self) -> bool {
+        #[cfg(test)]
+        {
+            !self.skip_https_check
+        }
+        #[cfg(not(test))]
+        {
+            true
+        }
+    }
+
+    fn request(&self, path: &str) -> Result<reqwest::RequestBuilder, GitHubError> {
         let url = format!("{}{path}", self.base_url);
+        if self.should_check_https() {
+            validate_https(&url, || GitHubError::InsecureUrl)?;
+        }
         let mut req = self
             .http
             .get(&url)
@@ -123,10 +152,9 @@ impl GitHubClient {
             .header("User-Agent", crate::USER_AGENT)
             .header("X-GitHub-Api-Version", "2022-11-28");
         if let Some(ref token) = self.token {
-            assert_https(&url);
             req = req.header("Authorization", format!("Bearer {}", token.expose()));
         }
-        req
+        Ok(req)
     }
 
     async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T, GitHubError> {
@@ -144,7 +172,7 @@ impl GitHubClient {
 
     async fn get_json_once<T: DeserializeOwned>(&self, path: &str) -> Result<T, GitHubError> {
         debug!(path, "github API request");
-        let response = self.request(path).send().await?;
+        let response = self.request(path)?.send().await?;
         let status = response.status();
         debug!(path, status = %status, "github API response");
         match status.as_u16() {
@@ -593,6 +621,18 @@ mod http_tests {
                 retry_after: Some(_)
             })
         ));
+    }
+
+    /// [T-GH013] HTTPS gating uses the generic validate_https with a github-owned
+    /// `InsecureUrl` variant. The closure is the only construction site for the
+    /// variant, so a successful URL never instantiates it.
+    #[test]
+    fn validate_https_with_insecure_url_yields_insecure_url_variant() {
+        let result = validate_https("http://insecure.example", || GitHubError::InsecureUrl);
+        assert!(
+            matches!(result, Err(GitHubError::InsecureUrl)),
+            "expected GitHubError::InsecureUrl for http URL, got: {result:?}"
+        );
     }
 
     /// [T-GH012] 2xx response with malformed JSON classifies as Decode (issue #101).

--- a/src/redacted.rs
+++ b/src/redacted.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use crate::brave::client::BraveError;
-
 #[derive(Clone)]
 pub(crate) struct Redacted(String);
 
@@ -21,18 +19,18 @@ impl fmt::Debug for Redacted {
     }
 }
 
-/// Returns `Ok(())` when `url` begins with `https://`; otherwise yields
-/// `BraveError::InsecureBaseUrl`. Used as a defense-in-depth check before
-/// sending an API key over HTTP.
+/// Returns `Ok(())` when `url` begins with `https://`; otherwise yields the
+/// error produced by `err`. Each backend supplies its own error variant so
+/// the helper stays decoupled from any single client's error enum.
 ///
 /// Unlike [`assert_https`], this function returns a `Result` and is never
 /// bypassed in test builds, so callers can exercise the rejection path
 /// directly.
-pub(crate) fn validate_https(url: &str) -> Result<(), BraveError> {
+pub(crate) fn validate_https<E>(url: &str, err: impl FnOnce() -> E) -> Result<(), E> {
     if url.starts_with("https://") {
         Ok(())
     } else {
-        Err(BraveError::InsecureBaseUrl)
+        Err(err())
     }
 }
 
@@ -65,16 +63,16 @@ mod tests {
     // T-RC004: validate_https_rejects_non_https_and_empty
     /// FR-004 / FR-005: `validate_https` must reject any input that does not begin with
     /// `https://`, including plain `http://` URLs and the empty string. Both surface as
-    /// `BraveError::InsecureBaseUrl`.
+    /// the caller-supplied error variant.
     #[test]
     fn validate_https_rejects_non_https_and_empty() {
-        let http_result = validate_https("http://insecure.example");
+        let http_result = validate_https("http://insecure.example", || BraveError::InsecureBaseUrl);
         assert!(
             matches!(http_result, Err(BraveError::InsecureBaseUrl)),
             "expected InsecureBaseUrl for http URL, got: {http_result:?}"
         );
 
-        let empty_result = validate_https("");
+        let empty_result = validate_https("", || BraveError::InsecureBaseUrl);
         assert!(
             matches!(empty_result, Err(BraveError::InsecureBaseUrl)),
             "expected InsecureBaseUrl for empty URL, got: {empty_result:?}"
@@ -86,7 +84,25 @@ mod tests {
     /// validation and return `Ok(())`.
     #[test]
     fn validate_https_accepts_https_url() {
-        let result = validate_https("https://api.search.brave.com/res/v1/web/search");
+        let result = validate_https("https://api.search.brave.com/res/v1/web/search", || {
+            BraveError::InsecureBaseUrl
+        });
         assert!(matches!(result, Ok(())), "expected Ok, got: {result:?}");
+    }
+
+    /// [T-RC007] `validate_https` is generic over the error type so each backend
+    /// can plug its own variant. The closure runs only on failure; a passing
+    /// URL never instantiates the error.
+    #[test]
+    fn validate_https_propagates_caller_supplied_error_type() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct CallerError;
+
+        let rejected: Result<(), CallerError> = validate_https("http://insecure", || CallerError);
+        assert_eq!(rejected, Err(CallerError));
+
+        let accepted: Result<(), CallerError> =
+            validate_https("https://ok.example", || CallerError);
+        assert_eq!(accepted, Ok(()));
     }
 }

--- a/src/redacted.rs
+++ b/src/redacted.rs
@@ -22,10 +22,8 @@ impl fmt::Debug for Redacted {
 /// Returns `Ok(())` when `url` begins with `https://`; otherwise yields the
 /// error produced by `err`. Each backend supplies its own error variant so
 /// the helper stays decoupled from any single client's error enum. Callers
-/// gate the call with a per-client `skip_https_check` flag (see
-/// `BraveClient::should_check_https` / `GitHubClient::should_check_https` /
-/// `SlackClient::should_check_https`) when targeting wiremock servers on
-/// `http://127.0.0.1`.
+/// gate the call with a per-client `should_check_https` so wiremock servers
+/// on `http://127.0.0.1` keep working in tests.
 pub(crate) fn validate_https<E>(url: &str, err: impl FnOnce() -> E) -> Result<(), E> {
     if url.starts_with("https://") {
         Ok(())
@@ -37,7 +35,6 @@ pub(crate) fn validate_https<E>(url: &str, err: impl FnOnce() -> E) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::brave::client::BraveError;
 
     /// [T-RD001] Redacted value hides contents in Debug output
     #[test]
@@ -46,49 +43,24 @@ mod tests {
         assert_eq!(format!("{secret:?}"), "[REDACTED]");
     }
 
-    // T-RC004: validate_https_rejects_non_https_and_empty
-    /// FR-004 / FR-005: `validate_https` must reject any input that does not begin with
-    /// `https://`, including plain `http://` URLs and the empty string. Both surface as
-    /// the caller-supplied error variant.
+    // T-RC007: validate_https_is_generic_over_caller_error_type
+    /// FR-004 / FR-005: `validate_https` rejects any input that does not begin
+    /// with `https://` (plain `http://`, empty string) and accepts a real
+    /// `https://` URL. The error variant is whatever the closure constructs,
+    /// so each backend plugs in its own type. The closure runs only on
+    /// failure; a passing URL never instantiates the error.
     #[test]
-    fn validate_https_rejects_non_https_and_empty() {
-        let http_result = validate_https("http://insecure.example", || BraveError::InsecureBaseUrl);
-        assert!(
-            matches!(http_result, Err(BraveError::InsecureBaseUrl)),
-            "expected InsecureBaseUrl for http URL, got: {http_result:?}"
-        );
-
-        let empty_result = validate_https("", || BraveError::InsecureBaseUrl);
-        assert!(
-            matches!(empty_result, Err(BraveError::InsecureBaseUrl)),
-            "expected InsecureBaseUrl for empty URL, got: {empty_result:?}"
-        );
-    }
-
-    // T-RC005: validate_https_accepts_https_url
-    /// FR-004 / FR-005: a real `https://` URL (production `API_BASE`) must pass
-    /// validation and return `Ok(())`.
-    #[test]
-    fn validate_https_accepts_https_url() {
-        let result = validate_https("https://api.search.brave.com/res/v1/web/search", || {
-            BraveError::InsecureBaseUrl
-        });
-        assert!(matches!(result, Ok(())), "expected Ok, got: {result:?}");
-    }
-
-    /// [T-RC007] `validate_https` is generic over the error type so each backend
-    /// can plug its own variant. The closure runs only on failure; a passing
-    /// URL never instantiates the error.
-    #[test]
-    fn validate_https_propagates_caller_supplied_error_type() {
+    fn validate_https_is_generic_over_caller_error_type() {
         #[derive(Debug, PartialEq, Eq)]
         struct CallerError;
 
-        let rejected: Result<(), CallerError> = validate_https("http://insecure", || CallerError);
-        assert_eq!(rejected, Err(CallerError));
+        let http: Result<(), CallerError> = validate_https("http://insecure", || CallerError);
+        assert_eq!(http, Err(CallerError));
 
-        let accepted: Result<(), CallerError> =
-            validate_https("https://ok.example", || CallerError);
-        assert_eq!(accepted, Ok(()));
+        let empty: Result<(), CallerError> = validate_https("", || CallerError);
+        assert_eq!(empty, Err(CallerError));
+
+        let https: Result<(), CallerError> = validate_https("https://ok.example", || CallerError);
+        assert_eq!(https, Ok(()));
     }
 }

--- a/src/redacted.rs
+++ b/src/redacted.rs
@@ -21,31 +21,17 @@ impl fmt::Debug for Redacted {
 
 /// Returns `Ok(())` when `url` begins with `https://`; otherwise yields the
 /// error produced by `err`. Each backend supplies its own error variant so
-/// the helper stays decoupled from any single client's error enum.
-///
-/// Unlike [`assert_https`], this function returns a `Result` and is never
-/// bypassed in test builds, so callers can exercise the rejection path
-/// directly.
+/// the helper stays decoupled from any single client's error enum. Callers
+/// gate the call with a per-client `skip_https_check` flag (see
+/// `BraveClient::should_check_https` / `GitHubClient::should_check_https` /
+/// `SlackClient::should_check_https`) when targeting wiremock servers on
+/// `http://127.0.0.1`.
 pub(crate) fn validate_https<E>(url: &str, err: impl FnOnce() -> E) -> Result<(), E> {
     if url.starts_with("https://") {
         Ok(())
     } else {
         Err(err())
     }
-}
-
-/// Panicking HTTPS check retained for backends that have not migrated to
-/// the [`validate_https`] `Result` form. Bypassed under `cfg!(test)` so
-/// wiremock servers on `http://127.0.0.1` keep working.
-// FIXME: callers `github.rs::request` and `slack.rs::api_get_once` still
-//        use this panic form; migrate both to validate_https + a per-client
-//        skip flag (parallel to BraveClient::skip_https_check) and delete
-//        this function.
-pub(crate) fn assert_https(url: &str) {
-    assert!(
-        url.starts_with("https://") || cfg!(test),
-        "credentials must only be sent over HTTPS"
-    );
 }
 
 #[cfg(test)]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -177,10 +177,7 @@ impl SlackClient {
         }
     }
 
-    /// Returns `true` when `api_get_once` should run [`validate_https`] against
-    /// the composed URL. Production builds always check; test builds honor the
-    /// per-client `skip_https_check` flag so wiremock servers on
-    /// `http://127.0.0.1` keep working without a global `cfg!(test)` bypass.
+    /// Test-only override of the production HTTPS gate. See [`validate_https`].
     fn should_check_https(&self) -> bool {
         #[cfg(test)]
         {
@@ -556,23 +553,11 @@ fn is_retriable(e: &SlackError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::redacted::validate_https;
 
     #[allow(dead_code)]
     #[derive(serde::Deserialize)]
     struct DummyBody {
         ok: bool,
-    }
-
-    /// [T-SK030] HTTPS gating uses validate_https with a slack-owned `InsecureUrl`
-    /// variant. The closure is the only construction site for the variant.
-    #[test]
-    fn validate_https_with_insecure_url_yields_insecure_url_variant() {
-        let result = validate_https("http://insecure.example", || SlackError::InsecureUrl);
-        assert!(
-            matches!(result, Err(SlackError::InsecureUrl)),
-            "expected SlackError::InsecureUrl for http URL, got: {result:?}"
-        );
     }
 
     mod http_tests {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use tracing::{debug, info, warn};
 
 use crate::fetch::converter::escape_yaml;
-use crate::redacted::{Redacted, assert_https};
+use crate::redacted::{Redacted, validate_https};
 use crate::retry::{parse_retry_after, retry_after_within_cap, retry_with_rate_limit};
 
 #[derive(Debug, thiserror::Error)]
@@ -30,6 +30,9 @@ pub(crate) enum SlackError {
 
     #[error("Slack response decode error: {0}")]
     Decode(String),
+
+    #[error("Insecure URL: HTTPS required for token-bearing request")]
+    InsecureUrl,
 }
 
 #[derive(Debug, Clone)]
@@ -136,6 +139,11 @@ pub(crate) struct SlackClient {
     http: Client,
     token: Redacted,
     base_url: String,
+    /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
+    /// Production constructors leave this `false` so `api_get_once` always
+    /// runs `validate_https`; only `with_base_url` opts in.
+    #[cfg(test)]
+    skip_https_check: bool,
 }
 
 const API_BASE: &str = "https://slack.com/api";
@@ -146,6 +154,8 @@ impl SlackClient {
             http,
             token,
             base_url: API_BASE.to_owned(),
+            #[cfg(test)]
+            skip_https_check: false,
         }
     }
 
@@ -163,6 +173,22 @@ impl SlackClient {
             http,
             token: Redacted::new("xoxp-test"),
             base_url: base_url.to_owned(),
+            skip_https_check: true,
+        }
+    }
+
+    /// Returns `true` when `api_get_once` should run [`validate_https`] against
+    /// the composed URL. Production builds always check; test builds honor the
+    /// per-client `skip_https_check` flag so wiremock servers on
+    /// `http://127.0.0.1` keep working without a global `cfg!(test)` bypass.
+    fn should_check_https(&self) -> bool {
+        #[cfg(test)]
+        {
+            !self.skip_https_check
+        }
+        #[cfg(not(test))]
+        {
+            true
         }
     }
 
@@ -194,7 +220,9 @@ impl SlackClient {
             url.query_pairs_mut().append_pair(k, v);
         }
 
-        assert_https(url.as_str());
+        if self.should_check_https() {
+            validate_https(url.as_str(), || SlackError::InsecureUrl)?;
+        }
 
         let resp = self
             .http
@@ -528,11 +556,23 @@ fn is_retriable(e: &SlackError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::redacted::validate_https;
 
     #[allow(dead_code)]
     #[derive(serde::Deserialize)]
     struct DummyBody {
         ok: bool,
+    }
+
+    /// [T-SK030] HTTPS gating uses validate_https with a slack-owned `InsecureUrl`
+    /// variant. The closure is the only construction site for the variant.
+    #[test]
+    fn validate_https_with_insecure_url_yields_insecure_url_variant() {
+        let result = validate_https("http://insecure.example", || SlackError::InsecureUrl);
+        assert!(
+            matches!(result, Err(SlackError::InsecureUrl)),
+            "expected SlackError::InsecureUrl for http URL, got: {result:?}"
+        );
     }
 
     mod http_tests {
@@ -877,9 +917,9 @@ parent body
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, ResponseTemplate};
 
-        /// [T-SK025] SlackClient::new constructs a client that reaches the API
+        /// [T-SK025] SlackClient::with_base_url constructs a client that reaches a wiremock server
         #[tokio::test]
-        async fn t010_new_constructs_usable_client() {
+        async fn t010_with_base_url_constructs_usable_client() {
             let Some(server) = try_spawn_mock_server("slack::http").await else {
                 return;
             };
@@ -891,9 +931,7 @@ parent body
                 .mount(&server)
                 .await;
 
-            let token = Redacted::new("xoxp-test-token");
-            let mut client = SlackClient::new(Client::new(), token);
-            client.base_url = server.uri();
+            let client = SlackClient::with_base_url(Client::new(), &server.uri());
 
             let result: Result<DummyBody, _> = client.api_get_once("auth.test", &[]).await;
             assert!(result.is_ok());

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -307,6 +307,8 @@ impl From<SlackError> for ScoutError {
             SlackError::Network(_) => transient_with_network_hint(&e),
             // Priority 4: TIMEOUT
             SlackError::Timeout(_) => timeout_with_retry_hint(&e),
+            // Priority 2: DATA_ERROR (insecure URL — peer to BraveError::InsecureBaseUrl)
+            SlackError::InsecureUrl => Self::data_error(e.to_string()),
             // Priority 5: INTERNAL — scout-side bug (unexpected schema)
             SlackError::Decode(_) => Self::internal_bug(e.to_string()),
         }

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -288,6 +288,8 @@ impl From<SlackError> for ScoutError {
             // Priority 1: USAGE_ERROR
             SlackError::TokenNotSet => Self::user_error(e.to_string())
                 .with_next_step("Export a User OAuth token to SLACK_TOKEN (xoxp-…)"),
+            // Priority 2: DATA_ERROR (insecure URL — peer to BraveError::InsecureBaseUrl)
+            SlackError::InsecureUrl => Self::data_error(e.to_string()),
             // Slack API surfaces failures as error code strings (not HTTP status),
             // so per-string classification replaces the priority-2 HTTP arm.
             SlackError::Api { error } => match error.as_str() {
@@ -307,8 +309,6 @@ impl From<SlackError> for ScoutError {
             SlackError::Network(_) => transient_with_network_hint(&e),
             // Priority 4: TIMEOUT
             SlackError::Timeout(_) => timeout_with_retry_hint(&e),
-            // Priority 2: DATA_ERROR (insecure URL — peer to BraveError::InsecureBaseUrl)
-            SlackError::InsecureUrl => Self::data_error(e.to_string()),
             // Priority 5: INTERNAL — scout-side bug (unexpected schema)
             SlackError::Decode(_) => Self::internal_bug(e.to_string()),
         }

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -198,6 +198,7 @@ impl From<github::GitHubError> for ScoutError {
                 ),
             github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string())
                 .with_next_step("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
+            github::GitHubError::InsecureUrl => Self::data_error(e.to_string()),
             github::GitHubError::Api { code, .. } if (400..500).contains(code) => {
                 Self::data_error(e.to_string())
             }

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -692,7 +692,9 @@ mod tests {
 
     /// [T-ER001b] DataError errors surface with exit 65 (EX_DATAERR per ADR-0002).
     /// Per ADR-0065 priority 2, `*Error::Api { code }` 4xx (other than 401/403/404) now
-    /// routes to DataError instead of folding onto IoError via `internal()`.
+    /// routes to DataError instead of folding onto IoError via `internal()`. The three
+    /// `Insecure*` variants (one per backend) belong here because a plain-HTTP URL is a
+    /// caller-supplied config defect, not a transient runtime failure.
     #[test]
     fn data_errors_have_exit_code_65() {
         let cases: Vec<ScoutError> = vec![
@@ -707,6 +709,7 @@ mod tests {
                 message: "unprocessable entity".into(),
             }
             .into(),
+            github::GitHubError::InsecureUrl.into(),
             FetchError::InvalidScheme.into(),
             FetchError::InternalHost.into(),
             FetchError::UnsupportedContentType("image/png".into()).into(),
@@ -720,6 +723,8 @@ mod tests {
                 message: "err".into(),
             }
             .into(),
+            BraveError::InsecureBaseUrl.into(),
+            SlackError::InsecureUrl.into(),
         ];
         for err in &cases {
             assert_eq!(err.error_kind(), ErrorCode::DataError, "{err}");


### PR DESCRIPTION
## What & Why

PR #109 (RC-02) で brave に導入した Hybrid B+ pattern (DI factory + Result-based `validate_https` + per-client skip flag) を github と slack に適用する。これまで `assert_https` (panic 形式、`cfg!(test)` で no-op) を使っていたため、production の HTTPS 強制が test path で untested だった。

完了時に `grep -n 'assert_https' src/` が 0 hits、`cfg!(test)` 分岐が `src/redacted.rs` から消える。

## Changes

- `validate_https` を generic closure 化: `<E>(url, err: impl FnOnce() -> E) -> Result<(), E>` で 3 backend が自身の error variant をプラグイン可能に
- GitHubClient + SlackClient に `#[cfg(test)] skip_https_check: bool` + `should_check_https()` + `validate_https` 呼び出し (brave と同形)
- `GitHubError::InsecureUrl` / `SlackError::InsecureUrl` variant 追加。`tools/errors.rs` で priority 2 (DataError(65)) に分類
- `assert_https` + `cfg!(test)` bypass + FIXME 削除

## Design Decisions

- **generic closure シグネチャ採用**: 共通 `HttpsCheckError` 型導入 (B 案) や `bool` 化 (C 案) と比較し、closure (A 案) を選択。callsite が `validate_https(&url, || GitHubError::InsecureUrl)?` で簡潔、crate に共通型を増やさず、brave の既存 callsite は最小 diff
- **`InsecureUrl` 文言は backend 個別**: 共通定数化はしない。brave の `InsecureBaseUrl` は固定 `base_url` のみ検証、github/slack は composed URL with path を検証するため、命名と意味が validated value を tracks
- **テスト統合**: 初版では backend ごとに T-RC007 / T-GH013 / T-SK030 と並べたが、polish review で 3 テストが型システムで保証される同じ性質を再証明していると判明。1 つの `validate_https_is_generic_over_caller_error_type` (T-RC007) に統合。production wiring (`request()` / `api_get_once()` 内の呼び出し) は手動 review + 既存 wiremock test で確認

## How to Test

```bash
cargo test --offline                                # 345 unit + 11 integration pass
cargo clippy --offline --all-targets -- -D warnings # clean
grep -n 'assert_https' src/                         # 0 hits
```

## Related

- Closes #110
- 関連 PR: #109 (RC-02 brave migration), #112 (sysexits 分類修正 / #101)
- ADR-0007 (`docs/decisions/0007-unify-brave-client-init-via-factory-and-result-based-https-check.md`)
