### PR TITLE
scout の timeout/retry を SCOUT_* env var で override 可能にする

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -5,6 +5,8 @@ use reqwest::Client;
 use tracing::{debug, warn};
 
 use crate::redacted::{Redacted, validate_https};
+#[cfg(test)]
+use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
     is_transient_network, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
@@ -80,6 +82,7 @@ pub(crate) struct BraveClient {
     http: Client,
     api_key: Redacted,
     base_url: String,
+    max_retries: u32,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `send_request` always
     /// runs `validate_https`; only `with_base_url` opts in.
@@ -88,17 +91,18 @@ pub(crate) struct BraveClient {
 }
 
 impl BraveClient {
-    /// Constructs a `BraveClient` from the `BRAVE_SEARCH_API_KEY` env var.
-    pub(crate) fn from_env(http: Client) -> Result<Self, BraveError> {
-        Self::from_env_with(http, |k| env::var(k))
+    pub(crate) fn from_env(http: Client, max_retries: u32) -> Result<Self, BraveError> {
+        Self::from_env_with(http, max_retries, |k| env::var(k))
     }
 
-    /// Constructs a `BraveClient` using a caller-supplied env reader. The
-    /// production [`Self::from_env`] delegates here with `std::env::var`;
-    /// unit tests pass a closure so the env-not-set / whitespace branches
-    /// can be exercised without `unsafe_code = "forbid"` rejecting
-    /// `set_var`.
-    pub(crate) fn from_env_with<F>(http: Client, get_var: F) -> Result<Self, BraveError>
+    /// Wraps [`Self::from_env`] with a caller-supplied env reader so unit
+    /// tests can exercise the env-not-set / whitespace branches without
+    /// `unsafe { std::env::set_var(...) }` (forbidden by `unsafe_code = "forbid"`).
+    pub(crate) fn from_env_with<F>(
+        http: Client,
+        max_retries: u32,
+        get_var: F,
+    ) -> Result<Self, BraveError>
     where
         F: Fn(&str) -> Result<String, env::VarError>,
     {
@@ -110,6 +114,7 @@ impl BraveClient {
             http,
             api_key: Redacted::new(&api_key),
             base_url: API_BASE.to_owned(),
+            max_retries,
             #[cfg(test)]
             skip_https_check: false,
         })
@@ -121,6 +126,7 @@ impl BraveClient {
             http,
             api_key: Redacted::new("test-key"),
             base_url: base_url.to_owned(),
+            max_retries: DEFAULT_MAX_RETRIES,
             skip_https_check: true,
         }
     }
@@ -233,6 +239,7 @@ impl SearchClient for BraveClient {
     ) -> Result<Vec<SearchResult>, BraveError> {
         let response = retry_with_rate_limit(
             || self.send_request(query, search_lang),
+            self.max_retries,
             is_retriable,
             |e| match e {
                 BraveError::RateLimited { retry_after } => *retry_after,
@@ -500,7 +507,9 @@ mod http_tests {
     /// env path that `from_env` delegates to.
     #[test]
     fn from_env_with_returns_api_key_not_set_when_closure_errs() {
-        let result = BraveClient::from_env_with(Client::new(), |_| Err(env::VarError::NotPresent));
+        let result = BraveClient::from_env_with(Client::new(), DEFAULT_MAX_RETRIES, |_| {
+            Err(env::VarError::NotPresent)
+        });
         assert!(
             matches!(result, Err(BraveError::ApiKeyNotSet)),
             "expected ApiKeyNotSet, got: {result:?}"
@@ -513,7 +522,12 @@ mod http_tests {
     /// `from_env`).
     #[test]
     fn from_env_with_rejects_whitespace_only_key() {
-        let result = BraveClient::from_env_with(Client::new(), |_| Ok("   ".to_owned()));
+        let result =
+            BraveClient::from_env_with(
+                Client::new(),
+                DEFAULT_MAX_RETRIES,
+                |_| Ok("   ".to_owned()),
+            );
         assert!(
             matches!(result, Err(BraveError::ApiKeyNotSet)),
             "expected ApiKeyNotSet for whitespace-only key, got: {result:?}"
@@ -526,7 +540,9 @@ mod http_tests {
     /// the constant `API_BASE`.
     #[test]
     fn from_env_with_constructs_client_with_api_base_and_exposed_key() {
-        let result = BraveClient::from_env_with(Client::new(), |_| Ok("real-key".to_owned()));
+        let result = BraveClient::from_env_with(Client::new(), DEFAULT_MAX_RETRIES, |_| {
+            Ok("real-key".to_owned())
+        });
         let client = result.expect("expected Ok(client) from valid key");
         assert_eq!(client.api_key.expose(), "real-key");
         assert_eq!(client.base_url, API_BASE);
@@ -538,8 +554,9 @@ mod http_tests {
     /// must be `false` when the client comes from `from_env_with`.
     #[test]
     fn from_env_with_does_not_set_skip_https_check() {
-        let client = BraveClient::from_env_with(Client::new(), |_| Ok("k".to_owned()))
-            .expect("expected Ok(client) from valid key");
+        let client =
+            BraveClient::from_env_with(Client::new(), DEFAULT_MAX_RETRIES, |_| Ok("k".to_owned()))
+                .expect("expected Ok(client) from valid key");
         assert!(
             !client.skip_https_check,
             "production constructor must not skip HTTPS check"

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,12 +3,6 @@ pub(crate) mod format;
 mod helpers;
 pub(crate) mod types;
 
-use helpers::encode_path;
-pub(crate) use helpers::{
-    apply_line_range, decode_content, filter_tree_entries, parse_line_range, parse_repo,
-    validate_path, validate_ref,
-};
-
 use std::env;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -20,18 +14,24 @@ use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
 use crate::redacted::{Redacted, validate_https};
+#[cfg(test)]
+use crate::retry::DEFAULT_MAX_RETRIES;
+use crate::retry::{
+    is_schema_decode_fail, is_transient_network, parse_retry_after, retry_after_within_cap,
+    retry_with_rate_limit,
+};
 
+use helpers::encode_path;
+pub(crate) use helpers::{
+    apply_line_range, decode_content, filter_tree_entries, parse_line_range, parse_repo,
+    validate_path, validate_ref,
+};
 use types::{
     BlobResponse, ContentsResponse, IssueInfo, PullInfo, ReleaseInfo, RepoInfo, TreeResponse,
 };
 
 const API_BASE: &str = "https://api.github.com";
 const TOKEN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
-
-use crate::retry::{
-    is_schema_decode_fail, is_transient_network, parse_retry_after, retry_after_within_cap,
-    retry_with_rate_limit,
-};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum GitHubError {
@@ -90,6 +90,7 @@ pub(crate) struct GitHubClient {
     http: Client,
     token: Option<Redacted>,
     base_url: String,
+    max_retries: u32,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `request` always runs
     /// `validate_https`; only `with_base_url` opts in.
@@ -98,7 +99,7 @@ pub(crate) struct GitHubClient {
 }
 
 impl GitHubClient {
-    pub async fn from_env(http: Client) -> Self {
+    pub async fn from_env(http: Client, max_retries: u32) -> Self {
         let token = resolve_token().await;
         if token.is_some() {
             debug!("GitHub token configured");
@@ -111,6 +112,7 @@ impl GitHubClient {
             http,
             token,
             base_url: API_BASE.to_owned(),
+            max_retries,
             #[cfg(test)]
             skip_https_check: false,
         }
@@ -122,6 +124,7 @@ impl GitHubClient {
             http,
             token: None,
             base_url: base_url.to_owned(),
+            max_retries: DEFAULT_MAX_RETRIES,
             skip_https_check: true,
         }
     }
@@ -158,6 +161,7 @@ impl GitHubClient {
     async fn get_json<T: DeserializeOwned>(&self, path: &str) -> Result<T, GitHubError> {
         retry_with_rate_limit(
             || self.get_json_once(path),
+            self.max_retries,
             is_retriable,
             |e| match e {
                 GitHubError::RateLimited { retry_after } => *retry_after,
@@ -417,7 +421,6 @@ mod http_tests {
     use std::sync::atomic::Ordering;
 
     use super::*;
-    use crate::retry::MAX_RETRIES;
     use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
@@ -650,7 +653,9 @@ mod http_tests {
     }
 
     /// [T-GH013] 2xx mid-stream body drop is treated as transient and the
-    /// retry loop exhausts MAX_RETRIES attempts before failing (issue #113).
+    /// retry loop exhausts the configured max_retries attempts before failing
+    /// (issue #113). The test uses the client default (3); issue #120 lets
+    /// production callers override the budget via `SCOUT_MAX_RETRIES`.
     ///
     /// reqwest 0.13 surfaces a mid-stream drop as `is_decode() == true` with
     /// an io::Error in the source chain. Without `is_transient_decode`,
@@ -663,7 +668,9 @@ mod http_tests {
     /// TcpListener is unaffected. Total wall time stays under 100 ms.
     #[tokio::test(start_paused = true)]
     async fn get_json_2xx_mid_stream_drop_exhausts_retries() {
-        let expected_attempts = usize::try_from(MAX_RETRIES).expect("MAX_RETRIES fits usize");
+        // Total attempts = 1 (initial) + DEFAULT_MAX_RETRIES (retries).
+        let expected_attempts =
+            usize::try_from(DEFAULT_MAX_RETRIES + 1).expect("DEFAULT_MAX_RETRIES + 1 fits usize");
         let Some((url, counter, handle)) = spawn_mid_stream_drop_server(expected_attempts) else {
             return;
         };
@@ -678,7 +685,7 @@ mod http_tests {
         assert_eq!(
             counter.load(Ordering::SeqCst),
             expected_attempts,
-            "retry loop must consume MAX_RETRIES connections"
+            "retry loop must consume the full max_retries budget"
         );
 
         let _ = handle.join();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,19 @@ Exit codes (sysexits.h + GNU coreutils + POSIX signal convention):
   143  Interrupted by SIGTERM (128 + 15; e.g. shell timeout, kill default)
 
 Environment:
-  BRAVE_SEARCH_API_KEY  Required for search and research commands
-  GITHUB_TOKEN          Optional for GitHub commands (higher rate limits)"
+  BRAVE_SEARCH_API_KEY          Required for search and research commands
+  GITHUB_TOKEN                  Optional for GitHub commands (higher rate limits)
+  SLACK_TOKEN                   Optional. User OAuth token (xoxp-…) required for Slack URLs
+
+Tuning (override built-in timeouts and retry budget):
+  SCOUT_FETCH_TIMEOUT_SECS      fetch wall-clock budget per URL (default 95, range 1-600)
+  SCOUT_RESEARCH_TIMEOUT_SECS   research wall-clock budget (default 45, range 1-600)
+  SCOUT_SLACK_TIMEOUT_SECS      slack fetch wall-clock budget (default 60, range 1-600)
+  SCOUT_MAX_RETRIES             retries on transient API failures, on top of the
+                                initial attempt (default 2 → 3 total attempts,
+                                range 0-10; set to 0 to disable retry)
+
+Invalid tuning values fail with exit 64 (usage error) before any request is made."
 )]
 pub(crate) struct Cli {
     /// Emit output as a JSON envelope (one line) on stdout
@@ -319,6 +330,29 @@ mod tests {
         assert!(
             help.contains("SIGTERM"),
             "root help missing SIGTERM (143) description"
+        );
+    }
+
+    /// [T-H001] root --help exposes SCOUT_* tuning env vars (issue #120).
+    /// AI agents discover override knobs by reading --help; missing entries
+    /// would force agents to read the source.
+    #[test]
+    fn root_help_lists_scout_tuning_env_vars() {
+        let help = super::Cli::command().render_long_help().to_string();
+        for var in [
+            "SCOUT_FETCH_TIMEOUT_SECS",
+            "SCOUT_RESEARCH_TIMEOUT_SECS",
+            "SCOUT_SLACK_TIMEOUT_SECS",
+            "SCOUT_MAX_RETRIES",
+        ] {
+            assert!(
+                help.contains(var),
+                "root help must list {var} so agents can discover the override"
+            );
+        }
+        assert!(
+            help.contains("SLACK_TOKEN"),
+            "root help should list SLACK_TOKEN alongside other auth env vars"
         );
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -8,9 +8,13 @@ use reqwest::header::{HeaderMap, RETRY_AFTER};
 use tokio::time::sleep;
 use tracing::debug;
 
-pub(crate) const MAX_RETRIES: u32 = 3;
 const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_RETRY_AFTER_SECS: u64 = 300;
+
+/// Default retry count used by every backend client when no override is
+/// supplied. The helper performs `1 + DEFAULT_MAX_RETRIES` total attempts,
+/// so `2` yields the 3-attempt budget that backends are tuned against.
+pub(crate) const DEFAULT_MAX_RETRIES: u32 = 2;
 
 pub(crate) fn jittered_backoff(attempt: u32) -> u64 {
     let base = INITIAL_BACKOFF_MS.saturating_mul(2u64.saturating_pow(attempt));
@@ -51,8 +55,14 @@ fn is_transient_decode(e: &Error) -> bool {
     false
 }
 
+/// Run `operation` up to `max_retries + 1` times: one initial attempt
+/// plus `max_retries` retries on retriable failures. Names follow the
+/// user-facing contract — `SCOUT_MAX_RETRIES=N` means "N retries on top
+/// of the original attempt", so `=0` runs once (no retry), `=2` runs at
+/// most three times.
 async fn retry_with<T, E, F, Fut>(
     operation: F,
+    max_retries: u32,
     is_retriable: impl Fn(&E) -> bool,
     delay_for: impl Fn(&E, u32) -> Duration,
     fallback_err: impl FnOnce() -> E,
@@ -62,11 +72,11 @@ where
     Fut: Future<Output = Result<T, E>>,
 {
     let mut last_err = None;
-    for attempt in 0..MAX_RETRIES {
+    for attempt in 0..=max_retries {
         match operation().await {
             Ok(v) => return Ok(v),
             Err(e) if is_retriable(&e) => {
-                if attempt + 1 < MAX_RETRIES {
+                if attempt < max_retries {
                     let delay = delay_for(&e, attempt);
                     debug!(
                         attempt = attempt + 1,
@@ -116,6 +126,7 @@ pub(crate) fn retry_after_or_backoff(retry_after: Option<u64>, attempt: u32) -> 
 /// typically via `retry_after_within_cap`.
 pub(crate) async fn retry_with_rate_limit<T, E, F, Fut>(
     operation: F,
+    max_retries: u32,
     is_retriable: impl Fn(&E) -> bool,
     extract_retry_after: impl Fn(&E) -> Option<u64>,
     fallback_err: impl FnOnce() -> E,
@@ -126,6 +137,7 @@ where
 {
     retry_with(
         operation,
+        max_retries,
         is_retriable,
         |e, attempt| retry_after_or_backoff(extract_retry_after(e), attempt),
         fallback_err,
@@ -194,6 +206,7 @@ mod tests {
                     Ok("ok")
                 }
             },
+            2,
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
@@ -219,9 +232,10 @@ mod tests {
 
     // T-R002: applies_jittered_backoff_when_extractor_returns_none
     // FR-002: non-RateLimited transient error always returns None from the
-    // extractor. Helper exhausts MAX_RETRIES (=3 attempts, 2 sleeps) using
-    // jittered exponential backoff. Total elapsed must fall within the
-    // backoff envelope: half + jitter for attempt 0 + attempt 1.
+    // extractor. Helper exhausts 1 + max_retries (=3 attempts when
+    // max_retries=2, 2 sleeps) using jittered exponential backoff. Total
+    // elapsed must fall within the backoff envelope: half + jitter for
+    // attempt 0 + attempt 1.
     #[tokio::test(start_paused = true)]
     async fn applies_jittered_backoff_when_extractor_returns_none() {
         let attempts = AtomicUsize::new(0);
@@ -232,6 +246,7 @@ mod tests {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Err(MockErr::Other)
             },
+            2,
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
@@ -243,8 +258,8 @@ mod tests {
         assert_eq!(result, Err(MockErr::Other));
         assert_eq!(
             attempts.load(Ordering::SeqCst),
-            usize::try_from(MAX_RETRIES).expect("MAX_RETRIES fits usize"),
-            "expected MAX_RETRIES invocations when every attempt fails"
+            3usize,
+            "expected 1 + max_retries (=3) invocations when every attempt fails"
         );
         // jittered_backoff(0) ∈ [500ms, 1000ms), jittered_backoff(1) ∈ [1000ms, 2000ms).
         // Sum of the two sleeps therefore ∈ [1500ms, 3000ms). Upper bound
@@ -268,6 +283,7 @@ mod tests {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Err(MockErr::RateLimited(Some(500)))
             },
+            2,
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
@@ -279,6 +295,40 @@ mod tests {
             attempts.load(Ordering::SeqCst),
             1,
             "expected no retry when retry_after exceeds MAX_RETRY_AFTER_SECS"
+        );
+    }
+
+    // T-R006: max_retries_zero_runs_once_without_retry
+    // Issue #120: `SCOUT_MAX_RETRIES=0` must disable retries entirely.
+    // The contract is "N retries on top of the original attempt", so 0
+    // means a single attempt with no sleep — the user-visible inverse of
+    // the default (=2 → 3 attempts).
+    #[tokio::test(start_paused = true)]
+    async fn max_retries_zero_runs_once_without_retry() {
+        let attempts = AtomicUsize::new(0);
+        let start = Instant::now();
+
+        let result: Result<(), MockErr> = retry_with_rate_limit(
+            || async {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(MockErr::Other)
+            },
+            0,
+            mock_is_retriable,
+            mock_extract_retry_after,
+            || MockErr::Other,
+        )
+        .await;
+
+        assert_eq!(result, Err(MockErr::Other));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "max_retries=0 must run exactly 1 attempt"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(50),
+            "no backoff sleep should occur when max_retries=0"
         );
     }
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -9,6 +9,8 @@ use tracing::{debug, info, warn};
 
 use crate::fetch::converter::escape_yaml;
 use crate::redacted::{Redacted, validate_https};
+#[cfg(test)]
+use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
     is_schema_decode_fail, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
@@ -141,6 +143,7 @@ pub(crate) struct SlackClient {
     http: Client,
     token: Redacted,
     base_url: String,
+    max_retries: u32,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `api_get_once` always
     /// runs `validate_https`; only `with_base_url` opts in.
@@ -151,22 +154,23 @@ pub(crate) struct SlackClient {
 const API_BASE: &str = "https://slack.com/api";
 
 impl SlackClient {
-    pub fn new(http: Client, token: Redacted) -> Self {
+    pub fn new(http: Client, token: Redacted, max_retries: u32) -> Self {
         Self {
             http,
             token,
             base_url: API_BASE.to_owned(),
+            max_retries,
             #[cfg(test)]
             skip_https_check: false,
         }
     }
 
-    pub fn from_env(http: Client) -> Result<Self, SlackError> {
+    pub fn from_env(http: Client, max_retries: u32) -> Result<Self, SlackError> {
         let raw = env::var("SLACK_TOKEN").map_err(|_| SlackError::TokenNotSet)?;
         if raw.trim().is_empty() {
             return Err(SlackError::TokenNotSet);
         }
-        Ok(Self::new(http, Redacted::new(&raw)))
+        Ok(Self::new(http, Redacted::new(&raw), max_retries))
     }
 
     #[cfg(test)]
@@ -175,6 +179,7 @@ impl SlackClient {
             http,
             token: Redacted::new("xoxp-test"),
             base_url: base_url.to_owned(),
+            max_retries: DEFAULT_MAX_RETRIES,
             skip_https_check: true,
         }
     }
@@ -198,6 +203,7 @@ impl SlackClient {
     ) -> Result<T, SlackError> {
         retry_with_rate_limit(
             || self.api_get_once(method, params),
+            self.max_retries,
             is_retriable,
             |e| match e {
                 SlackError::RateLimited { retry_after } => *retry_after,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,9 +1,12 @@
+mod config;
 mod errors;
 mod params;
 mod typo;
 
 pub use errors::ScoutError;
 pub use params::Command;
+
+pub(crate) use config::RuntimeConfig;
 
 use std::io::{IsTerminal, stdin};
 use std::time::Duration;
@@ -116,18 +119,10 @@ async fn resolve_stdin_arg(
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
-/// HTTP_TIMEOUT (30s) + CDP_TIMEOUT (60s) + 5s margin.
-const FETCH_TOOL_TIMEOUT: Duration = Duration::from_secs(95);
 const MAX_REDIRECTS: usize = 5;
 const OVERVIEW_ITEMS: u8 = 5;
 const OVERVIEW_RELEASES: u8 = 3;
 const MAX_FETCH_OUTPUT_BYTES: usize = 100_000;
-/// Slack: up to 3 API calls + N user resolutions; 60s covers large threads.
-const SLACK_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
-/// Research: Brave search (up to 20s + retries) + up to 10 page fetches (15s each).
-/// 45s caps total wall-clock at the orchestration layer; without this cap a degraded
-/// Brave + full-depth fetch could block ~210s.
-const RESEARCH_TOOL_TIMEOUT: Duration = Duration::from_secs(45);
 
 pub struct Scout {
     http: Client,
@@ -145,10 +140,13 @@ pub struct Scout {
     /// earlier slot finishes). `Notify` was tried first but loses wakeups
     /// when no waiter is registered at signal time (issue #121).
     cancel: watch::Sender<bool>,
+    /// Tunables overridable via `SCOUT_*` env vars (issue #120).
+    config: RuntimeConfig,
 }
 
 impl Scout {
     pub async fn new() -> Result<Self, ScoutError> {
+        let config = RuntimeConfig::from_env()?;
         let http = Client::builder()
             .connect_timeout(CONNECT_TIMEOUT)
             .timeout(HTTP_TIMEOUT)
@@ -161,7 +159,7 @@ impl Scout {
             .redirect(Policy::none())
             .build()
             .map_err(|e| ScoutError::io_error(format!("HTTP client init failed: {e}")))?;
-        let brave = BraveClient::from_env(http.clone())
+        let brave = BraveClient::from_env(http.clone(), config.max_retries)
             .inspect_err(|e| warn!("Brave client not available: {e}"))
             .ok();
         let (cancel, _) = watch::channel(false);
@@ -171,6 +169,7 @@ impl Scout {
             brave,
             github: OnceCell::new(),
             cancel,
+            config,
         })
     }
 
@@ -184,7 +183,7 @@ impl Scout {
 
     async fn github(&self) -> &GitHubClient {
         self.github
-            .get_or_init(|| GitHubClient::from_env(self.http.clone()))
+            .get_or_init(|| GitHubClient::from_env(self.http.clone(), self.config.max_retries))
             .await
     }
 
@@ -244,8 +243,9 @@ impl Scout {
             js: params.js,
             raw: params.raw,
         };
+        let fetch_timeout = self.config.fetch_timeout;
         let result = timeout(
-            FETCH_TOOL_TIMEOUT,
+            fetch_timeout,
             fetch_page(
                 &self.fetch_http,
                 &url,
@@ -258,7 +258,7 @@ impl Scout {
         .unwrap_or_else(|_| {
             Err(FetchError::Timeout(format!(
                 "fetch timed out after {}s",
-                FETCH_TOOL_TIMEOUT.as_secs()
+                fetch_timeout.as_secs()
             )))
         })?;
 
@@ -283,13 +283,14 @@ impl Scout {
 
     async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<CommandOutput, ScoutError> {
         info!(workspace = %slack_url.workspace, channel = %slack_url.channel, "fetch (slack)");
-        let client = SlackClient::from_env(self.http.clone())?;
-        let output = timeout(SLACK_TOOL_TIMEOUT, client.fetch_message(&slack_url))
+        let client = SlackClient::from_env(self.http.clone(), self.config.max_retries)?;
+        let slack_timeout = self.config.slack_timeout;
+        let output = timeout(slack_timeout, client.fetch_message(&slack_url))
             .await
             .unwrap_or_else(|_| {
                 Err(SlackError::Timeout(format!(
                     "slack fetch timed out after {}s",
-                    SLACK_TOOL_TIMEOUT.as_secs()
+                    slack_timeout.as_secs()
                 )))
             })
             .inspect_err(|e| {
@@ -318,8 +319,9 @@ impl Scout {
 
         let mut degradation = Degradation::default();
 
+        let research_timeout = self.config.research_timeout;
         let report = match timeout(
-            RESEARCH_TOOL_TIMEOUT,
+            research_timeout,
             engine::research(
                 brave,
                 &self.fetch_http,
@@ -347,7 +349,7 @@ impl Scout {
             Err(_) => {
                 return Err(ScoutError::timeout(format!(
                     "research timed out after {}s",
-                    RESEARCH_TOOL_TIMEOUT.as_secs()
+                    research_timeout.as_secs()
                 )));
             }
         };
@@ -1112,6 +1114,7 @@ mod tests {
             brave: Some(BraveClient::with_base_url(http, brave_uri)),
             github: cell,
             cancel: watch::channel(false).0,
+            config: RuntimeConfig::default(),
         }
     }
 
@@ -1123,6 +1126,7 @@ mod tests {
             brave: Some(BraveClient::with_base_url(http, brave_uri)),
             github: OnceCell::new(),
             cancel: watch::channel(false).0,
+            config: RuntimeConfig::default(),
         }
     }
 

--- a/src/tools/config.rs
+++ b/src/tools/config.rs
@@ -1,0 +1,279 @@
+use std::env;
+use std::time::Duration;
+
+use crate::retry::DEFAULT_MAX_RETRIES;
+
+use super::errors::ScoutError;
+
+const DEFAULT_FETCH_TIMEOUT_SECS: u64 = 95;
+const DEFAULT_RESEARCH_TIMEOUT_SECS: u64 = 45;
+const DEFAULT_SLACK_TIMEOUT_SECS: u64 = 60;
+
+const ENV_FETCH_TIMEOUT: &str = "SCOUT_FETCH_TIMEOUT_SECS";
+const ENV_RESEARCH_TIMEOUT: &str = "SCOUT_RESEARCH_TIMEOUT_SECS";
+const ENV_SLACK_TIMEOUT: &str = "SCOUT_SLACK_TIMEOUT_SECS";
+const ENV_MAX_RETRIES: &str = "SCOUT_MAX_RETRIES";
+
+const TIMEOUT_MIN_SECS: u64 = 1;
+const TIMEOUT_MAX_SECS: u64 = 600;
+/// Upper bound on the retry count. `10` was picked so a misconfigured
+/// agent cannot starve scout by chaining requests; combined with the
+/// default 1s+ backoff this caps the worst-case retry wall-clock around
+/// 30s before the surrounding `*_TOOL_TIMEOUT` cuts in.
+const RETRIES_CAP: u32 = 10;
+
+/// Runtime tuning loaded from `SCOUT_*` env vars. Each field has a
+/// hard-coded default and validates against a min/max range so a
+/// misconfigured agent fails fast instead of running with an extreme value.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RuntimeConfig {
+    pub(crate) fetch_timeout: Duration,
+    pub(crate) research_timeout: Duration,
+    pub(crate) slack_timeout: Duration,
+    pub(crate) max_retries: u32,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            fetch_timeout: Duration::from_secs(DEFAULT_FETCH_TIMEOUT_SECS),
+            research_timeout: Duration::from_secs(DEFAULT_RESEARCH_TIMEOUT_SECS),
+            slack_timeout: Duration::from_secs(DEFAULT_SLACK_TIMEOUT_SECS),
+            max_retries: DEFAULT_MAX_RETRIES,
+        }
+    }
+}
+
+impl RuntimeConfig {
+    pub(crate) fn from_env() -> Result<Self, ScoutError> {
+        Self::from_env_with(|k| env::var(k))
+    }
+
+    /// Wraps [`Self::from_env`] with a caller-supplied env reader so tests
+    /// can exercise parse and range failures without
+    /// `unsafe { std::env::set_var(...) }` (forbidden by `unsafe_code = "forbid"`).
+    pub(crate) fn from_env_with<F>(get_var: F) -> Result<Self, ScoutError>
+    where
+        F: Fn(&str) -> Result<String, env::VarError>,
+    {
+        Ok(Self {
+            fetch_timeout: parse_timeout(&get_var, ENV_FETCH_TIMEOUT, DEFAULT_FETCH_TIMEOUT_SECS)?,
+            research_timeout: parse_timeout(
+                &get_var,
+                ENV_RESEARCH_TIMEOUT,
+                DEFAULT_RESEARCH_TIMEOUT_SECS,
+            )?,
+            slack_timeout: parse_timeout(&get_var, ENV_SLACK_TIMEOUT, DEFAULT_SLACK_TIMEOUT_SECS)?,
+            max_retries: parse_max_retries(&get_var)?,
+        })
+    }
+}
+
+/// Read an env var with the "unset means default, anything else must parse"
+/// contract. `VarError::NotUnicode` is treated as a configured-but-invalid
+/// value (UsageError), not as "absent" — the agent shouldn't accidentally
+/// fall through to the default when the value was set but unreadable.
+fn read_env_raw<F>(get_var: &F, key: &str) -> Result<Option<String>, ScoutError>
+where
+    F: Fn(&str) -> Result<String, env::VarError>,
+{
+    match get_var(key) {
+        Ok(v) => Ok(Some(v)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => {
+            Err(ScoutError::user_error(format!("{key} must be valid UTF-8")))
+        }
+    }
+}
+
+fn parse_timeout<F>(get_var: &F, key: &str, default: u64) -> Result<Duration, ScoutError>
+where
+    F: Fn(&str) -> Result<String, env::VarError>,
+{
+    let Some(raw) = read_env_raw(get_var, key)? else {
+        return Ok(Duration::from_secs(default));
+    };
+    let secs: u64 = raw.trim().parse().map_err(|_| {
+        ScoutError::user_error(format!(
+            "{key} must be an integer between {TIMEOUT_MIN_SECS} and {TIMEOUT_MAX_SECS} seconds, got: {raw:?}"
+        ))
+    })?;
+    if !(TIMEOUT_MIN_SECS..=TIMEOUT_MAX_SECS).contains(&secs) {
+        return Err(ScoutError::user_error(format!(
+            "{key} must be between {TIMEOUT_MIN_SECS} and {TIMEOUT_MAX_SECS} seconds, got: {secs}"
+        )));
+    }
+    Ok(Duration::from_secs(secs))
+}
+
+fn parse_max_retries<F>(get_var: &F) -> Result<u32, ScoutError>
+where
+    F: Fn(&str) -> Result<String, env::VarError>,
+{
+    let Some(raw) = read_env_raw(get_var, ENV_MAX_RETRIES)? else {
+        return Ok(DEFAULT_MAX_RETRIES);
+    };
+    let n: u32 = raw.trim().parse().map_err(|_| {
+        ScoutError::user_error(format!(
+            "{ENV_MAX_RETRIES} must be an integer between 0 and {RETRIES_CAP}, got: {raw:?}"
+        ))
+    })?;
+    if n > RETRIES_CAP {
+        return Err(ScoutError::user_error(format!(
+            "{ENV_MAX_RETRIES} must be at most {RETRIES_CAP}, got: {n}"
+        )));
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::VarError;
+
+    use crate::envelope::ErrorCode;
+
+    use super::*;
+
+    fn empty_env(_: &str) -> Result<String, VarError> {
+        Err(VarError::NotPresent)
+    }
+
+    fn single_env(
+        target: &'static str,
+        value: &'static str,
+    ) -> impl Fn(&str) -> Result<String, VarError> {
+        move |k| {
+            if k == target {
+                Ok(value.to_owned())
+            } else {
+                Err(VarError::NotPresent)
+            }
+        }
+    }
+
+    /// [T-CFG001] env 未設定時はデフォルト値が使われる
+    #[test]
+    fn defaults_when_no_env_set() {
+        let cfg = RuntimeConfig::from_env_with(empty_env).unwrap();
+        assert_eq!(cfg.fetch_timeout, Duration::from_secs(95));
+        assert_eq!(cfg.research_timeout, Duration::from_secs(45));
+        assert_eq!(cfg.slack_timeout, Duration::from_secs(60));
+        assert_eq!(cfg.max_retries, 2);
+    }
+
+    /// [T-CFG002] SCOUT_FETCH_TIMEOUT_SECS=120 は fetch_timeout に反映され、他はデフォルト
+    #[test]
+    fn fetch_timeout_override_reflects_only_fetch() {
+        let cfg =
+            RuntimeConfig::from_env_with(single_env("SCOUT_FETCH_TIMEOUT_SECS", "120")).unwrap();
+        assert_eq!(cfg.fetch_timeout, Duration::from_secs(120));
+        assert_eq!(cfg.research_timeout, Duration::from_secs(45));
+        assert_eq!(cfg.slack_timeout, Duration::from_secs(60));
+        assert_eq!(cfg.max_retries, 2);
+    }
+
+    /// [T-CFG003] SCOUT_RESEARCH_TIMEOUT_SECS override が独立に効く
+    #[test]
+    fn research_timeout_override() {
+        let cfg =
+            RuntimeConfig::from_env_with(single_env("SCOUT_RESEARCH_TIMEOUT_SECS", "30")).unwrap();
+        assert_eq!(cfg.research_timeout, Duration::from_secs(30));
+        assert_eq!(cfg.fetch_timeout, Duration::from_secs(95));
+        assert_eq!(cfg.max_retries, 2);
+    }
+
+    /// [T-CFG004] SCOUT_SLACK_TIMEOUT_SECS override が独立に効く
+    #[test]
+    fn slack_timeout_override() {
+        let cfg =
+            RuntimeConfig::from_env_with(single_env("SCOUT_SLACK_TIMEOUT_SECS", "10")).unwrap();
+        assert_eq!(cfg.slack_timeout, Duration::from_secs(10));
+    }
+
+    /// [T-CFG005] SCOUT_MAX_RETRIES=5 が max_retries に反映される
+    #[test]
+    fn max_retries_override() {
+        let cfg = RuntimeConfig::from_env_with(single_env("SCOUT_MAX_RETRIES", "5")).unwrap();
+        assert_eq!(cfg.max_retries, 5);
+    }
+
+    /// [T-CFG006] SCOUT_MAX_RETRIES=0 (retry 無効) を許容
+    #[test]
+    fn max_retries_zero_is_allowed() {
+        let cfg = RuntimeConfig::from_env_with(single_env("SCOUT_MAX_RETRIES", "0")).unwrap();
+        assert_eq!(cfg.max_retries, 0);
+    }
+
+    /// [T-CFG010] parse 失敗（英字混入）は UsageError(64) で fail-fast
+    #[test]
+    fn non_integer_value_fails_fast() {
+        let err = RuntimeConfig::from_env_with(single_env("SCOUT_FETCH_TIMEOUT_SECS", "abc"))
+            .unwrap_err();
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+        assert_eq!(err.exit_code(), 64);
+        assert!(
+            err.message().contains("SCOUT_FETCH_TIMEOUT_SECS"),
+            "error should name the offending env var, got: {}",
+            err.message()
+        );
+    }
+
+    /// [T-CFG011] 空文字列は parse 失敗扱いで UsageError
+    #[test]
+    fn empty_value_fails_fast() {
+        let err = RuntimeConfig::from_env_with(single_env("SCOUT_MAX_RETRIES", "")).unwrap_err();
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+    }
+
+    /// [T-CFG012] 範囲外 timeout (0) は UsageError
+    #[test]
+    fn timeout_below_min_fails() {
+        let err =
+            RuntimeConfig::from_env_with(single_env("SCOUT_FETCH_TIMEOUT_SECS", "0")).unwrap_err();
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+        assert!(
+            err.message().contains("between"),
+            "error should mention the valid range, got: {}",
+            err.message()
+        );
+    }
+
+    /// [T-CFG013] 範囲外 timeout (601) は UsageError
+    #[test]
+    fn timeout_above_max_fails() {
+        let err = RuntimeConfig::from_env_with(single_env("SCOUT_RESEARCH_TIMEOUT_SECS", "601"))
+            .unwrap_err();
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+    }
+
+    /// [T-CFG014] 範囲外 retries (11) は UsageError
+    #[test]
+    fn max_retries_above_cap_fails() {
+        let err = RuntimeConfig::from_env_with(single_env("SCOUT_MAX_RETRIES", "11")).unwrap_err();
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+        assert!(
+            err.message().contains("at most"),
+            "error should mention the cap, got: {}",
+            err.message()
+        );
+    }
+
+    /// [T-CFG015] 負数は u64 parse 失敗で UsageError
+    #[test]
+    fn negative_value_fails() {
+        let err =
+            RuntimeConfig::from_env_with(single_env("SCOUT_SLACK_TIMEOUT_SECS", "-5")).unwrap_err();
+        assert_eq!(err.error_kind(), ErrorCode::UsageError);
+    }
+
+    /// [T-CFG020] Default impl は from_env_with(empty) と同値
+    #[test]
+    fn default_matches_empty_env() {
+        let from_empty = RuntimeConfig::from_env_with(empty_env).unwrap();
+        let from_default = RuntimeConfig::default();
+        assert_eq!(from_empty.fetch_timeout, from_default.fetch_timeout);
+        assert_eq!(from_empty.research_timeout, from_default.research_timeout);
+        assert_eq!(from_empty.slack_timeout, from_default.slack_timeout);
+        assert_eq!(from_empty.max_retries, from_default.max_retries);
+    }
+}


### PR DESCRIPTION
## 概要

Closes #120.

scout の主要 timeout / retry を compile-time const から `SCOUT_*` 環境変数による override に置き換える。AI エージェントが再ビルドなしにセッション猶予を調整できるようになる。

| 環境変数 | デフォルト | 範囲 |
|---|---|---|
| `SCOUT_FETCH_TIMEOUT_SECS` | 95 | 1-600 |
| `SCOUT_RESEARCH_TIMEOUT_SECS` | 45 | 1-600 |
| `SCOUT_SLACK_TIMEOUT_SECS` | 60 | 1-600 |
| `SCOUT_MAX_RETRIES` | 2 | 0-10 |

## 意味論の変更 (issue 表との差分)

Issue body の表は `SCOUT_MAX_RETRIES` の default を `3` と書いてるが、本 PR では `2` に変更。理由：

- 旧コードの `MAX_RETRIES=3` は実装上「3 attempts」(初回 + 2 retries) の意味。env var として "retries" 名で公開すると、`=0` と `=1` が同挙動になり名前と挙動が矛盾する
- 新意味論を「N retries on top of the initial attempt」に統一。`=0` で retry 完全無効、`=2` で 1 + 2 = 3 attempts (legacy 互換)
- 未設定時の **observable behaviour は変わらず** 3 attempts のまま

## 異常系

- Parse 失敗 / 範囲外 / 非 UTF-8 → `UsageError` で exit 64 (fail-fast)
- silent fallback なし

## テスト計画

- [x] `cargo nextest run --offline` (383 tests pass、14 new: T-CFG001-020, T-R006, T-H001)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `--help` に新 env var 4 本が露出することを T-H001 で固定
- [ ] (手動) `SCOUT_MAX_RETRIES=0 scout fetch ...` で retry が発生しないことを確認
- [ ] (手動) `SCOUT_FETCH_TIMEOUT_SECS=abc scout fetch ...` で exit 64 が返ることを確認
- [ ] (手動) `SCOUT_FETCH_TIMEOUT_SECS=601 scout fetch ...` で exit 64 が返ることを確認

## スコープ外

- `scout fetch` 自体への retry 追加 (issue 検討事項 3)。本 PR は「既存 timeout/retry の override」に限定。fetch retry の CDP 再起動コスト trade-off は別 issue として切り出し