### PR TITLE
chore(ci): Dependabot 設定に cooldown を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - ci
@@ -15,6 +17,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - rust


### PR DESCRIPTION
## 概要

GitHub Code Scanning が報告していた `zizmor/dependabot-cooldown` warning (alerts #1, #2) を解消するため、`.github/dependabot.yml` の両 ecosystem に 7 日の cooldown を追加する。

| ecosystem | 追加設定 |
|---|---|
| github-actions | `cooldown.default-days: 7` |
| cargo | `cooldown.default-days: 7` |

## なぜ 7 日

zizmor 作者自身のリポ (`woodruffw/zizmor`) と同値で、コミュニティ標準の cooldown 期間。新規 release が PR 化されるまで 7 日の猶予を入れ、悪意あるリリースが community / security vendor に flag される時間を確保する。

`cooldown` は version updates のみが対象で、security updates には適用されないため、緊急 security patch の到達は遅延しない。

## 検証

- [x] `zizmor .github/dependabot.yml` → `No findings to report. Good job!`
- [x] YAML 構文 OK

## スコープ外

- semver 粒度別 cooldown (`semver-major-days` 等)。scout の規模では過剰
- 他 ecosystem の追加 (現状は github-actions / cargo のみ管理)