### PR TITLE
feat(clock): Clock trait + SystemClock/FixedClock を導入し rate-limit reset 計算を test seam 化 (issue #103)

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,8 +1,5 @@
-//! Time abstraction for testability.
-//!
-//! Issue #103 / H-12: `secs_until_ratelimit_reset` previously called
-//! `SystemTime::now()` directly, making it impossible to verify the
-//! `x-ratelimit-reset - now` arithmetic without time-of-day flakiness.
+//! Wall-clock abstraction. `SystemClock` for production, `FixedClock` for tests
+//! that need deterministic `now`.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -12,9 +9,7 @@ pub(crate) trait Clock: Send + Sync {
     fn now_secs(&self) -> u64;
 }
 
-/// Production clock. Returns 0 if the system clock is set before 1970-01-01,
-/// which is treated as "unknown now" — the only callers that read this value
-/// (rate-limit reset arithmetic) saturate to 0 anyway.
+/// Returns 0 when the wall clock is pre-epoch (treat as unknown).
 pub(crate) struct SystemClock;
 
 impl Clock for SystemClock {

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,65 @@
+//! Time abstraction for testability.
+//!
+//! Issue #103 / H-12: `secs_until_ratelimit_reset` previously called
+//! `SystemTime::now()` directly, making it impossible to verify the
+//! `x-ratelimit-reset - now` arithmetic without time-of-day flakiness.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Source of unix-epoch wall-clock seconds. `Send + Sync` so implementations
+/// can live behind an `Arc<dyn Clock>` shared across async tasks.
+pub(crate) trait Clock: Send + Sync {
+    fn now_secs(&self) -> u64;
+}
+
+/// Production clock. Returns 0 if the system clock is set before 1970-01-01,
+/// which is treated as "unknown now" — the only callers that read this value
+/// (rate-limit reset arithmetic) saturate to 0 anyway.
+pub(crate) struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_secs(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+}
+
+/// Test clock that always returns the configured second.
+#[cfg(test)]
+pub(crate) struct FixedClock(pub u64);
+
+#[cfg(test)]
+impl Clock for FixedClock {
+    fn now_secs(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [T-CLOCK001] FixedClock echoes its constructor argument so callers can
+    /// pin `now` for deterministic retry-after arithmetic tests.
+    #[test]
+    fn fixed_clock_returns_constructor_value() {
+        let c = FixedClock(1_700_000_000);
+        assert_eq!(c.now_secs(), 1_700_000_000);
+    }
+
+    /// [T-CLOCK002] SystemClock returns a unix epoch second that is plausibly
+    /// "now" (after 2020-01-01). Guards against an accidental `Duration::ZERO`
+    /// regression in the unwrap_or branch.
+    #[test]
+    fn system_clock_returns_post_2020_epoch_seconds() {
+        let c = SystemClock;
+        let now = c.now_secs();
+        // 2020-01-01T00:00:00Z = 1_577_836_800 unix seconds.
+        assert!(
+            now > 1_577_836_800,
+            "system clock should be after 2020-01-01, got {now}"
+        );
+    }
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,7 +4,8 @@ mod helpers;
 pub(crate) mod types;
 
 use std::env;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::Arc;
+use std::time::Duration;
 
 use reqwest::Client;
 use reqwest::header::HeaderMap;
@@ -13,6 +14,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
+use crate::clock::{Clock, SystemClock};
 use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
@@ -91,6 +93,11 @@ pub(crate) struct GitHubClient {
     token: Option<Redacted>,
     base_url: String,
     max_retries: u32,
+    /// Wall-clock source for `secs_until_ratelimit_reset` arithmetic. Default
+    /// `SystemClock`; tests inject `FixedClock` via `with_clock` to verify
+    /// the `x-ratelimit-reset - now` calculation without real-time flakiness
+    /// (issue #103 / H-12).
+    clock: Arc<dyn Clock>,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `request` always runs
     /// `validate_https`; only `with_base_url` opts in.
@@ -113,6 +120,7 @@ impl GitHubClient {
             token,
             base_url: API_BASE.to_owned(),
             max_retries,
+            clock: Arc::new(SystemClock),
             #[cfg(test)]
             skip_https_check: false,
         }
@@ -125,8 +133,17 @@ impl GitHubClient {
             token: None,
             base_url: base_url.to_owned(),
             max_retries: DEFAULT_MAX_RETRIES,
+            clock: Arc::new(SystemClock),
             skip_https_check: true,
         }
+    }
+
+    /// Inject an alternate `Clock` (for `FixedClock` in tests). Production
+    /// callers use the `SystemClock` installed by the constructors above.
+    #[cfg(test)]
+    pub(crate) fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
     }
 
     /// Test-only override of the production HTTPS gate. See [`validate_https`].
@@ -205,7 +222,8 @@ impl GitHubClient {
                     .get("x-ratelimit-remaining")
                     .and_then(|v| v.to_str().ok())
                     .and_then(|v| v.parse::<u64>().ok());
-                let retry_after = secs_until_ratelimit_reset(response.headers());
+                let retry_after =
+                    secs_until_ratelimit_reset(response.headers(), self.clock.as_ref());
                 match remaining {
                     Some(r) if r > 0 => {
                         let message =
@@ -358,13 +376,12 @@ fn is_retriable(e: &GitHubError) -> bool {
     }
 }
 
-fn secs_until_ratelimit_reset(headers: &HeaderMap) -> Option<u64> {
+fn secs_until_ratelimit_reset(headers: &HeaderMap, clock: &dyn Clock) -> Option<u64> {
     let reset_ts = headers
         .get("x-ratelimit-reset")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse::<u64>().ok())?;
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
-    Some(reset_ts.saturating_sub(now))
+    Some(reset_ts.saturating_sub(clock.now_secs()))
 }
 
 async fn resolve_token() -> Option<Redacted> {
@@ -419,8 +436,10 @@ async fn resolve_token_with(env_reader: impl Fn(&str) -> Option<String>) -> Opti
 #[cfg(test)]
 mod http_tests {
     use std::sync::atomic::Ordering;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
+    use crate::clock::FixedClock;
     use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
@@ -689,5 +708,72 @@ mod http_tests {
         );
 
         let _ = handle.join();
+    }
+
+    /// [T-GH014] secs_until_ratelimit_reset subtracts the injected clock
+    /// from the x-ratelimit-reset header (issue #103 / H-12). Pinning the
+    /// clock removes wall-clock flakiness from the arithmetic test.
+    #[test]
+    fn secs_until_ratelimit_reset_uses_injected_clock() {
+        use reqwest::header::HeaderValue;
+        let mut headers = HeaderMap::new();
+        headers.insert("x-ratelimit-reset", HeaderValue::from_static("1300"));
+        let clock = FixedClock(1000);
+        assert_eq!(secs_until_ratelimit_reset(&headers, &clock), Some(300));
+    }
+
+    /// [T-GH015] secs_until_ratelimit_reset saturates to 0 when the injected
+    /// clock has already passed the reset timestamp — `Duration::saturating_sub`
+    /// prevents a u64 underflow that would otherwise wrap to a huge delay.
+    #[test]
+    fn secs_until_ratelimit_reset_saturates_when_clock_past_reset() {
+        use reqwest::header::HeaderValue;
+        let mut headers = HeaderMap::new();
+        headers.insert("x-ratelimit-reset", HeaderValue::from_static("100"));
+        let clock = FixedClock(200);
+        assert_eq!(secs_until_ratelimit_reset(&headers, &clock), Some(0));
+    }
+
+    /// [T-GH016] secs_until_ratelimit_reset returns None when the
+    /// x-ratelimit-reset header is absent; production callers then fall back
+    /// to jittered backoff.
+    #[test]
+    fn secs_until_ratelimit_reset_returns_none_when_header_missing() {
+        let headers = HeaderMap::new();
+        let clock = FixedClock(1000);
+        assert_eq!(secs_until_ratelimit_reset(&headers, &clock), None);
+    }
+
+    /// [T-GH017] with_clock injection threads through to the 403 retry_after
+    /// calculation. End-to-end proof that the seam works for callers (the
+    /// pure-function tests above only cover the helper in isolation).
+    #[tokio::test]
+    async fn get_json_403_uses_injected_clock_for_retry_after() {
+        let Some(server) = try_spawn_mock_server("github::http_clock_inject").await else {
+            return;
+        };
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo"))
+            .respond_with(
+                ResponseTemplate::new(403)
+                    .append_header("x-ratelimit-remaining", "0")
+                    .append_header("x-ratelimit-reset", "1300")
+                    .set_body_json(serde_json::json!({"message": "rate limit exceeded"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base_url(Client::new(), &server.uri())
+            .with_clock(Arc::new(FixedClock(1000)));
+        let result: Result<RepoInfo, _> = client.get_json_once("/repos/owner/repo").await;
+        assert!(
+            matches!(
+                result,
+                Err(GitHubError::RateLimited {
+                    retry_after: Some(300)
+                })
+            ),
+            "expected retry_after = 300 (reset 1300 - clock 1000), got: {result:?}"
+        );
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -93,10 +93,8 @@ pub(crate) struct GitHubClient {
     token: Option<Redacted>,
     base_url: String,
     max_retries: u32,
-    /// Wall-clock source for `secs_until_ratelimit_reset` arithmetic. Default
-    /// `SystemClock`; tests inject `FixedClock` via `with_clock` to verify
-    /// the `x-ratelimit-reset - now` calculation without real-time flakiness
-    /// (issue #103 / H-12).
+    /// Wall-clock source for `secs_until_ratelimit_reset`. Defaults to
+    /// `SystemClock`; tests inject `FixedClock` via `with_clock`.
     clock: Arc<dyn Clock>,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `request` always runs
@@ -138,8 +136,6 @@ impl GitHubClient {
         }
     }
 
-    /// Inject an alternate `Clock` (for `FixedClock` in tests). Production
-    /// callers use the `SystemClock` installed by the constructors above.
     #[cfg(test)]
     pub(crate) fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
         self.clock = clock;
@@ -436,7 +432,6 @@ async fn resolve_token_with(env_reader: impl Fn(&str) -> Option<String>) -> Opti
 #[cfg(test)]
 mod http_tests {
     use std::sync::atomic::Ordering;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
     use crate::clock::FixedClock;
@@ -614,36 +609,36 @@ mod http_tests {
         ));
     }
 
-    /// [T-GH008] get_json_once uses x-ratelimit-reset to compute delay on 403 rate limit
+    /// [T-GH008] get_json_once uses x-ratelimit-reset to compute delay on 403 rate limit.
+    /// Pinned clock + reset 60s later asserts the exact subtraction result.
     #[tokio::test]
     async fn get_json_403_with_ratelimit_reset_carries_delay() {
         let Some(server) = try_spawn_mock_server("github::http").await else {
             return;
         };
-        let future_reset = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            + 60;
         Mock::given(method("GET"))
             .and(path("/repos/owner/repo"))
             .respond_with(
                 ResponseTemplate::new(403)
                     .append_header("x-ratelimit-remaining", "0")
-                    .append_header("x-ratelimit-reset", future_reset.to_string().as_str())
+                    .append_header("x-ratelimit-reset", "1060")
                     .set_body_json(serde_json::json!({"message": "rate limit exceeded"})),
             )
             .mount(&server)
             .await;
 
-        let client = GitHubClient::with_base_url(Client::new(), &server.uri());
+        let client = GitHubClient::with_base_url(Client::new(), &server.uri())
+            .with_clock(Arc::new(FixedClock(1000)));
         let result: Result<RepoInfo, _> = client.get_json_once("/repos/owner/repo").await;
-        assert!(matches!(
-            result,
-            Err(GitHubError::RateLimited {
-                retry_after: Some(_)
-            })
-        ));
+        assert!(
+            matches!(
+                result,
+                Err(GitHubError::RateLimited {
+                    retry_after: Some(60)
+                })
+            ),
+            "expected retry_after = 60 (reset 1060 - clock 1000), got: {result:?}"
+        );
     }
 
     /// [T-GH012] 2xx response with malformed JSON classifies as Decode (issue #101).
@@ -711,8 +706,8 @@ mod http_tests {
     }
 
     /// [T-GH014] secs_until_ratelimit_reset subtracts the injected clock
-    /// from the x-ratelimit-reset header (issue #103 / H-12). Pinning the
-    /// clock removes wall-clock flakiness from the arithmetic test.
+    /// from the x-ratelimit-reset header. Pinning the clock removes wall-clock
+    /// flakiness from the arithmetic test.
     #[test]
     fn secs_until_ratelimit_reset_uses_injected_clock() {
         use reqwest::header::HeaderValue;
@@ -723,8 +718,8 @@ mod http_tests {
     }
 
     /// [T-GH015] secs_until_ratelimit_reset saturates to 0 when the injected
-    /// clock has already passed the reset timestamp — `Duration::saturating_sub`
-    /// prevents a u64 underflow that would otherwise wrap to a huge delay.
+    /// clock has already passed the reset timestamp — `u64::saturating_sub`
+    /// prevents an underflow that would otherwise wrap to a huge delay.
     #[test]
     fn secs_until_ratelimit_reset_saturates_when_clock_past_reset() {
         use reqwest::header::HeaderValue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod brave;
+mod clock;
 mod envelope;
 mod fetch;
 mod github;


### PR DESCRIPTION
## 概要

- `GitHubClient::secs_until_ratelimit_reset` が `SystemTime::now()` を直読していたため、`x-ratelimit-reset - now` の算術が時刻 flakiness なしで検証できなかった。
- `clock` module を新設し、`Clock` trait + 本番用 `SystemClock` + test 用 `FixedClock(u64)` を追加。
- `GitHubClient` に `clock: Arc<dyn Clock>` field を追加 (default `SystemClock`)、test 用 `with_clock()` builder method を生やして注入可能に。
- 既存 T-GH008 (`get_json_403_with_ratelimit_reset_carries_delay`) も `SystemTime` 直読をやめて `FixedClock(1000) + reset=1060` に書き換え。`retry_after = Some(60)` を厳密に assert。
- issue #103 全体 6 PR のうち 2 本目 (PR 0 = tracing fix #127 マージ済み)。後続で `Rng` / `TokenSource` trait + `ScoutBuilder`。

## 変更

| ファイル | 内容 |
|---|---|
| `src/clock.rs` (新規) | `Clock` trait + `SystemClock` + `FixedClock` + unit test 2 |
| `src/github.rs` | `clock` field + `with_clock()` + `secs_until_ratelimit_reset` を Clock 経由に、test 4 個追加 + 既存 T-GH008 を FixedClock 経由に |
| `src/lib.rs` | `mod clock;` 1 行 |

## テスト

- [x] `cargo test --offline` (378 + integration 11 = 全 pass、Clock 関連 6 新規 test を含む)
- [x] `cargo fmt --check`
- [x] `cargo clippy --offline --all-targets -- -D warnings`

## polish 履歴

- 2 commit 構成 (`c5ecc75` Clock 導入、`0a043d5` polish 反映)
- simplify (reuse/quality/efficiency) + codex + coderabbit + gemini + enhancer-code で review 済み
- review feedback: T-GH008 を FixedClock 経由に / rustdoc から issue ref 削除 / with_clock の冗長 doc 削除 / SystemClock コメント中立化

## 関連

- Issue #103 — AC: 「Clock trait + `SystemClock` / `FixedClock(u64)` 実装」