### PR TITLE
SSRF defense: ValidatedUrl 型導入と CDP block silent failure 修正

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -6,8 +6,8 @@ pub(crate) mod converter;
 mod extractor;
 mod ssrf;
 
-pub(crate) use ssrf::{DnsResolver, TokioDnsResolver};
-use ssrf::{redact_url_credentials, ssrf_check};
+pub(crate) use ssrf::{DnsResolver, RedactedLogUrl, TokioDnsResolver};
+use ssrf::{ValidatedUrl, ssrf_check};
 
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
@@ -25,6 +25,10 @@ use extractor::{extract_article, extract_raw};
 use reqwest::Client;
 use reqwest::header::LOCATION;
 
+#[cfg(feature = "js-rendering")]
+use chromiumoxide::error::CdpError;
+#[cfg(feature = "js-rendering")]
+use tracing::error;
 use tracing::{debug, info, warn};
 
 /// Options for [`fetch_page`] that control rendering and output.
@@ -100,15 +104,15 @@ pub(crate) async fn fetch_page(
     // SECURITY: Local CLI only. TOCTOU gap between DNS check and reqwest connect
     // is acceptable here; a network service would need a custom resolver that
     // enforces the allowlist at connect time.
-    ssrf_check(url, resolver).await?;
+    //
+    // The returned `ValidatedUrl` is the only constructor for SSRF-checked URLs;
+    // `download` requires `&ValidatedUrl` so the redirect loop cannot bypass it.
+    let validated = ssrf_check(url, resolver).await?;
 
     #[cfg(feature = "js-rendering")]
-    let (final_url, mut html) = download(client, url, MAX_REDIRECTS, resolver).await?;
+    let (final_url, mut html) = download(client, &validated, MAX_REDIRECTS, resolver).await?;
     #[cfg(not(feature = "js-rendering"))]
-    let (final_url, html) = download(client, url, MAX_REDIRECTS, resolver).await?;
-
-    // Defense-in-depth: catch bugs in the manual redirect loop.
-    ssrf_check(&final_url, resolver).await?;
+    let (final_url, html) = download(client, &validated, MAX_REDIRECTS, resolver).await?;
 
     let need_js = if opts.js {
         info!("--js flag set, requesting JS rendering");
@@ -147,25 +151,25 @@ pub(crate) async fn fetch_page(
     let article = if opts.raw {
         extract_raw(&html)
     } else {
-        extract_article(&html, Some(&final_url))
+        extract_article(&html, Some(final_url.as_str()))
     };
 
     let need_thin_fallback = !opts.raw && !need_js && is_thin_extract(&article);
     #[cfg(feature = "js-rendering")]
     let article = if need_thin_fallback {
-        warn!(url = %redact_url_credentials(&final_url), "extraction yielded too little content, trying JS rendering fallback");
+        warn!(url = %RedactedLogUrl(final_url.as_str()), "extraction yielded too little content, trying JS rendering fallback");
         match fetch_with_cdp(&final_url, Clone::clone(resolver)).await {
             Ok(js_html) => {
-                let re_extracted = extract_article(&js_html, Some(&final_url));
+                let re_extracted = extract_article(&js_html, Some(final_url.as_str()));
                 if is_thin_extract(&re_extracted) {
-                    debug!(url = %redact_url_credentials(&final_url), "JS re-extraction still thin, returning best-effort result");
+                    debug!(url = %RedactedLogUrl(final_url.as_str()), "JS re-extraction still thin, returning best-effort result");
                 } else {
-                    debug!(url = %redact_url_credentials(&final_url), "JS rendering fallback succeeded (post-extraction)");
+                    debug!(url = %RedactedLogUrl(final_url.as_str()), "JS rendering fallback succeeded (post-extraction)");
                 }
                 re_extracted
             }
             Err(e) => {
-                warn!(url = %redact_url_credentials(&final_url), error = %e, "JS rendering fallback failed, using original extraction");
+                warn!(url = %RedactedLogUrl(final_url.as_str()), error = %e, "JS rendering fallback failed, using original extraction");
                 article
             }
         }
@@ -174,11 +178,11 @@ pub(crate) async fn fetch_page(
     };
     #[cfg(not(feature = "js-rendering"))]
     if need_thin_fallback {
-        warn!(url = %redact_url_credentials(&final_url), "extraction yielded too little content but JS rendering unavailable");
+        warn!(url = %RedactedLogUrl(final_url.as_str()), "extraction yielded too little content but JS rendering unavailable");
     }
 
-    debug!(url = %redact_url_credentials(&final_url), bytes = html.len(), "page fetched");
-    Ok(to_fetch_result(&article, final_url))
+    debug!(url = %RedactedLogUrl(final_url.as_str()), bytes = html.len(), "page fetched");
+    Ok(to_fetch_result(&article, final_url.as_str().to_owned()))
 }
 
 /// Raw fallback is always thin because shell text (nav, footer) inflates
@@ -323,6 +327,26 @@ impl From<BrowserError> for FetchError {
     }
 }
 
+/// Reasons the CDP request-pause interceptor aborts.
+///
+/// Surfaces a failure inside the spawned interceptor task to the navigation
+/// task via a `oneshot` channel — without this, an `execute()` failure on the
+/// Continue/Fail command would be silently dropped and the subrequest would
+/// hang until the CDP timeout fires.
+#[cfg(feature = "js-rendering")]
+#[derive(Debug, thiserror::Error)]
+enum CdpInterceptError {
+    #[error("CDP intercept execute failed: {0}")]
+    Execute(CdpError),
+}
+
+#[cfg(feature = "js-rendering")]
+impl From<CdpInterceptError> for BrowserError {
+    fn from(e: CdpInterceptError) -> Self {
+        BrowserError::ProcessFailed(e.to_string())
+    }
+}
+
 #[cfg(feature = "js-rendering")]
 fn resolve_browser_binary() -> Result<PathBuf, BrowserError> {
     static CACHE: OnceLock<Result<PathBuf, String>> = OnceLock::new();
@@ -392,7 +416,7 @@ pub(crate) async fn check_browser_request(url: &str, resolver: &impl ssrf::DnsRe
     {
         return true;
     } else {
-        warn!(url = %url, "SSRF: blocked browser subrequest with unrecognized scheme");
+        warn!(url = %RedactedLogUrl(url), "SSRF: blocked browser subrequest with unrecognized scheme");
         return false;
     };
     ssrf::ssrf_check(&check_url, resolver).await.is_ok()
@@ -403,7 +427,7 @@ const CDP_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[cfg(feature = "js-rendering")]
 async fn fetch_with_cdp(
-    url: &str,
+    url: &ValidatedUrl,
     resolver: impl ssrf::DnsResolver,
 ) -> Result<String, BrowserError> {
     use chromiumoxide::Browser;
@@ -440,6 +464,11 @@ async fn fetch_with_cdp(
 
     let _ = timeout(Duration::from_secs(5), browser.close()).await;
     handler_task.abort();
+    match handler_task.await {
+        Ok(()) => {}
+        Err(e) if e.is_cancelled() => {}
+        Err(e) => error!(error = ?e, "CDP handler task panicked"),
+    }
 
     result
 }
@@ -448,7 +477,7 @@ async fn fetch_with_cdp(
 #[cfg(feature = "js-rendering")]
 async fn cdp_navigate(
     browser: &mut chromiumoxide::Browser,
-    url: &str,
+    url: &ValidatedUrl,
     resolver: impl ssrf::DnsResolver,
 ) -> Result<String, BrowserError> {
     use chromiumoxide::cdp::browser_protocol::fetch::{
@@ -456,6 +485,7 @@ async fn cdp_navigate(
     };
     use chromiumoxide::cdp::browser_protocol::network::ErrorReason;
     use futures::StreamExt;
+    use tokio::sync::oneshot;
 
     let page = browser
         .new_page("about:blank")
@@ -471,43 +501,66 @@ async fn cdp_navigate(
         .await
         .map_err(|e| BrowserError::ProcessFailed(format!("event listener: {e}")))?;
 
+    let (intercept_err_tx, intercept_err_rx) = oneshot::channel::<CdpInterceptError>();
     let intercept_page = page.clone();
     let interceptor = tokio::spawn(async move {
+        let mut intercept_err_tx = Some(intercept_err_tx);
         while let Some(event) = events.next().await {
             let req_url = &event.request.url;
             let allowed = check_browser_request(req_url, &resolver).await;
-            if allowed {
-                if let Ok(cmd) = ContinueRequestParams::builder()
-                    .request_id(event.request_id.clone())
-                    .build()
-                {
-                    let _ = intercept_page.execute(cmd).await;
-                }
+            let exec_result: Result<(), CdpError> = if allowed {
+                intercept_page
+                    .execute(ContinueRequestParams::new(event.request_id.clone()))
+                    .await
+                    .map(|_| ())
             } else {
-                warn!(blocked_url = %req_url, "SSRF: blocked browser subrequest");
-                if let Ok(cmd) = FailRequestParams::builder()
-                    .request_id(event.request_id.clone())
-                    .error_reason(ErrorReason::BlockedByClient)
-                    .build()
-                {
-                    let _ = intercept_page.execute(cmd).await;
-                }
+                warn!(blocked_url = %RedactedLogUrl(req_url), "SSRF: blocked browser subrequest");
+                intercept_page
+                    .execute(FailRequestParams::new(
+                        event.request_id.clone(),
+                        ErrorReason::BlockedByClient,
+                    ))
+                    .await
+                    .map(|_| ())
+            };
+            if let Err(e) = exec_result
+                && let Some(tx) = intercept_err_tx.take()
+            {
+                // Receiver dropped (= navigation already completed) is harmless; ignore.
+                let _ = tx.send(CdpInterceptError::Execute(e));
+                break;
             }
         }
     });
 
-    let result = async {
-        page.goto(url)
+    let navigation = async {
+        page.goto(url.as_str())
             .await
             .map_err(|e| BrowserError::ProcessFailed(format!("navigation: {e}")))?;
-
         page.content()
             .await
             .map_err(|e| BrowserError::ProcessFailed(format!("content: {e}")))
-    }
-    .await;
+    };
+    tokio::pin!(navigation);
+    let mut intercept_err_rx = intercept_err_rx;
+    // `biased;` so a fast-completing navigation cannot race past an
+    // already-sent intercept error.
+    let result = tokio::select! {
+        biased;
+        intercept_err = &mut intercept_err_rx => Err(intercept_err
+            .map(BrowserError::from)
+            .unwrap_or_else(|_| BrowserError::ProcessFailed(
+                "CDP intercept task dropped without status".into(),
+            ))),
+        nav_result = &mut navigation => nav_result,
+    };
 
     interceptor.abort();
+    match interceptor.await {
+        Ok(()) => {}
+        Err(e) if e.is_cancelled() => {}
+        Err(e) => error!(error = ?e, "CDP intercept task panicked"),
+    }
     result
 }
 
@@ -540,17 +593,20 @@ fn resolve_browser_binary_from(
 /// redirects before the application can re-check the resolved URL against
 /// the SSRF allowlist. Manual per-hop validation is the only way to enforce
 /// the SSRF contract. See ADR-0001 for the contract details.
+///
+/// `&ValidatedUrl` here closes that gap at the type level — the manual
+/// redirect loop cannot accept an unchecked URL.
 async fn download(
     client: &Client,
-    url: &str,
+    url: &ValidatedUrl,
     max_redirects: usize,
     resolver: &impl DnsResolver,
-) -> Result<(String, String), FetchError> {
-    let mut current_url = url.to_owned();
+) -> Result<(ValidatedUrl, String), FetchError> {
+    let mut current_url = url.clone();
 
     for _hop in 0..=max_redirects {
         let response = client
-            .get(&current_url)
+            .get(current_url.as_str())
             .header("User-Agent", crate::USER_AGENT)
             .send()
             .await?;
@@ -562,17 +618,17 @@ async fn download(
                 .and_then(|v| v.to_str().ok())
                 .ok_or(FetchError::RedirectMissingLocation)?;
 
-            let base = url::Url::parse(&current_url)?;
+            let base = url::Url::parse(current_url.as_str())?;
             let next_url = base.join(location)?.to_string();
 
-            ssrf_check(&next_url, resolver).await?;
+            let next_validated = ssrf_check(&next_url, resolver).await?;
 
             debug!(
-                from = %redact_url_credentials(&current_url),
-                to = %redact_url_credentials(&next_url),
+                from = %RedactedLogUrl(current_url.as_str()),
+                to = %RedactedLogUrl(next_validated.as_str()),
                 "following redirect"
             );
-            current_url = next_url;
+            current_url = next_validated;
             continue;
         }
 
@@ -584,7 +640,7 @@ async fn download(
         let mut charset = None;
         match response.headers().get("content-type") {
             None => {
-                debug!(url = %redact_url_credentials(&current_url), "no Content-Type header, proceeding as text")
+                debug!(url = %RedactedLogUrl(current_url.as_str()), "no Content-Type header, proceeding as text")
             }
             Some(ct) => match ct.to_str() {
                 Ok(ct_str) => {
@@ -592,7 +648,7 @@ async fn download(
                     charset = extract_charset(ct_str);
                 }
                 Err(_) => {
-                    debug!(url = %redact_url_credentials(&current_url), "Content-Type header is not valid ASCII, proceeding as text")
+                    debug!(url = %RedactedLogUrl(current_url.as_str()), "Content-Type header is not valid ASCII, proceeding as text")
                 }
             },
         }
@@ -774,6 +830,10 @@ mod download_tests {
         Client::builder().redirect(Policy::none()).build().unwrap()
     }
 
+    fn validated(url: &str) -> ValidatedUrl {
+        ValidatedUrl::for_test(url)
+    }
+
     #[derive(Clone, Copy)]
     struct PublicResolver;
     impl DnsResolver for PublicResolver {
@@ -800,14 +860,14 @@ mod download_tests {
         let client = no_redirect_client();
         let (final_url, html) = download(
             &client,
-            &format!("{}/page", server.uri()),
+            &validated(&format!("{}/page", server.uri())),
             MAX_REDIRECTS,
             &PublicResolver,
         )
         .await
         .unwrap();
 
-        assert!(final_url.contains("/page"));
+        assert!(final_url.as_str().contains("/page"));
         assert!(html.contains("hello"));
     }
 
@@ -832,7 +892,7 @@ mod download_tests {
         assert!(matches!(
             download(
                 &client,
-                &format!("{}/404", server.uri()),
+                &validated(&format!("{}/404", server.uri())),
                 MAX_REDIRECTS,
                 &PublicResolver
             )
@@ -842,7 +902,7 @@ mod download_tests {
         assert!(matches!(
             download(
                 &client,
-                &format!("{}/500", server.uri()),
+                &validated(&format!("{}/500", server.uri())),
                 MAX_REDIRECTS,
                 &PublicResolver
             )
@@ -867,7 +927,7 @@ mod download_tests {
         let client = no_redirect_client();
         let result = download(
             &client,
-            &format!("{}/huge", server.uri()),
+            &validated(&format!("{}/huge", server.uri())),
             MAX_REDIRECTS,
             &PublicResolver,
         )
@@ -894,7 +954,7 @@ mod download_tests {
         let client = no_redirect_client();
         let result = download(
             &client,
-            &format!("{}/binary", server.uri()),
+            &validated(&format!("{}/binary", server.uri())),
             MAX_REDIRECTS,
             &PublicResolver,
         )
@@ -922,7 +982,7 @@ mod download_tests {
         let client = no_redirect_client();
         let result = download(
             &client,
-            &format!("{}/redir", server.uri()),
+            &validated(&format!("{}/redir", server.uri())),
             MAX_REDIRECTS,
             &PublicResolver,
         )
@@ -958,7 +1018,7 @@ mod download_tests {
         let client = no_redirect_client();
         let result = download(
             &client,
-            &format!("{}/redir", server.uri()),
+            &validated(&format!("{}/redir", server.uri())),
             MAX_REDIRECTS,
             &PrivateResolver,
         )
@@ -986,7 +1046,7 @@ mod download_tests {
         let client = no_redirect_client();
         let result = download(
             &client,
-            &format!("{}/redir", server.uri()),
+            &validated(&format!("{}/redir", server.uri())),
             0, // max_redirects = 0
             &PublicResolver,
         )
@@ -1012,7 +1072,7 @@ mod download_tests {
         let client = no_redirect_client();
         let result = download(
             &client,
-            &format!("{}/bad-redir", server.uri()),
+            &validated(&format!("{}/bad-redir", server.uri())),
             MAX_REDIRECTS,
             &PublicResolver,
         )
@@ -1048,6 +1108,42 @@ mod fetch_page_tests {
         )
         .await;
         assert!(matches!(result, Err(FetchError::InternalHost)));
+    }
+
+    /// [T-F052] fetch_does_not_log_userinfo_credentials_on_blocked_url
+    ///
+    /// Adversarial: even when SSRF blocks the fetch, the `warn!` line emitted
+    /// by `ssrf_check` MUST flow through `redact_url_credentials` so no
+    /// password fragment ever appears in stderr / `tracing` output.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn fetch_does_not_log_userinfo_credentials_on_blocked_url() {
+        let client = no_redirect_client();
+        let result = fetch_page(
+            &client,
+            "http://user:supersecret@127.0.0.1/private",
+            FetchOptions::default(),
+            &TokioDnsResolver,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(FetchError::InternalHost)),
+            "should be blocked as InternalHost, got: {result:?}"
+        );
+        // Positive anchor: a future refactor that drops the warn! line
+        // entirely would silently make the userinfo asserts vacuous.
+        assert!(
+            logs_contain("blocked fetch to internal/private host"),
+            "expected the SSRF block warning to fire",
+        );
+        assert!(
+            !logs_contain("supersecret"),
+            "password fragment must not appear in logs",
+        );
+        assert!(
+            !logs_contain("user:"),
+            "userinfo must be stripped from logs",
+        );
     }
 
     /// [T-F018] js_flag_attempts_rendering_on_rich_body
@@ -1458,9 +1554,12 @@ mod cdp_integration_tests {
             eprintln!("SKIP: Chrome not found");
             return;
         }
-        let html = fetch_with_cdp("https://example.com", TokioDnsResolver)
-            .await
-            .expect("fetch_with_cdp should succeed for public URL");
+        let html = fetch_with_cdp(
+            &ValidatedUrl::for_test("https://example.com"),
+            TokioDnsResolver,
+        )
+        .await
+        .expect("fetch_with_cdp should succeed for public URL");
         assert!(
             html.contains("Example Domain") || html.contains("example"),
             "rendered HTML should contain page content, got {} bytes",

--- a/src/fetch/ssrf.rs
+++ b/src/fetch/ssrf.rs
@@ -1,6 +1,7 @@
 //! SSRF defense-in-depth: URL validation and DNS pre-check.
 
 use std::borrow::Cow;
+use std::fmt;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
@@ -35,7 +36,7 @@ impl DnsResolver for TokioDnsResolver {
 }
 
 /// SEC-003: strip userinfo before logging.
-pub(super) fn redact_url_credentials(raw: &str) -> Cow<'_, str> {
+fn redact_url_credentials(raw: &str) -> Cow<'_, str> {
     if !raw.contains('@') {
         return Cow::Borrowed(raw);
     }
@@ -49,7 +50,50 @@ pub(super) fn redact_url_credentials(raw: &str) -> Cow<'_, str> {
     Cow::Borrowed(raw)
 }
 
-pub(crate) async fn ssrf_check(raw: &str, resolver: &impl DnsResolver) -> Result<(), FetchError> {
+/// Display wrapper that redacts URL credentials on each format.
+///
+/// Centralizes redaction so every `info!`/`warn!` that logs a URL flows through
+/// the same code path. Constructed at the log call site to keep the bare `&str`
+/// out of the `tracing` field unless redacted.
+pub(crate) struct RedactedLogUrl<'a>(pub &'a str);
+
+impl fmt::Display for RedactedLogUrl<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&redact_url_credentials(self.0))
+    }
+}
+
+/// A URL that has passed SSRF validation (scheme allowlist + private-IP block).
+///
+/// Constructed only by [`ssrf_check`]; downstream consumers (`download`,
+/// `reqwest::Client::get`) accept `&ValidatedUrl` so the type system forces
+/// every fetch path through the SSRF check.
+#[derive(Debug, Clone)]
+pub(crate) struct ValidatedUrl(url::Url);
+
+impl ValidatedUrl {
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Bypasses SSRF validation. Test-only — production code must go through
+    /// [`ssrf_check`] so the type system enforces the SSRF contract.
+    #[cfg(test)]
+    pub(crate) fn for_test(raw: &str) -> Self {
+        Self(url::Url::parse(raw).expect("test URL must parse"))
+    }
+}
+
+impl fmt::Display for ValidatedUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+pub(crate) async fn ssrf_check(
+    raw: &str,
+    resolver: &impl DnsResolver,
+) -> Result<ValidatedUrl, FetchError> {
     let parsed = validate_url_sync(raw).map_err(|e| {
         if matches!(e, FetchError::InternalHost) {
             warn!(url = %redact_url_credentials(raw), "blocked fetch to internal/private host");
@@ -71,7 +115,7 @@ pub(crate) async fn ssrf_check(raw: &str, resolver: &impl DnsResolver) -> Result
         }
     }
 
-    Ok(())
+    Ok(ValidatedUrl(parsed))
 }
 
 pub(crate) fn validate_url_sync(raw: &str) -> Result<url::Url, FetchError> {
@@ -275,5 +319,17 @@ mod dns_tests {
         let safe = redact_url_credentials(url);
         assert!(!safe.contains("admin"));
         assert!(safe.contains("example.com"));
+    }
+
+    /// [T-FS011] redacted_log_url_display_strips_userinfo
+    ///
+    /// Guards the `Display` impl directly so a future divergence between
+    /// `RedactedLogUrl::fmt` and `redact_url_credentials` would be caught.
+    #[test]
+    fn redacted_log_url_display_strips_userinfo() {
+        let formatted = format!("{}", RedactedLogUrl("https://user:secret@example.com/path"));
+        assert!(!formatted.contains("secret"));
+        assert!(!formatted.contains("user:"));
+        assert!(formatted.contains("example.com/path"));
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -24,7 +24,7 @@ use params::{
 use crate::brave::client::{BraveClient, BraveError, SearchClient as _};
 use crate::envelope::{CommandOutput, Degradation, DegradedReason};
 use crate::fetch::converter::{FetchResult, RAW_FALLBACK_NOTE};
-use crate::fetch::{FetchError, FetchOptions, TokioDnsResolver, fetch_page};
+use crate::fetch::{FetchError, FetchOptions, RedactedLogUrl, TokioDnsResolver, fetch_page};
 use crate::github::types::ContentsResponse;
 use crate::github::{self, GitHubClient};
 use crate::markdown::{shift_headings, truncate_with_note};
@@ -221,7 +221,7 @@ impl Scout {
             return self.fetch_slack(slack_url).await;
         }
 
-        info!(url = %url, js = params.js, raw = params.raw, "fetch");
+        info!(url = %RedactedLogUrl(&url), js = params.js, raw = params.raw, "fetch");
 
         let opts = FetchOptions {
             js: params.js,
@@ -240,10 +240,10 @@ impl Scout {
         })?;
 
         if result.used_raw_fallback {
-            warn!(url = %url, "readability extraction failed, using raw fallback");
+            warn!(url = %RedactedLogUrl(&url), "readability extraction failed, using raw fallback");
         }
 
-        info!(url = %url, "fetch complete");
+        info!(url = %RedactedLogUrl(&url), "fetch complete");
         let markdown = format_fetch_output(&result);
         let data = serde_json::to_value(&result).expect("FetchResult is Serialize");
         let mut degradation = Degradation::default();


### PR DESCRIPTION
## What & Why

OUTCOME Constraint 1「全 fetch 経路で SSRF 防御必須」を手続き的ガード (`ssrf_check` が `Result<(), _>` を返す形) から型強制に置き換える。新しい fetch 経路を追加しても、`ValidatedUrl` 経由でしか reqwest/CDP に到達できない。

また URL credentials の redact 漏れ (tools.rs:225/244/247, fetch.rs:395/487) と、CDP intercept の `execute()` Err 握りつぶし (fetch.rs:480-494)、interceptor / handler_task panic の観察不能を同時に解消する。

## Changes

- `ssrf_check` が `Result<ValidatedUrl, FetchError>` を返すように変更。`download` と `fetch_with_cdp` は `&ValidatedUrl` を受け、`reqwest::Client::get` / `page.goto` の callsite から raw `&str` を排除
- `RedactedLogUrl` Display wrapper を追加し、`tools.rs` / `fetch.rs` の `info!`/`warn!` で URL を扱う全 callsite を経由させる
- CDP intercept Continue/Fail を `*Params::new()` で生成（fallible builder 回避）し、`execute()` Err は oneshot で navigation に伝搬。`tokio::select! biased;` で nav 完了を待つ前にエラーを優先処理
- interceptor / CDP handler `JoinHandle` を `abort()` 後に `await` し、`is_cancelled()` でフィルタした上で panic を `tracing::error!` に記録
- adversarial test `fetch_does_not_log_userinfo_credentials_on_blocked_url` を追加。positive anchor (block warning が実際に出てる) を組み合わせ、将来 warn 自体が消えても vacuous-true にならないようにガード
- `RedactedLogUrl::Display` の単体テストを追加し、`redact_url_credentials` との将来的な divergence を catch

## Scope

- **Not included**: ssrf.rs 内 `validate_url_sync` / `is_private_ip` のロジック変更（既存ガード値は据え置き）。CDP intercept の構造変更 (spawn → select! へのリファクタ) は本 PR ではやらず、最小変更で AC を満たす方針

## Design Decisions

- `fetch_page` の 2 回目の `ssrf_check(&final_url, ...)` (defense-in-depth) を削除。`download` が `ValidatedUrl` を返すようになり、redirect loop 内で per-hop の `ssrf_check` 通過が型レベルで保証されるため、実行時の二重チェックは型システムで代替できる
- CDP interceptor は `tokio::spawn` を維持。`select!` でイベントループを navigation と inline 化する案も検討したが、(a) SSRF DNS check (~hundreds of ms) が goto future を阻害する、(b) chromiumoxide の `event_listener` 消費パターンに反する、(c) 既存の `interceptor.abort()` 構造を流用できる、の 3 点から spawn + oneshot を採用
- `ContinueRequestParams::new(request_id)` を採用 (builder 経由しない)。builder の `build()` Err は `request_id` 未指定が原因で、static に保証されるため握りつぶしの根を断つ

## How to Test

1. `cargo test --offline --all-features` → 365 tests pass (lib 354 + integration 11)
2. `cargo clippy --all-targets --all-features -- -D warnings` → no warnings
3. `cargo test fetch_does_not_log_userinfo_credentials` → adversarial test 単体で pass。tracing 出力に `supersecret` / `user:` が現れず、block warning が実際に発火していることを確認
4. `chromiumoxide` 経由の CDP interception を要する場合: `cargo test --features js-rendering t005_cdp_renders_public_url`（Chrome が PATH にある環境のみ）

## Related

- Closes #100
