### PR TITLE
ci: cargo test → cargo nextest run に移行

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "120s", terminate-after = 2 }
+final-status-level = "flaky"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,5 +3,8 @@ fail-fast = false
 
 [profile.ci]
 fail-fast = false
+# js-rendering tests have observed runs ~30s; 120s gives ample headroom and the
+# terminate-after cap bounds total wait to 4 min even on a hang.
 slow-timeout = { period = "120s", terminate-after = 2 }
+# Surface flaky tests in CI logs; default "pass" hides them on retry success.
 final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo check --features js-rendering
 
       - name: Install nextest
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,16 @@ jobs:
       - name: Check (js-rendering)
         run: cargo check --features js-rendering
 
+      - name: Install nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
-        run: cargo test
+        run: cargo nextest run --profile ci
 
       - name: Test (js-rendering)
-        run: cargo test --features js-rendering
+        run: cargo nextest run --features js-rendering --profile ci
 
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## What & Why

CI の `cargo test` を `cargo nextest run` に置換。nextest はテストを並列プロセスで実行し、per-test isolation + slow-test の deadline 制御 + flaky 検出を提供する。`thkt/rurico` で先行移行 ([rurico@17c10f5](https://github.com/thkt/rurico/commit/17c10f5)) しており、cli 配下リポへの横展開の一環。

## Changes

- `.config/nextest.toml` 新規作成: `default` + `ci` profile
  - `fail-fast = false`: CI で全テスト結果を取得
  - `slow-timeout = { period = "120s", terminate-after = 2 }`: hang 時 4 分で強制終了 (CI 上限 15 分内に収まる)
  - `final-status-level = "flaky"`: 再試行で pass した flaky を CI ログに surface
- `.github/workflows/ci.yml`: `Test` step (features なし / `js-rendering` あり) を `cargo nextest run --profile ci` に置換。`taiki-e/install-action` で nextest を SHA pin インストール (v2.78.1)

## Design Decisions

- **profile を `default` + `ci` に分割**: `fail-fast = false` を `default` にも置くことでローカル開発者にも CI と同じ挙動。`slow-timeout` 等は `ci` 専用にして、ローカルでは timeout なしで debug しやすく
- **`final-status-level = "flaky"`**: デフォルト `pass` は flaky 通過を見逃すので、CI ログで flaky を明示
- **`slow-timeout` の 120s 設定**: 実測 ~30s のテスト suite に対し 4 倍のバッファ。`terminate-after = 2` で hang 時の最悪ケースを 4 分に bound、CI 上限 15 分内に収まる

## How to Test

ローカル検証:

```bash
cargo nextest run --profile ci                          # 358 passed, 0 failed
cargo nextest run --features js-rendering --profile ci  # 359 passed (1 leaky)
```

CI 検証は本 PR の Actions ログで確認。

## Related

- Closes #106
- 参考: [rurico migration](https://github.com/thkt/rurico/commit/17c10f5)
- [nextest configuration](https://nexte.st/docs/configuration/)
