### PR TITLE
fix(retry): mid-stream body drop を transient として retry 経路に乗せる (issue #113)

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -29,7 +29,7 @@ const API_BASE: &str = "https://api.github.com";
 const TOKEN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 use crate::retry::{
-    is_transient_decode, is_transient_network, parse_retry_after, retry_after_within_cap,
+    is_schema_decode_fail, is_transient_network, parse_retry_after, retry_after_within_cap,
     retry_with_rate_limit,
 };
 
@@ -174,11 +174,11 @@ impl GitHubClient {
         let status = response.status();
         debug!(path, status = %status, "github API response");
         match status.as_u16() {
-            // Schema mismatch is a scout-side invariant — non-retryable.
-            // Transport errors (timeout, connect, mid-stream body drop — issue
-            // #113) fall through to Network so the retry loop can recover.
+            // Schema fail → Decode (terminal). Transport drop / connect /
+            // timeout → Network → retry loop. See `is_schema_decode_fail`
+            // for the source-chain discrimination (issue #113).
             200..=299 => response.json().await.map_err(|e| {
-                if e.is_decode() && !is_transient_decode(&e) {
+                if is_schema_decode_fail(&e) {
                     GitHubError::Decode(e.to_string())
                 } else {
                     e.into()
@@ -657,7 +657,11 @@ mod http_tests {
     /// every attempt would route to `GitHubError::Decode` → Internal(70)
     /// retryable=false. With it, attempts route to `GitHubError::Network` →
     /// TempFailure(75) and the retry loop kicks in.
-    #[tokio::test]
+    ///
+    /// `start_paused = true` advances the tokio runtime past `retry_with`'s
+    /// `sleep` calls as soon as the task parks; the std::thread-driven
+    /// TcpListener is unaffected. Total wall time stays under 100 ms.
+    #[tokio::test(start_paused = true)]
     async fn get_json_2xx_mid_stream_drop_exhausts_retries() {
         let expected_attempts = usize::try_from(MAX_RETRIES).expect("MAX_RETRIES fits usize");
         let Some((url, counter, handle)) = spawn_mid_stream_drop_server(expected_attempts) else {

--- a/src/github.rs
+++ b/src/github.rs
@@ -29,7 +29,8 @@ const API_BASE: &str = "https://api.github.com";
 const TOKEN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 use crate::retry::{
-    is_transient_network, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
+    is_transient_decode, is_transient_network, parse_retry_after, retry_after_within_cap,
+    retry_with_rate_limit,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -174,10 +175,10 @@ impl GitHubClient {
         debug!(path, status = %status, "github API response");
         match status.as_u16() {
             // Schema mismatch is a scout-side invariant — non-retryable.
-            // Transport errors (timeout, connect) fall through to Network so
-            // the retry loop can recover.
+            // Transport errors (timeout, connect, mid-stream body drop — issue
+            // #113) fall through to Network so the retry loop can recover.
             200..=299 => response.json().await.map_err(|e| {
-                if e.is_decode() {
+                if e.is_decode() && !is_transient_decode(&e) {
                     GitHubError::Decode(e.to_string())
                 } else {
                     e.into()
@@ -413,8 +414,11 @@ async fn resolve_token_with(env_reader: impl Fn(&str) -> Option<String>) -> Opti
 
 #[cfg(test)]
 mod http_tests {
+    use std::sync::atomic::Ordering;
+
     use super::*;
-    use crate::test_support::try_spawn_mock_server;
+    use crate::retry::MAX_RETRIES;
+    use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
@@ -643,5 +647,36 @@ mod http_tests {
             matches!(result, Err(GitHubError::Decode(_))),
             "expected GitHubError::Decode for 2xx malformed JSON, got: {result:?}"
         );
+    }
+
+    /// [T-GH013] 2xx mid-stream body drop is treated as transient and the
+    /// retry loop exhausts MAX_RETRIES attempts before failing (issue #113).
+    ///
+    /// reqwest 0.13 surfaces a mid-stream drop as `is_decode() == true` with
+    /// an io::Error in the source chain. Without `is_transient_decode`,
+    /// every attempt would route to `GitHubError::Decode` → Internal(70)
+    /// retryable=false. With it, attempts route to `GitHubError::Network` →
+    /// TempFailure(75) and the retry loop kicks in.
+    #[tokio::test]
+    async fn get_json_2xx_mid_stream_drop_exhausts_retries() {
+        let expected_attempts = usize::try_from(MAX_RETRIES).expect("MAX_RETRIES fits usize");
+        let Some((url, counter, handle)) = spawn_mid_stream_drop_server(expected_attempts) else {
+            return;
+        };
+
+        let client = GitHubClient::with_base_url(Client::new(), &url);
+        let result: Result<RepoInfo, _> = client.get_json("/repos/owner/repo").await;
+
+        assert!(
+            matches!(result, Err(GitHubError::Network(_))),
+            "expected GitHubError::Network for exhausted mid-stream drop, got: {result:?}"
+        );
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            expected_attempts,
+            "retry loop must consume MAX_RETRIES connections"
+        );
+
+        let _ = handle.join();
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,4 +1,6 @@
+use std::error::Error as StdError;
 use std::future::Future;
+use std::io;
 use std::time::Duration;
 
 use reqwest::Error;
@@ -17,7 +19,27 @@ pub(crate) fn jittered_backoff(attempt: u32) -> u64 {
 }
 
 pub(crate) fn is_transient_network(e: &Error) -> bool {
-    e.is_connect() || e.is_timeout()
+    e.is_connect() || e.is_timeout() || is_transient_decode(e)
+}
+
+/// True when a `Decode`-classified reqwest error originates in a transport
+/// IO failure (mid-stream body drop, connection reset). Issue #113: reqwest
+/// 0.13 surfaces an `UnexpectedEof` from hyper as `is_decode() == true`,
+/// indistinguishable from a serde schema mismatch by boolean alone. Walking
+/// the source chain for any `io::Error` separates transport (retryable) from
+/// schema (terminal).
+pub(crate) fn is_transient_decode(e: &Error) -> bool {
+    if !e.is_decode() {
+        return false;
+    }
+    let mut src: Option<&dyn StdError> = e.source();
+    while let Some(cur) = src {
+        if cur.downcast_ref::<io::Error>().is_some() {
+            return true;
+        }
+        src = cur.source();
+    }
+    false
 }
 
 async fn retry_with<T, E, F, Fut>(
@@ -107,8 +129,11 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use tokio::time::Instant;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, ResponseTemplate};
 
     use super::*;
+    use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
 
     /// Test-only error type. `RateLimited` carries the server-supplied
     /// `Retry-After` (seconds); `Other` represents a non-rate-limit transient
@@ -245,6 +270,61 @@ mod tests {
             attempts.load(Ordering::SeqCst),
             1,
             "expected no retry when retry_after exceeds MAX_RETRY_AFTER_SECS"
+        );
+    }
+
+    // T-R004: is_transient_network_recognizes_mid_stream_body_drop
+    // Issue #113: reqwest 0.13 surfaces a mid-stream body drop as
+    // `is_decode() == true` with an `io::Error` (UnexpectedEof) in the
+    // source chain. is_transient_network must classify this as transient
+    // so the retry loop attempts recovery; left untreated it falls into
+    // GitHubError::Decode → Internal(70), retryable=false.
+    #[tokio::test]
+    async fn is_transient_network_recognizes_mid_stream_body_drop() {
+        let Some((url, _counter, handle)) = spawn_mid_stream_drop_server(1) else {
+            return; // loopback bind unavailable — skip
+        };
+        let client = reqwest::Client::new();
+        let resp = client.get(&url).send().await.expect("send");
+        let result: Result<serde_json::Value, _> = resp.json().await;
+        let err = result.expect_err("mid-stream drop must fail body decode");
+
+        assert!(
+            is_transient_network(&err),
+            "mid-stream drop must classify as transient (is_body={}, is_decode={}, is_connect={}, is_timeout={}): {err}",
+            err.is_body(),
+            err.is_decode(),
+            err.is_connect(),
+            err.is_timeout()
+        );
+
+        let _ = handle.join();
+    }
+
+    // T-R005: is_transient_network_rejects_schema_fail
+    // Counterpart to T-R004. A 2xx with malformed JSON also returns
+    // `is_decode() == true` but the source chain is a serde_json::Error,
+    // not an io::Error. is_transient_network must keep returning false
+    // so the error stays on the Decode → Internal(70) non-retry path.
+    #[tokio::test]
+    async fn is_transient_network_rejects_schema_fail() {
+        let Some(server) = try_spawn_mock_server("retry::is_transient_network_schema").await else {
+            return;
+        };
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{not valid json"))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let resp = client.get(server.uri()).send().await.expect("send");
+        let result: Result<serde_json::Value, _> = resp.json().await;
+        let err = result.expect_err("malformed JSON must fail body decode");
+
+        assert!(
+            !is_transient_network(&err),
+            "schema fail must not classify as transient (is_decode={}): {err}",
+            err.is_decode()
         );
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,4 +1,4 @@
-use std::error::Error as StdError;
+use std::error::Error as _;
 use std::future::Future;
 use std::io;
 use std::time::Duration;
@@ -22,17 +22,26 @@ pub(crate) fn is_transient_network(e: &Error) -> bool {
     e.is_connect() || e.is_timeout() || is_transient_decode(e)
 }
 
+/// True only when a `Decode`-classified reqwest error originates in a
+/// schema mismatch (serde failure), not a transport-level IO failure.
+/// Body-decode call sites use this to route schema fails to terminal
+/// `Decode` while letting transport drops fall through to `Network` for
+/// the retry loop (issue #113).
+pub(crate) fn is_schema_decode_fail(e: &Error) -> bool {
+    e.is_decode() && !is_transient_decode(e)
+}
+
 /// True when a `Decode`-classified reqwest error originates in a transport
 /// IO failure (mid-stream body drop, connection reset). Issue #113: reqwest
 /// 0.13 surfaces an `UnexpectedEof` from hyper as `is_decode() == true`,
 /// indistinguishable from a serde schema mismatch by boolean alone. Walking
 /// the source chain for any `io::Error` separates transport (retryable) from
 /// schema (terminal).
-pub(crate) fn is_transient_decode(e: &Error) -> bool {
+fn is_transient_decode(e: &Error) -> bool {
     if !e.is_decode() {
         return false;
     }
-    let mut src: Option<&dyn StdError> = e.source();
+    let mut src = e.source();
     while let Some(cur) = src {
         if cur.downcast_ref::<io::Error>().is_some() {
             return true;

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -9,7 +9,9 @@ use tracing::{debug, info, warn};
 
 use crate::fetch::converter::escape_yaml;
 use crate::redacted::{Redacted, validate_https};
-use crate::retry::{parse_retry_after, retry_after_within_cap, retry_with_rate_limit};
+use crate::retry::{
+    is_transient_decode, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SlackError {
@@ -237,7 +239,12 @@ impl SlackClient {
         }
 
         let body: serde_json::Value = resp.json().await.map_err(|e| {
-            if e.is_decode() {
+            // Issue #113: reqwest 0.13 reports mid-stream body drop as
+            // `is_decode() == true` with an io::Error in the source chain.
+            // Schema-fail Decode is terminal; transport-drop Decode is
+            // transient and must route through Network so the retry loop
+            // catches it.
+            if e.is_decode() && !is_transient_decode(&e) {
                 SlackError::Decode(e.to_string())
             } else {
                 SlackError::Network(e.to_string())
@@ -566,7 +573,7 @@ mod tests {
 
     mod http_tests {
         use super::*;
-        use crate::test_support::try_spawn_mock_server;
+        use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
         use reqwest::Client;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, ResponseTemplate};
@@ -680,6 +687,24 @@ mod tests {
                 matches!(result, Err(SlackError::Decode(_))),
                 "expected SlackError::Decode for ok:false without error field, got: {result:?}"
             );
+        }
+
+        /// [T-SK030] Mid-stream body drop on 2xx routes through SlackError::Network
+        /// (transient, retry path) rather than SlackError::Decode (terminal). reqwest
+        /// 0.13 reports the drop as `is_decode() == true`; `is_transient_decode`
+        /// distinguishes it from a schema fail via the io::Error source chain (issue #113).
+        #[tokio::test]
+        async fn api_get_once_2xx_mid_stream_drop_returns_network() {
+            let Some((url, _counter, handle)) = spawn_mid_stream_drop_server(1) else {
+                return;
+            };
+            let client = SlackClient::with_base_url(Client::new(), &url);
+            let result: Result<DummyBody, _> = client.api_get_once("test.method", &[]).await;
+            assert!(
+                matches!(result, Err(SlackError::Network(_))),
+                "expected SlackError::Network for mid-stream drop, got: {result:?}"
+            );
+            let _ = handle.join();
         }
     }
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info, warn};
 use crate::fetch::converter::escape_yaml;
 use crate::redacted::{Redacted, validate_https};
 use crate::retry::{
-    is_transient_decode, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
+    is_schema_decode_fail, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -239,12 +239,9 @@ impl SlackClient {
         }
 
         let body: serde_json::Value = resp.json().await.map_err(|e| {
-            // Issue #113: reqwest 0.13 reports mid-stream body drop as
-            // `is_decode() == true` with an io::Error in the source chain.
-            // Schema-fail Decode is terminal; transport-drop Decode is
-            // transient and must route through Network so the retry loop
-            // catches it.
-            if e.is_decode() && !is_transient_decode(&e) {
+            // Schema fail → Decode (terminal). Transport drop → Network →
+            // retry loop. See `is_schema_decode_fail` (issue #113).
+            if is_schema_decode_fail(&e) {
                 SlackError::Decode(e.to_string())
             } else {
                 SlackError::Network(e.to_string())

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,7 +1,9 @@
 use std::env;
-use std::io;
+use std::io::{self, Read, Write};
 use std::net::TcpListener;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::{self, JoinHandle};
 
 use wiremock::MockServer;
 
@@ -34,6 +36,37 @@ pub async fn try_spawn_with_bind(
             None
         }
     }
+}
+
+/// One-shot server that accepts up to `accept_count` connections and replies
+/// with an HTTP/1.1 response declaring `Content-Length: 1000` but writing
+/// only `hello` before dropping the socket. reqwest surfaces the resulting
+/// mid-stream close as `is_decode() == true` with an `io::Error` of kind
+/// `UnexpectedEof` in the source chain (issue #113).
+///
+/// Returns `None` when loopback bind is unavailable so callers can early-return
+/// in restricted environments, matching the `try_spawn_mock_server` pattern.
+/// The returned `AtomicUsize` counts how many connections were accepted so
+/// callers can confirm the retry loop kicked in.
+pub fn spawn_mid_stream_drop_server(
+    accept_count: usize,
+) -> Option<(String, Arc<AtomicUsize>, JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").ok()?;
+    let addr = listener.local_addr().ok()?;
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_clone = Arc::clone(&counter);
+    let handle = thread::spawn(move || {
+        for _ in 0..accept_count {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\nhello");
+        }
+    });
+    Some((format!("http://{addr}"), counter, handle))
 }
 
 #[cfg(test)]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -48,6 +48,10 @@ pub async fn try_spawn_with_bind(
 /// in restricted environments, matching the `try_spawn_mock_server` pattern.
 /// The returned `AtomicUsize` counts how many connections were accepted so
 /// callers can confirm the retry loop kicked in.
+///
+/// `accept_count` must equal the number of connections the client will make;
+/// passing a larger value blocks the spawned thread on `listener.accept()`
+/// and makes `handle.join()` hang.
 pub fn spawn_mid_stream_drop_server(
     accept_count: usize,
 ) -> Option<(String, Arc<AtomicUsize>, JoinHandle<()>)> {
@@ -61,6 +65,9 @@ pub fn spawn_mid_stream_drop_server(
                 return;
             };
             counter_clone.fetch_add(1, Ordering::SeqCst);
+            // Drain the request before replying so reqwest observes the
+            // close as a mid-stream body drop on `json().await`, not as a
+            // write error during `send().await`.
             let mut buf = [0u8; 4096];
             let _ = stream.read(&mut buf);
             let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\nhello");

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -270,8 +270,9 @@ impl From<FetchError> for ScoutError {
             // Priority 4: TEMP_FAILURE (non-Status variants)
             FetchError::DnsResolution(_) => Self::transient(e.to_string())
                 .with_next_step("Check the URL's domain name and your DNS resolver"),
-            // `is_transient_network` covers both connect and timeout, but
-            // ADR-0065 splits timeout into 124. Check `is_timeout()` first.
+            // `is_transient_network` covers connect, timeout, and mid-stream
+            // body drop (issue #113), but ADR-0065 splits timeout into 124.
+            // Check `is_timeout()` first.
             FetchError::Http(re) if re.is_timeout() => timeout_with_retry_hint(&e),
             FetchError::Http(re) if is_transient_network(re) => transient_with_network_hint(&e),
             // Priority 5 sibling: IO_ERROR — external tool failure (browser)


### PR DESCRIPTION
## 概要

issue #113 を実装。reqwest 0.13 では mid-stream body drop が `is_decode() == true` として観測され、PR #112 後の Decode 分岐に乗ると `Internal(70)` に固定化されて retry されなかった。source chain を walk して `io::Error` を見つけたら transient と判定する `is_transient_decode` を内部追加し、call site では inverse predicate `is_schema_decode_fail` 経由で github / slack の Decode 分岐から retry 経路 (`Network` → `TempFailure(75)`) へ流す。

## 変更点

- **`src/retry.rs`**: `is_schema_decode_fail` (pub) + `is_transient_decode` (private) 追加 / `is_transient_network` 拡張。T-R004 / T-R005 で classifier の正逆 confirm
- **`src/github.rs`**: 2xx body decode 分岐で `is_schema_decode_fail` を経由。T-GH013 で MAX_RETRIES 回 retry されることを TcpListener mock + `start_paused` で confirm
- **`src/slack.rs`**: `api_get_once` body decode 分岐に同じ修正。T-SK030 で `SlackError::Network` 経路に乗ることを confirm
- **`src/test_support.rs`**: `spawn_mid_stream_drop_server` を追加 (raw TcpListener + Arc<AtomicUsize> counter)。`accept_count` contract と request-drain 意図を doc / comment に明示
- **`src/tools/errors.rs`**: コメント update (TIDYINGS)。副次効果として fetch 経路の mid-stream drop も `Unknown(104)` → `TempFailure(75)` 昇格

## 受け入れ条件

- [x] mid-stream body drop reproducer + classifier test (T-R004 / T-R005 / `spawn_mid_stream_drop_server`)
- [x] source chain で transport vs schema を区別する判定関数追加 (`is_transient_decode` / `is_schema_decode_fail`)
- [x] retry loop で mid-stream drop が retry される (回数 = MAX_RETRIES) ことを confirm (T-GH013)
- [x] \`cargo test --offline\` pass (351 unit + 11 integration)

## 設計判断

- **`io::Error` 存在を discriminator にした理由**: reqwest 0.13 の `is_decode()` は transport (UnexpectedEof) と schema (serde) の両方を返す。observation で source chain の `io::Error` の有無が両者を分けると確認できた。connection reset 等の他 transport error も自然にカバーされる。
- **hyper 直接依存追加を採用しなかった理由**: `hyper::Error::is_incomplete_message()` 案もあったが、hyper version 結合が増えて MSRV 整合コストが発生する。`std::error::Error::source()` + downcast なら std のみで完結し、reqwest version 上げにも追従しやすい。
- **slack 同時修正**: 共通ヘルパー (`is_schema_decode_fail`) を直す修正なので追加コストは use 行 1 つと test 1 つ。片方だけ直すと slack で同様の retry 漏れが残る。
- **`is_schema_decode_fail` を inverse predicate として抽出**: compound predicate `e.is_decode() && !is_transient_decode(&e)` は 3 ケースをトレースしないと読めない。named predicate にすることで call site の comments も縮約できる。
- **T-GH013 に `start_paused = true`**: tokio runtime のみ時間を auto-advance するため、std::thread の TcpListener は影響を受けない。wall time 3.56s → 0.75s。

## テスト方法

\`\`\`bash
cargo test --offline                                  # 351 unit + 11 integration pass
cargo clippy --offline --all-targets -- -D warnings   # clean
\`\`\`

## 関連

- Refs #113
- 親 issue: #101 (scope 縮小で #113 として別出し)
- PR #112: https://github.com/thkt/scout/pull/112
- ADR-0065