### PR TITLE
fix(lib): tracing_subscriber を try_init() に変更し二重 init を許容 (issue #103)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,12 @@ pub(crate) struct Cli {
     command: Command,
 }
 
-pub async fn run() -> ExitCode {
+/// Install the tracing subscriber. `try_init` tolerates a second invocation
+/// (e.g., integration tests that exercise `lib::run` more than once) — the
+/// installed subscriber from the first call is reused.
+fn init_tracing() {
     use tracing_subscriber::filter::Directive;
-    tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .with_writer(stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env().add_directive(
@@ -104,7 +107,11 @@ pub async fn run() -> ExitCode {
                     .unwrap_or_else(|_| Directive::from(tracing::Level::INFO)),
             ),
         )
-        .init();
+        .try_init();
+}
+
+pub async fn run() -> ExitCode {
+    init_tracing();
 
     // Pre-scan argv so a clap parse error (which exits before `cli.json` is
     // populated) still routes through the JSON envelope path when requested.
@@ -240,7 +247,17 @@ mod tests {
 
     use clap::CommandFactory;
 
-    use super::write_output;
+    use super::{init_tracing, write_output};
+
+    /// [T-INIT001] init_tracing tolerates a second invocation (issue #103).
+    /// `.init()` would panic on the duplicate; `.try_init()` returns Err which
+    /// init_tracing silently ignores so callers (integration tests reusing
+    /// `lib::run`) survive.
+    #[test]
+    fn init_tracing_is_idempotent() {
+        init_tracing();
+        init_tracing();
+    }
 
     /// [T-W001] write_output appends newline when output lacks trailing newline
     #[test]


### PR DESCRIPTION
## 概要

- `tracing_subscriber::fmt().init()` は 2 回目の呼び出しで panic するため、`lib::run` を複数回呼ぶ integration test が書けない。
- subscriber の初期化を `init_tracing()` に切り出し、`try_init()` に切り替え。2 回目以降の caller は最初の subscriber を再利用する形に。
- issue #103 全体を 6 PR に分割するうちの最初の slice (test seam 整備)。後続で `Clock` / `Rng` / `TokenSource` trait + `ScoutBuilder` を追加。

## テスト

- [x] `cargo test --offline` (新規 `init_tracing_is_idempotent` を含む全 test pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --offline --all-targets -- -D warnings`

## 関連

- Issue #103 — AC: 「tracing_subscriber::fmt().try_init() に変えて 2 重 init を許容」