### PR TITLE
Slack 内部エラー誤分類: "message not found" と ok:false 欠落の修正 (#114)

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -247,8 +247,7 @@ impl SlackClient {
         if body.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
             // ok:false with a missing `error` field is a Slack API contract
             // violation, not a user-fixable failure — route through Decode so
-            // it classifies as Internal(70) instead of the "unknown" UsageError
-            // path that the previous `unwrap_or("unknown")` produced (issue #114).
+            // it classifies as Internal(70) rather than UsageError.
             let Some(error) = body.get("error").and_then(|v| v.as_str()) else {
                 return Err(SlackError::Decode(
                     "Slack response had `ok: false` without an `error` field".into(),

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -245,10 +245,15 @@ impl SlackClient {
         })?;
 
         if body.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
-            let error = body
-                .get("error")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
+            // ok:false with a missing `error` field is a Slack API contract
+            // violation, not a user-fixable failure — route through Decode so
+            // it classifies as Internal(70) instead of the "unknown" UsageError
+            // path that the previous `unwrap_or("unknown")` produced (issue #114).
+            let Some(error) = body.get("error").and_then(|v| v.as_str()) else {
+                return Err(SlackError::Decode(
+                    "Slack response had `ok: false` without an `error` field".into(),
+                ));
+            };
             if error == "ratelimited" {
                 warn!(retry_after_secs = retry_after, "Slack API rate limited");
                 return Err(SlackError::RateLimited { retry_after });
@@ -555,7 +560,7 @@ mod tests {
     use super::*;
 
     #[allow(dead_code)]
-    #[derive(serde::Deserialize)]
+    #[derive(Debug, serde::Deserialize)]
     struct DummyBody {
         ok: bool,
     }
@@ -651,6 +656,31 @@ mod tests {
                 result,
                 Err(SlackError::Api { error }) if error == "channel_not_found"
             ));
+        }
+
+        /// [T-SK031] ok:false without an `error` field surfaces as SlackError::Decode
+        /// (issue #114 condition 5). The previous code substituted the literal
+        /// "unknown" string and mapped to UsageError; a missing `error` is a
+        /// Slack API contract violation, not a user-fixable failure.
+        #[tokio::test]
+        async fn api_get_once_ok_false_without_error_field_returns_decode() {
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
+            Mock::given(method("GET"))
+                .and(path("/test.method"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": false})),
+                )
+                .mount(&server)
+                .await;
+
+            let client = SlackClient::with_base_url(Client::new(), &server.uri());
+            let result: Result<DummyBody, _> = client.api_get_once("test.method", &[]).await;
+            assert!(
+                matches!(result, Err(SlackError::Decode(_))),
+                "expected SlackError::Decode for ok:false without error field, got: {result:?}"
+            );
         }
     }
 

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -293,10 +293,9 @@ impl From<SlackError> for ScoutError {
             // Slack API surfaces failures as error code strings (not HTTP status),
             // so per-string classification replaces the priority-2 HTTP arm.
             SlackError::Api { error } => match error.as_str() {
-                // Priority 3: NOT_FOUND. The underscore forms come from Slack's
-                // API; "message not found" (with a space) is scout's own string
-                // emitted from `fetch_message` when the resolved messages list
-                // is empty — same NotFound class as the API-native variants.
+                // Priority 3: NOT_FOUND. Underscore forms are Slack-native error
+                // codes; "message not found" (space) is scout's own string from
+                // `fetch_message` when the resolved messages list is empty.
                 "channel_not_found" | "message_not_found" | "thread_not_found"
                 | "message not found" => Self::not_found(e.to_string()),
                 // Priority 4: TEMP_FAILURE

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -293,10 +293,12 @@ impl From<SlackError> for ScoutError {
             // Slack API surfaces failures as error code strings (not HTTP status),
             // so per-string classification replaces the priority-2 HTTP arm.
             SlackError::Api { error } => match error.as_str() {
-                // Priority 3: NOT_FOUND
-                "channel_not_found" | "message_not_found" | "thread_not_found" => {
-                    Self::not_found(e.to_string())
-                }
+                // Priority 3: NOT_FOUND. The underscore forms come from Slack's
+                // API; "message not found" (with a space) is scout's own string
+                // emitted from `fetch_message` when the resolved messages list
+                // is empty — same NotFound class as the API-native variants.
+                "channel_not_found" | "message_not_found" | "thread_not_found"
+                | "message not found" => Self::not_found(e.to_string()),
                 // Priority 4: TEMP_FAILURE
                 "internal_error" | "service_unavailable" | "fatal_error" => {
                     transient_with_retry_hint(&e)
@@ -553,6 +555,20 @@ mod tests {
             error: "invalid_auth".to_owned(),
         });
         assert_eq!(err.error_kind(), ErrorCode::UsageError);
+    }
+
+    /// [T-ER031] scout-internal "message not found" (space form) classifies as NotFound
+    /// (issue #114 condition 4). scout returns this string from `fetch_message`
+    /// when the resolved messages list is empty; it must classify as the same
+    /// NotFound(66) class as Slack's native `message_not_found` (underscore form).
+    #[test]
+    fn slack_space_message_not_found_classifies_as_not_found() {
+        use crate::slack::SlackError;
+        let err = ScoutError::from(SlackError::Api {
+            error: "message not found".to_owned(),
+        });
+        assert_eq!(err.error_kind(), ErrorCode::NotFound);
+        assert_eq!(err.exit_code(), 66, "expected EX_NOINPUT (66)");
     }
 
     /// [T-ER023] ADR-0065 priority 2 wins over priority 5 for Api 4xx codes.


### PR DESCRIPTION
## What & Why

issue #101 から切り出した受け入れ条件 4, 5 を対応。Slack 経由で取得する一次ソースで起きる 2 種類の誤分類を修正し、AI エージェントが受け取る exit code の観測精度を整える。

## Changes

- **条件 4**: scout 自身が `fetch_message` の `messages.is_empty()` 時に返す `SlackError::Api { error: "message not found" }` (スペース版) を `tools/errors.rs` の NotFound 文字列リストに追加。Slack ネイティブの `message_not_found` (アンダースコア) と同じ NotFound(66) に分類
- **条件 5**: `slack.rs::api_get_once` の `unwrap_or("unknown")` を let-else に置換。Slack が `{"ok": false}` で `error` field なしを返した場合 (API 契約違反、頻度極低) を `SlackError::Decode` 経由で Internal(70) retryable=false に振り替え

## Design Decisions

- **typed variant 化 (例: `SlackError::NotFound` / `SlackError::EmptyMessage`) は別 issue 候補**: 文字列リスト追加で最小 diff で目的達成、scope 縮小。typed variant 化は scout 全体の error 設計変更を伴うので、必要なら別途議論
- **scout 起源と Slack 起源の string 共存**: アンダースコア (Slack ネイティブ) とスペース (scout 起源) を同じ NotFound arm にまとめる。producer (`slack.rs:372`) と classifier (`tools/errors.rs:301`) の string 同期は 2 callsite で DRY 3+ gate 未満。3 callsite 目が出たら typed 化検討

## How to Test

```bash
cargo test --offline                                # 347 unit + 11 integration pass
cargo clippy --offline --all-targets -- -D warnings # clean
```

新規 regression test:
- `T-ER031` (`tools/errors.rs`): `SlackError::Api { error: "message not found" }` → NotFound(66) + exit 66
- `T-SK031` (`slack.rs`): wiremock `{"ok": false}` (error field 欠落) → `SlackError::Decode`

## Related

- Closes #114
- 親 issue: #101 (PR #112 で部分対応、本 PR で残作業 条件 4+5 を完了)
- ADR-0065 priority 3 (NotFound) / priority 5 (Internal)
