### PR TITLE
CDP graceful close を SIGINT/SIGTERM 経路でも保証する (sticky cancellation)

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -17,6 +17,7 @@ use std::sync::OnceLock;
 #[cfg(feature = "js-rendering")]
 use std::time::Duration;
 
+use tokio::sync::Notify;
 #[cfg(feature = "js-rendering")]
 use tokio::time::timeout;
 
@@ -93,7 +94,14 @@ pub(crate) async fn fetch_page(
     url: &str,
     opts: FetchOptions,
     resolver: &impl DnsResolver,
+    cancel: &Notify,
 ) -> Result<FetchResult, FetchError> {
+    // `cancel` is only consumed on the CDP path. Silence the unused-arg
+    // warning in builds without `js-rendering` instead of duplicating the
+    // function signature behind cfg.
+    #[cfg(not(feature = "js-rendering"))]
+    let _ = cancel;
+
     #[cfg(not(feature = "js-rendering"))]
     if opts.js {
         return Err(FetchError::BrowserNotFound(
@@ -127,7 +135,7 @@ pub(crate) async fn fetch_page(
     if need_js {
         #[cfg(feature = "js-rendering")]
         {
-            match fetch_with_cdp(&final_url, Clone::clone(resolver)).await {
+            match fetch_with_cdp(&final_url, Clone::clone(resolver), cancel).await {
                 Ok(js_html) => {
                     debug!("JS rendering succeeded via CDP");
                     html = js_html;
@@ -158,7 +166,7 @@ pub(crate) async fn fetch_page(
     #[cfg(feature = "js-rendering")]
     let article = if need_thin_fallback {
         warn!(url = %RedactedLogUrl(final_url.as_str()), "extraction yielded too little content, trying JS rendering fallback");
-        match fetch_with_cdp(&final_url, Clone::clone(resolver)).await {
+        match fetch_with_cdp(&final_url, Clone::clone(resolver), cancel).await {
             Ok(js_html) => {
                 let re_extracted = extract_article(&js_html, Some(final_url.as_str()));
                 if is_thin_extract(&re_extracted) {
@@ -314,6 +322,8 @@ enum BrowserError {
     ProcessFailed(String),
     #[error("browser rendering timed out")]
     TimedOut,
+    #[error("browser cancelled by signal")]
+    Cancelled,
 }
 
 #[cfg_attr(not(feature = "js-rendering"), allow(dead_code))]
@@ -322,7 +332,7 @@ impl From<BrowserError> for FetchError {
         match e {
             BrowserError::NotFound => Self::BrowserNotFound(e.to_string()),
             BrowserError::ProcessFailed(msg) => Self::BrowserFailed(msg),
-            BrowserError::TimedOut => Self::Timeout(e.to_string()),
+            BrowserError::TimedOut | BrowserError::Cancelled => Self::Timeout(e.to_string()),
         }
     }
 }
@@ -429,6 +439,7 @@ const CDP_TIMEOUT: Duration = Duration::from_secs(60);
 async fn fetch_with_cdp(
     url: &ValidatedUrl,
     resolver: impl ssrf::DnsResolver,
+    cancel: &Notify,
 ) -> Result<String, BrowserError> {
     use chromiumoxide::Browser;
     use chromiumoxide::browser::BrowserConfig;
@@ -457,11 +468,21 @@ async fn fetch_with_cdp(
         }
     });
 
-    // unwrap_or (not ?) so cleanup below runs even on timeout.
-    let result = timeout(CDP_TIMEOUT, cdp_navigate(&mut browser, url, resolver))
-        .await
-        .unwrap_or(Err(BrowserError::TimedOut));
+    // Race navigate against cancellation so SIGINT/SIGTERM still reaches the
+    // graceful close path below. Without this branch the future would be
+    // dropped by the outer select! in lib::run and chromium subprocesses
+    // would orphan to ppid=1 (issue #121).
+    let result = tokio::select! {
+        biased;
+        () = cancel.notified() => Err(BrowserError::Cancelled),
+        r = timeout(CDP_TIMEOUT, cdp_navigate(&mut browser, url, resolver)) => {
+            r.unwrap_or(Err(BrowserError::TimedOut))
+        }
+    };
 
+    // Always issue browser.close() so chromium can wind down its own subprocess
+    // tree (renderer, crashpad, GPU). 5s covers the slow-path graceful close;
+    // if it overruns, the Drop chain falls back to SIGKILL on the parent.
     let _ = timeout(Duration::from_secs(5), browser.close()).await;
     handler_task.abort();
     match handler_task.await {
@@ -1100,11 +1121,13 @@ mod fetch_page_tests {
     #[tokio::test]
     async fn blocks_ssrf_to_localhost() {
         let client = no_redirect_client();
+        let cancel = Notify::new();
         let result = fetch_page(
             &client,
             "http://127.0.0.1/secret",
             FetchOptions::default(),
             &TokioDnsResolver,
+            &cancel,
         )
         .await;
         assert!(matches!(result, Err(FetchError::InternalHost)));
@@ -1119,11 +1142,13 @@ mod fetch_page_tests {
     #[tracing_test::traced_test]
     async fn fetch_does_not_log_userinfo_credentials_on_blocked_url() {
         let client = no_redirect_client();
+        let cancel = Notify::new();
         let result = fetch_page(
             &client,
             "http://user:supersecret@127.0.0.1/private",
             FetchOptions::default(),
             &TokioDnsResolver,
+            &cancel,
         )
         .await;
         assert!(
@@ -1167,11 +1192,13 @@ mod fetch_page_tests {
             js: true,
             ..Default::default()
         };
+        let cancel = Notify::new();
         let result = fetch_page(
             &client,
             &format!("{}/rich", server.uri()),
             opts,
             &TokioDnsResolver,
+            &cancel,
         )
         .await;
 
@@ -1190,7 +1217,15 @@ mod fetch_page_tests {
             js: true,
             ..Default::default()
         };
-        let result = fetch_page(&client, "https://example.com/page", opts, &TokioDnsResolver).await;
+        let cancel = Notify::new();
+        let result = fetch_page(
+            &client,
+            "https://example.com/page",
+            opts,
+            &TokioDnsResolver,
+            &cancel,
+        )
+        .await;
 
         assert!(
             matches!(&result, Err(FetchError::BrowserNotFound(msg)) if msg.contains("js-rendering")),

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 #[cfg(feature = "js-rendering")]
 use std::time::Duration;
 
-use tokio::sync::Notify;
+use tokio::sync::watch;
 #[cfg(feature = "js-rendering")]
 use tokio::time::timeout;
 
@@ -94,7 +94,7 @@ pub(crate) async fn fetch_page(
     url: &str,
     opts: FetchOptions,
     resolver: &impl DnsResolver,
-    cancel: &Notify,
+    cancel: &watch::Sender<bool>,
 ) -> Result<FetchResult, FetchError> {
     // `cancel` is only consumed on the CDP path. Silence the unused-arg
     // warning in builds without `js-rendering` instead of duplicating the
@@ -439,7 +439,7 @@ const CDP_TIMEOUT: Duration = Duration::from_secs(60);
 async fn fetch_with_cdp(
     url: &ValidatedUrl,
     resolver: impl ssrf::DnsResolver,
-    cancel: &Notify,
+    cancel: &watch::Sender<bool>,
 ) -> Result<String, BrowserError> {
     use chromiumoxide::Browser;
     use chromiumoxide::browser::BrowserConfig;
@@ -472,9 +472,15 @@ async fn fetch_with_cdp(
     // graceful close path below. Without this branch the future would be
     // dropped by the outer select! in lib::run and chromium subprocesses
     // would orphan to ppid=1 (issue #121).
+    //
+    // `wait_for` is sticky: if the flag was already `true` at subscribe time
+    // (e.g. SIGINT arrived while reqwest was still downloading the initial
+    // HTML), the closure runs against the current value and returns
+    // immediately. `Notify` would have silently dropped that wakeup.
+    let mut rx = cancel.subscribe();
     let result = tokio::select! {
         biased;
-        () = cancel.notified() => Err(BrowserError::Cancelled),
+        _ = rx.wait_for(|&cancelled| cancelled) => Err(BrowserError::Cancelled),
         r = timeout(CDP_TIMEOUT, cdp_navigate(&mut browser, url, resolver)) => {
             r.unwrap_or(Err(BrowserError::TimedOut))
         }
@@ -1121,7 +1127,7 @@ mod fetch_page_tests {
     #[tokio::test]
     async fn blocks_ssrf_to_localhost() {
         let client = no_redirect_client();
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let result = fetch_page(
             &client,
             "http://127.0.0.1/secret",
@@ -1142,7 +1148,7 @@ mod fetch_page_tests {
     #[tracing_test::traced_test]
     async fn fetch_does_not_log_userinfo_credentials_on_blocked_url() {
         let client = no_redirect_client();
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let result = fetch_page(
             &client,
             "http://user:supersecret@127.0.0.1/private",
@@ -1192,7 +1198,7 @@ mod fetch_page_tests {
             js: true,
             ..Default::default()
         };
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let result = fetch_page(
             &client,
             &format!("{}/rich", server.uri()),
@@ -1217,7 +1223,7 @@ mod fetch_page_tests {
             js: true,
             ..Default::default()
         };
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let result = fetch_page(
             &client,
             "https://example.com/page",
@@ -1589,9 +1595,11 @@ mod cdp_integration_tests {
             eprintln!("SKIP: Chrome not found");
             return;
         }
+        let (cancel, _) = watch::channel(false);
         let html = fetch_with_cdp(
             &ValidatedUrl::for_test("https://example.com"),
             TokioDnsResolver,
+            &cancel,
         )
         .await
         .expect("fetch_with_cdp should succeed for public URL");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub async fn run() -> ExitCode {
         res = &mut cmd_fut => Outcome::Completed(res),
         sig = wait_for_signal() => {
             tracing::info!(signal = %sig, "interrupted, draining for graceful close");
-            cancel.notify_waiters();
+            let _ = cancel.send(true);
             let _ = timeout(SHUTDOWN_DRAIN_TIMEOUT, &mut cmd_fut).await;
             Outcome::Interrupted(sig)
         }
@@ -146,7 +146,6 @@ pub async fn run() -> ExitCode {
         }
         Outcome::Completed(Err(e)) => emit_error(&e, json_mode),
         Outcome::Interrupted(sig) => {
-            tracing::info!(signal = %sig, "interrupted");
             eprintln!("error: interrupted ({sig})");
             ExitCode::from(sig.exit_code())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,24 @@ pub(crate) const USER_AGENT: &str = concat!("scout/", env!("CARGO_PKG_VERSION"))
 use std::env;
 use std::io::{self, ErrorKind, Write, stderr, stdout};
 use std::process::ExitCode;
+use std::time::Duration;
 
 use clap::Parser;
 use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload, SuccessEnvelope};
-use signals::{Outcome, select_outcome, wait_for_signal};
+use signals::{InterruptSignal, wait_for_signal};
+use tokio::time::timeout;
 use tools::{Command, Scout, ScoutError};
+
+/// Maximum time the runtime waits for the in-flight command to wind down
+/// after a SIGINT/SIGTERM. Long enough for CDP `browser.close()` (5s) plus
+/// chromium's own subprocess cleanup margin; short enough not to feel like
+/// a hang to the caller. Issue #121.
+const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(7);
+
+enum Outcome<T> {
+    Completed(T),
+    Interrupted(InterruptSignal),
+}
 
 fn write_output<W: Write>(w: &mut W, output: &str) -> io::Result<()> {
     if output.is_empty() {
@@ -96,8 +109,24 @@ pub async fn run() -> ExitCode {
         Ok(s) => s,
         Err(e) => return emit_error(&e, json_mode),
     };
+    let cancel = scout.cancel_handle();
 
-    let outcome = select_outcome(scout.run(cli.command), wait_for_signal()).await;
+    let cmd_fut = scout.run(cli.command);
+    tokio::pin!(cmd_fut);
+
+    // Race the in-flight command against signal arrival. On interrupt,
+    // notify the cancel handle so fetch_with_cdp can run `browser.close()`
+    // (issue #121) and then await the command for a bounded window before
+    // returning the interrupt exit code.
+    let outcome: Outcome<Result<CommandOutput, ScoutError>> = tokio::select! {
+        res = &mut cmd_fut => Outcome::Completed(res),
+        sig = wait_for_signal() => {
+            tracing::info!(signal = %sig, "interrupted, draining for graceful close");
+            cancel.notify_waiters();
+            let _ = timeout(SHUTDOWN_DRAIN_TIMEOUT, &mut cmd_fut).await;
+            Outcome::Interrupted(sig)
+        }
+    };
     match outcome {
         Outcome::Completed(Ok(output)) => {
             let rendered = if json_mode {

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
 use reqwest::Client;
-use tokio::sync::Notify;
+use tokio::sync::watch;
 use tokio::time::timeout;
 use tracing::warn;
 
@@ -46,7 +46,7 @@ pub(crate) async fn research(
     http: &Client,
     req: &ResearchRequest<'_>,
     resolver: &impl DnsResolver,
-    cancel: &Notify,
+    cancel: &watch::Sender<bool>,
 ) -> Result<ResearchReport, BraveError> {
     let search_lang = req.lang.to_brave_param();
     let sources = brave.search(req.query, search_lang).await?;
@@ -66,7 +66,7 @@ async fn fetch_sources(
     sources: &[SearchResult],
     depth: usize,
     resolver: &impl DnsResolver,
-    cancel: &Notify,
+    cancel: &watch::Sender<bool>,
 ) -> (Vec<FetchResult>, Vec<FailedUrl>) {
     let fetch_outcomes: Vec<_> = stream::iter(sources.iter().take(depth).enumerate())
         .map(|(idx, source)| async move {
@@ -344,7 +344,7 @@ mod tests {
             depth: 3,
             lang: Lang::En,
         };
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let report = research(&mock, &http, &req, &resolver, &cancel)
             .await
             .unwrap();
@@ -377,7 +377,7 @@ mod tests {
             depth: 3,
             lang: Lang::Auto,
         };
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let _ = research(&mock, &http, &req, &resolver, &cancel)
             .await
             .unwrap();
@@ -407,7 +407,7 @@ mod tests {
             depth: 3,
             lang: Lang::En,
         };
-        let cancel = Notify::new();
+        let (cancel, _) = watch::channel(false);
         let err = research(&mock, &http, &req, &resolver, &cancel)
             .await
             .unwrap_err();

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
 use reqwest::Client;
+use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::warn;
 
@@ -45,12 +46,13 @@ pub(crate) async fn research(
     http: &Client,
     req: &ResearchRequest<'_>,
     resolver: &impl DnsResolver,
+    cancel: &Notify,
 ) -> Result<ResearchReport, BraveError> {
     let search_lang = req.lang.to_brave_param();
     let sources = brave.search(req.query, search_lang).await?;
 
     let (fetched_pages, failed_urls) =
-        fetch_sources(http, &sources, req.depth as usize, resolver).await;
+        fetch_sources(http, &sources, req.depth as usize, resolver, cancel).await;
 
     Ok(ResearchReport {
         fetched_pages,
@@ -64,13 +66,14 @@ async fn fetch_sources(
     sources: &[SearchResult],
     depth: usize,
     resolver: &impl DnsResolver,
+    cancel: &Notify,
 ) -> (Vec<FetchResult>, Vec<FailedUrl>) {
     let fetch_outcomes: Vec<_> = stream::iter(sources.iter().take(depth).enumerate())
         .map(|(idx, source)| async move {
             let url = source.url.as_str();
             let result = timeout(
                 FETCH_TIMEOUT,
-                fetch::fetch_page(http, url, fetch::FetchOptions::default(), resolver),
+                fetch::fetch_page(http, url, fetch::FetchOptions::default(), resolver, cancel),
             )
             .await;
             let result = match result {
@@ -341,7 +344,10 @@ mod tests {
             depth: 3,
             lang: Lang::En,
         };
-        let report = research(&mock, &http, &req, &resolver).await.unwrap();
+        let cancel = Notify::new();
+        let report = research(&mock, &http, &req, &resolver, &cancel)
+            .await
+            .unwrap();
 
         assert_eq!(report.sources.len(), 1);
 
@@ -371,7 +377,10 @@ mod tests {
             depth: 3,
             lang: Lang::Auto,
         };
-        let _ = research(&mock, &http, &req, &resolver).await.unwrap();
+        let cancel = Notify::new();
+        let _ = research(&mock, &http, &req, &resolver, &cancel)
+            .await
+            .unwrap();
 
         let captured = mock.captured();
         assert_eq!(
@@ -398,7 +407,10 @@ mod tests {
             depth: 3,
             lang: Lang::En,
         };
-        let err = research(&mock, &http, &req, &resolver).await.unwrap_err();
+        let cancel = Notify::new();
+        let err = research(&mock, &http, &req, &resolver, &cancel)
+            .await
+            .unwrap_err();
         assert!(matches!(err, BraveError::RateLimited { .. }));
     }
 

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -69,10 +69,6 @@ pub(crate) async fn wait_for_signal() -> InterruptSignal {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use tokio::time::sleep;
-
     use super::*;
 
     // T-S001: sigint_exit_code_is_130

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::future::Future;
 
 /// Interrupt signal observed by `wait_for_signal`. Maps to a POSIX exit
 /// convention so shell pipeline callers can distinguish user-initiated
@@ -30,27 +29,6 @@ impl fmt::Display for InterruptSignal {
             #[cfg(unix)]
             Self::Sigterm => "SIGTERM",
         })
-    }
-}
-
-pub(crate) enum Outcome<T> {
-    Completed(T),
-    Interrupted(InterruptSignal),
-}
-
-/// Race a command future against a signal source. Whichever future
-/// resolves first determines the outcome. The unresolved future is
-/// dropped — for the command path this triggers the CDP browser's
-/// Drop chain (chromiumoxide uses `kill_on_drop`) to terminate any
-/// child chromium process before scout exits.
-pub(crate) async fn select_outcome<F, S>(cmd: F, sig: S) -> Outcome<F::Output>
-where
-    F: Future,
-    S: Future<Output = InterruptSignal>,
-{
-    tokio::select! {
-        out = cmd => Outcome::Completed(out),
-        s = sig => Outcome::Interrupted(s),
     }
 }
 
@@ -110,39 +88,6 @@ mod tests {
     #[test]
     fn sigterm_exit_code_is_143() {
         assert_eq!(InterruptSignal::Sigterm.exit_code(), 143);
-    }
-
-    // T-S003: completes_when_command_finishes_first
-    // When the command future resolves before the signal future,
-    // `select_outcome` must return Completed and drop the signal listener.
-    #[tokio::test(start_paused = true)]
-    async fn completes_when_command_finishes_first() {
-        let cmd = async { 42_i32 };
-        let sig = async {
-            sleep(Duration::from_secs(60)).await;
-            InterruptSignal::Sigint
-        };
-        match select_outcome(cmd, sig).await {
-            Outcome::Completed(v) => assert_eq!(v, 42),
-            Outcome::Interrupted(_) => panic!("expected Completed, got Interrupted"),
-        }
-    }
-
-    // T-S004: interrupted_when_signal_fires_first
-    // When the signal future resolves before the command future,
-    // `select_outcome` must return Interrupted and drop the command future,
-    // triggering the CDP browser's `kill_on_drop` chain.
-    #[tokio::test(start_paused = true)]
-    async fn interrupted_when_signal_fires_first() {
-        let cmd = async {
-            sleep(Duration::from_secs(60)).await;
-            42_i32
-        };
-        let sig = async { InterruptSignal::Sigint };
-        match select_outcome(cmd, sig).await {
-            Outcome::Completed(_) => panic!("expected Interrupted, got Completed"),
-            Outcome::Interrupted(s) => assert_eq!(s, InterruptSignal::Sigint),
-        }
     }
 
     // T-S005: sigint_display_is_sigint

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -6,12 +6,13 @@ pub use errors::ScoutError;
 pub use params::Command;
 
 use std::io::{IsTerminal, stdin};
+use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::Client;
 use reqwest::redirect::Policy;
 use tokio::io::{AsyncReadExt, stdin as tokio_stdin};
-use tokio::sync::OnceCell;
+use tokio::sync::{Notify, OnceCell};
 use tokio::time::timeout;
 use tracing::{info, warn};
 
@@ -138,6 +139,11 @@ pub struct Scout {
     /// Lazy-initialized on first GitHub API call. Non-GitHub commands
     /// (search, fetch, research) never pay the `gh auth token` cost.
     github: OnceCell<GitHubClient>,
+    /// Broadcast handle for graceful shutdown. `lib::run` fires
+    /// `notify_waiters()` on SIGINT/SIGTERM so in-flight CDP fetches can
+    /// invoke `browser.close().await` before the runtime drops the task,
+    /// preventing chromium subprocess orphans (issue #121).
+    cancel: Arc<Notify>,
 }
 
 impl Scout {
@@ -162,7 +168,15 @@ impl Scout {
             fetch_http,
             brave,
             github: OnceCell::new(),
+            cancel: Arc::new(Notify::new()),
         })
+    }
+
+    /// Hand back the shared cancel handle so `lib::run` can fire it
+    /// when a termination signal arrives. Cloning an `Arc<Notify>` is
+    /// cheap and lets the signal handler outlive the borrow of `Scout`.
+    pub fn cancel_handle(&self) -> Arc<Notify> {
+        self.cancel.clone()
     }
 
     async fn github(&self) -> &GitHubClient {
@@ -229,7 +243,13 @@ impl Scout {
         };
         let result = timeout(
             FETCH_TOOL_TIMEOUT,
-            fetch_page(&self.fetch_http, &url, opts, &TokioDnsResolver),
+            fetch_page(
+                &self.fetch_http,
+                &url,
+                opts,
+                &TokioDnsResolver,
+                &self.cancel,
+            ),
         )
         .await
         .unwrap_or_else(|_| {
@@ -297,7 +317,13 @@ impl Scout {
 
         let report = match timeout(
             RESEARCH_TOOL_TIMEOUT,
-            engine::research(brave, &self.fetch_http, &req, &TokioDnsResolver),
+            engine::research(
+                brave,
+                &self.fetch_http,
+                &req,
+                &TokioDnsResolver,
+                &self.cancel,
+            ),
         )
         .await
         {
@@ -1082,6 +1108,7 @@ mod tests {
             fetch_http,
             brave: Some(BraveClient::with_base_url(http, brave_uri)),
             github: cell,
+            cancel: Arc::new(Notify::new()),
         }
     }
 
@@ -1092,6 +1119,7 @@ mod tests {
             fetch_http,
             brave: Some(BraveClient::with_base_url(http, brave_uri)),
             github: OnceCell::new(),
+            cancel: Arc::new(Notify::new()),
         }
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -6,13 +6,12 @@ pub use errors::ScoutError;
 pub use params::Command;
 
 use std::io::{IsTerminal, stdin};
-use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::Client;
 use reqwest::redirect::Policy;
 use tokio::io::{AsyncReadExt, stdin as tokio_stdin};
-use tokio::sync::{Notify, OnceCell};
+use tokio::sync::{OnceCell, watch};
 use tokio::time::timeout;
 use tracing::{info, warn};
 
@@ -139,11 +138,13 @@ pub struct Scout {
     /// Lazy-initialized on first GitHub API call. Non-GitHub commands
     /// (search, fetch, research) never pay the `gh auth token` cost.
     github: OnceCell<GitHubClient>,
-    /// Broadcast handle for graceful shutdown. `lib::run` fires
-    /// `notify_waiters()` on SIGINT/SIGTERM so in-flight CDP fetches can
-    /// invoke `browser.close().await` before the runtime drops the task,
-    /// preventing chromium subprocess orphans (issue #121).
-    cancel: Arc<Notify>,
+    /// Sticky shutdown flag. `lib::run` flips this to `true` on SIGINT or
+    /// SIGTERM. Each `fetch_with_cdp` invocation subscribes a fresh receiver
+    /// so the cancellation is delivered to fetches that start after the
+    /// signal arrives (e.g. queued slots in `research --depth N` once an
+    /// earlier slot finishes). `Notify` was tried first but loses wakeups
+    /// when no waiter is registered at signal time (issue #121).
+    cancel: watch::Sender<bool>,
 }
 
 impl Scout {
@@ -163,19 +164,21 @@ impl Scout {
         let brave = BraveClient::from_env(http.clone())
             .inspect_err(|e| warn!("Brave client not available: {e}"))
             .ok();
+        let (cancel, _) = watch::channel(false);
         Ok(Self {
             http,
             fetch_http,
             brave,
             github: OnceCell::new(),
-            cancel: Arc::new(Notify::new()),
+            cancel,
         })
     }
 
-    /// Hand back the shared cancel handle so `lib::run` can fire it
-    /// when a termination signal arrives. Cloning an `Arc<Notify>` is
-    /// cheap and lets the signal handler outlive the borrow of `Scout`.
-    pub fn cancel_handle(&self) -> Arc<Notify> {
+    /// Hand back a cloned `watch::Sender` so `lib::run` can flip the
+    /// cancellation flag without keeping a reference to `Scout`. The clone
+    /// shares state with every receiver subscribed from the underlying
+    /// fetch paths.
+    pub fn cancel_handle(&self) -> watch::Sender<bool> {
         self.cancel.clone()
     }
 
@@ -1108,7 +1111,7 @@ mod tests {
             fetch_http,
             brave: Some(BraveClient::with_base_url(http, brave_uri)),
             github: cell,
-            cancel: Arc::new(Notify::new()),
+            cancel: watch::channel(false).0,
         }
     }
 
@@ -1119,7 +1122,7 @@ mod tests {
             fetch_http,
             brave: Some(BraveClient::with_base_url(http, brave_uri)),
             github: OnceCell::new(),
-            cancel: Arc::new(Notify::new()),
+            cancel: watch::channel(false).0,
         }
     }
 


### PR DESCRIPTION
## 概要

scout が SIGINT/SIGTERM を受けた際、`fetch_with_cdp` 内の `browser.close().await` を含む graceful close path が走らずに chromium parent が SIGKILL される問題を解消する。`Scout` に sticky な cancellation flag (`tokio::sync::watch::Sender<bool>`) を持たせ、`lib::run` の signal arm から flip、`fetch_with_cdp` が `wait_for` でその flag を listen する。

## 変更点

- `src/tools.rs`: `Scout` に `cancel: watch::Sender<bool>` を追加。`Scout::new()` で `watch::channel(false)` を初期化、`cancel_handle()` で `Sender` の clone を返す
- `src/fetch.rs`:
  - `fetch_page` / `fetch_with_cdp` に `cancel: &watch::Sender<bool>` を追加
  - `fetch_with_cdp` の navigate を `tokio::select! { biased; rx.wait_for(|&v| v) | navigate timeout }` で race。cancel / timeout / 正常完了の全パスで既存の `browser.close().await` (5s timeout) が走る
  - `BrowserError::Cancelled` variant 追加 (`FetchError::Timeout` 経由でマップ)
  - js-rendering 無効 build 用に `#[cfg(not(feature = \"js-rendering\"))] let _ = cancel;` で unused 警告を抑止
- `src/search/engine.rs`: `research` / `fetch_sources` のシグネチャに cancel を追加し、depth=N の並列 `fetch_page` 群へ伝播
- `src/lib.rs`:
  - `Outcome<T>` enum と `SHUTDOWN_DRAIN_TIMEOUT = 7s` を crate-local 定義
  - command future を `tokio::pin!` し、`tokio::select!` の Interrupted arm で `cancel.send(true)` + `tokio::time::timeout(7s, &mut cmd_fut).await` で bounded drain
- `src/signals.rs`: 前 PR の `Outcome` / `select_outcome` 抽象を撤回 (drain ロジックが lib.rs inline に必要なため)
- `--help` / README は変更なし (前 PR で 130/143 既に追加済み)

## スコープ

- **対象**: SIGINT/SIGTERM 経路で `browser.close()` を経由する graceful close path を統一する
- **対象外**: chromium subprocess (Google Chrome Helper 等) の完全排除。手動検証で正常終了パスでも T+30s で subprocess が ppid=1 reparent され残存することを確認。macOS には PR_SET_PDEATHSIG 無く `browser.close()` でも到達不能、process-group kill が必要なため別 issue #123 へ切り出し
- `chrome_crashpad_handler` の長生きは Chrome ship の crash reporter の by design 仕様、許容する

## 設計判断

- **`Notify` → `watch::Sender<bool>` (sticky cancellation)**: 当初 `Arc<Notify>` で試みたが、`Notify::notify_waiters()` は wakeup を貯めない semantics で、(a) signal が reqwest download 中 (cancel subscriber 未登録) に到着、または (b) `research --depth 6..=10` で concurrency cap で queue 待機中のスロットが後から起動した場合に wakeup を取りこぼす。`watch::Receiver::wait_for` は predicate が現在値で true なら即 resolve するため sticky であり、subscribe-before-signal race を排除できる。Codex P2 + reviewer-efficiency Major の重複指摘
- **`tokio_util::sync::CancellationToken` ではなく `tokio::sync::watch`**: `tokio_util` は transitive dep のみで `sync` feature 未活性、direct dep 追加が必要。`watch` は std tokio で機能等価
- **`enum Outcome<T>` を lib.rs ローカル定義**: 前 PR で `signals` モジュールに置いたが、本 PR では Interrupted arm 内で drain ロジック (cmd_fut の継続 await) が必要になり、`select_outcome` の generic 抽象では cmd_fut を pin して再 await できない。inline で `tokio::select!` を書く方が筋良く、`Outcome` 型もそこに近い場所に置いた
- **drain timeout 7s**: `browser.close()` の internal 5s + chromium 自身の subprocess cleanup 余裕で 7s。AI caller から「ハング」と感じない範囲
- **不採用**: `fetch_with_cdp` 入り口での pre-check + 重複 cleanup。enhancer-code 指摘で `wait_for` の sticky 契約を信頼すれば `select!` だけで already-cancelled も cover でき、cleanup 単一化が可能

## テスト方法

### 自動テスト

`cargo nextest run --offline` → 368 tests pass / 0 skipped
`cargo check --all-targets --features js-rendering --offline` → clean

### 手動検証 (SIGINT during CDP launch)

```
$ ./target/debug/scout fetch --js https://example.com >/dev/null 2>/tmp/e.txt &
$ sleep 2 && kill -INT $!
$ wait $!
$ echo "exit code => $?"
exit code => 130

stderr (出力サンプル):
  scout::tools  fetch url=https://example.com js=true raw=false
  scout::fetch  --js flag set, requesting JS rendering
  scout         interrupted, draining for graceful close signal=SIGINT
  scout::tools  fetch complete url=https://example.com   ← graceful close path 完走
  error         interrupted (SIGINT)
```

`fetch complete` が中断ログ後に出る = `browser.close().await` を含む完全な後始末が drain 7s 以内に完了している。

### Polish 結果

- Codex P1 (test callsite 漏れ) / P2 (sticky cancellation) を適用
- reviewer-efficiency Major (lost wakeup race) を適用
- reviewer-readability: 重複 `tracing::info!` 削除
- enhancer-code: `fetch_with_cdp` 入り口の pre-check + 重複 cleanup を簡素化
- reviewer-reuse: findings なし
- CodeRabbit: findings なし

## 関連

- Closes #121
- 関連: #123 (subprocess 完全排除のための process-group kill)
- 前 PR: #122 (SIGINT/SIGTERM handler 導入)