### PR TITLE
feat(rng): Rng trait + FastrandRng/SeededRng で jittered_backoff を test seam 化 (issue #103)

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -10,6 +10,7 @@ use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
     is_transient_network, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
+use crate::rng::FastrandRng;
 
 use super::types::{SearchResult, WebSearchResponse};
 
@@ -246,6 +247,7 @@ impl SearchClient for BraveClient {
                 _ => None,
             },
             || BraveError::RateLimited { retry_after: None },
+            &FastrandRng,
         )
         .await?;
         Ok(response.into_results())

--- a/src/github.rs
+++ b/src/github.rs
@@ -22,6 +22,7 @@ use crate::retry::{
     is_schema_decode_fail, is_transient_network, parse_retry_after, retry_after_within_cap,
     retry_with_rate_limit,
 };
+use crate::rng::FastrandRng;
 
 use helpers::encode_path;
 pub(crate) use helpers::{
@@ -181,6 +182,7 @@ impl GitHubClient {
                 _ => None,
             },
             || GitHubError::RateLimited { retry_after: None },
+            &FastrandRng,
         )
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod github;
 mod markdown;
 mod redacted;
 mod retry;
+mod rng;
 mod search;
 mod signals;
 mod slack;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -8,6 +8,8 @@ use reqwest::header::{HeaderMap, RETRY_AFTER};
 use tokio::time::sleep;
 use tracing::debug;
 
+use crate::rng::Rng;
+
 const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_RETRY_AFTER_SECS: u64 = 300;
 
@@ -16,10 +18,10 @@ const MAX_RETRY_AFTER_SECS: u64 = 300;
 /// so `2` yields the 3-attempt budget that backends are tuned against.
 pub(crate) const DEFAULT_MAX_RETRIES: u32 = 2;
 
-pub(crate) fn jittered_backoff(attempt: u32) -> u64 {
+pub(crate) fn jittered_backoff(attempt: u32, rng: &dyn Rng) -> u64 {
     let base = INITIAL_BACKOFF_MS.saturating_mul(2u64.saturating_pow(attempt));
     let half = base / 2;
-    half + fastrand::u64(..half.max(1))
+    half + rng.u64_below(half.max(1))
 }
 
 pub(crate) fn is_transient_network(e: &Error) -> bool {
@@ -108,10 +110,14 @@ pub(crate) fn retry_after_within_cap(retry_after: Option<u64>) -> bool {
     retry_after.is_none_or(|s| s <= MAX_RETRY_AFTER_SECS)
 }
 
-pub(crate) fn retry_after_or_backoff(retry_after: Option<u64>, attempt: u32) -> Duration {
+pub(crate) fn retry_after_or_backoff(
+    retry_after: Option<u64>,
+    attempt: u32,
+    rng: &dyn Rng,
+) -> Duration {
     match retry_after {
         Some(secs) => Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)),
-        None => Duration::from_millis(jittered_backoff(attempt)),
+        None => Duration::from_millis(jittered_backoff(attempt, rng)),
     }
 }
 
@@ -119,7 +125,7 @@ pub(crate) fn retry_after_or_backoff(retry_after: Option<u64>, attempt: u32) -> 
 ///
 /// Caller supplies `extract_retry_after` to pull `Option<u64>` from the
 /// error's `RateLimited` variant. The delay per attempt is then
-/// `retry_after_or_backoff(extract_retry_after(&e), attempt)`.
+/// `retry_after_or_backoff(extract_retry_after(&e), attempt, rng)`.
 ///
 /// The cap policy (refuse retry when retry-after exceeds
 /// `MAX_RETRY_AFTER_SECS`) is the caller's `is_retriable` responsibility,
@@ -130,6 +136,7 @@ pub(crate) async fn retry_with_rate_limit<T, E, F, Fut>(
     is_retriable: impl Fn(&E) -> bool,
     extract_retry_after: impl Fn(&E) -> Option<u64>,
     fallback_err: impl FnOnce() -> E,
+    rng: &dyn Rng,
 ) -> Result<T, E>
 where
     F: Fn() -> Fut,
@@ -139,7 +146,7 @@ where
         operation,
         max_retries,
         is_retriable,
-        |e, attempt| retry_after_or_backoff(extract_retry_after(e), attempt),
+        |e, attempt| retry_after_or_backoff(extract_retry_after(e), attempt, rng),
         fallback_err,
     )
     .await
@@ -154,6 +161,7 @@ mod tests {
     use wiremock::{Mock, ResponseTemplate};
 
     use super::*;
+    use crate::rng::{FastrandRng, SeededRng};
     use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
 
     /// Test-only error type. `RateLimited` carries the server-supplied
@@ -210,6 +218,7 @@ mod tests {
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
+            &FastrandRng,
         )
         .await;
 
@@ -250,6 +259,7 @@ mod tests {
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
+            &FastrandRng,
         )
         .await;
 
@@ -287,6 +297,7 @@ mod tests {
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
+            &FastrandRng,
         )
         .await;
 
@@ -317,6 +328,7 @@ mod tests {
             mock_is_retriable,
             mock_extract_retry_after,
             || MockErr::Other,
+            &FastrandRng,
         )
         .await;
 
@@ -329,6 +341,21 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_millis(50),
             "no backoff sleep should occur when max_retries=0"
+        );
+    }
+
+    // T-R007: jittered_backoff_is_deterministic_with_seeded_rng
+    // Same seed → identical sample, proving the Rng seam threads through to
+    // jittered_backoff. The envelope check guards the half + jitter formula
+    // (attempt=0 → half=500, jitter ∈ [0,500), result ∈ [500,1000)).
+    #[test]
+    fn jittered_backoff_is_deterministic_with_seeded_rng() {
+        let first = jittered_backoff(0, &SeededRng::new(42));
+        let second = jittered_backoff(0, &SeededRng::new(42));
+        assert_eq!(first, second, "same seed must reproduce identical backoff");
+        assert!(
+            (500..1000).contains(&first),
+            "jittered_backoff(0) should fall in [500, 1000), got {first}"
         );
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -121,15 +121,9 @@ pub(crate) fn retry_after_or_backoff(
     }
 }
 
-/// Retry with the standard rate-limit-aware delay formula.
-///
-/// Caller supplies `extract_retry_after` to pull `Option<u64>` from the
-/// error's `RateLimited` variant. The delay per attempt is then
-/// `retry_after_or_backoff(extract_retry_after(&e), attempt, rng)`.
-///
-/// The cap policy (refuse retry when retry-after exceeds
-/// `MAX_RETRY_AFTER_SECS`) is the caller's `is_retriable` responsibility,
-/// typically via `retry_after_within_cap`.
+/// Retry with the rate-limit-aware delay formula. The cap policy (refuse
+/// retry when retry-after exceeds `MAX_RETRY_AFTER_SECS`) is the caller's
+/// `is_retriable` responsibility, typically via `retry_after_within_cap`.
 pub(crate) async fn retry_with_rate_limit<T, E, F, Fut>(
     operation: F,
     max_retries: u32,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,8 +1,11 @@
 //! Random-number abstraction. `FastrandRng` for production, `SeededRng` for
 //! tests that need deterministic backoff arithmetic.
 
-/// Bounded random `u64` source. `Send + Sync` so implementations can sit
-/// behind an `Arc<dyn Rng>` shared across async tasks.
+#[cfg(test)]
+use std::sync::Mutex;
+
+/// Bounded random `u64` source. `Send + Sync` so `&dyn Rng` can cross
+/// `.await` points in the retry loop.
 pub(crate) trait Rng: Send + Sync {
     /// Returns a uniform sample in `[0, upper_exclusive)`. Callers ensure
     /// `upper_exclusive > 0`; passing 0 will panic to match `fastrand`.
@@ -18,22 +21,27 @@ impl Rng for FastrandRng {
     }
 }
 
-/// Test RNG seeded with a fixed value so every backoff calculation is
-/// reproducible across runs.
+/// Test RNG seeded with a fixed value. `Mutex` is required because `Rng` is
+/// `&self` but `fastrand::Rng::u64` mutates internal state; the bare value
+/// would have to be `.clone()`d each call, which discards sequence progress
+/// and produces the same sample every time.
 #[cfg(test)]
-pub(crate) struct SeededRng(pub fastrand::Rng);
+pub(crate) struct SeededRng(Mutex<fastrand::Rng>);
 
 #[cfg(test)]
 impl SeededRng {
     pub fn new(seed: u64) -> Self {
-        Self(fastrand::Rng::with_seed(seed))
+        Self(Mutex::new(fastrand::Rng::with_seed(seed)))
     }
 }
 
 #[cfg(test)]
 impl Rng for SeededRng {
     fn u64_below(&self, upper_exclusive: u64) -> u64 {
-        self.0.clone().u64(..upper_exclusive)
+        self.0
+            .lock()
+            .expect("SeededRng mutex poisoned")
+            .u64(..upper_exclusive)
     }
 }
 
@@ -53,7 +61,7 @@ mod tests {
     }
 
     /// [T-RNG002] Two SeededRng with the same seed produce the same sequence,
-    /// proving the deterministic test seam.
+    /// proving deterministic seam works across calls (not just instances).
     #[test]
     fn seeded_rng_is_reproducible_under_identical_seed() {
         let a = SeededRng::new(42);
@@ -61,5 +69,23 @@ mod tests {
         for _ in 0..5 {
             assert_eq!(a.u64_below(1_000_000), b.u64_below(1_000_000));
         }
+    }
+
+    /// [T-RNG003] Repeated calls on the same SeededRng advance the internal
+    /// state — guards against the earlier `self.0.clone()` bug where every
+    /// call returned the seed's first sample.
+    #[test]
+    fn seeded_rng_advances_state_across_calls() {
+        use std::collections::HashSet;
+        let rng = SeededRng::new(7);
+        let mut samples = Vec::with_capacity(5);
+        for _ in 0..5 {
+            samples.push(rng.u64_below(u64::MAX));
+        }
+        let unique: HashSet<_> = samples.iter().collect();
+        assert!(
+            unique.len() > 1,
+            "SeededRng must advance state; got constant sequence: {samples:?}"
+        );
     }
 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,65 @@
+//! Random-number abstraction. `FastrandRng` for production, `SeededRng` for
+//! tests that need deterministic backoff arithmetic.
+
+/// Bounded random `u64` source. `Send + Sync` so implementations can sit
+/// behind an `Arc<dyn Rng>` shared across async tasks.
+pub(crate) trait Rng: Send + Sync {
+    /// Returns a uniform sample in `[0, upper_exclusive)`. Callers ensure
+    /// `upper_exclusive > 0`; passing 0 will panic to match `fastrand`.
+    fn u64_below(&self, upper_exclusive: u64) -> u64;
+}
+
+/// Production RNG backed by the process-global `fastrand` state.
+pub(crate) struct FastrandRng;
+
+impl Rng for FastrandRng {
+    fn u64_below(&self, upper_exclusive: u64) -> u64 {
+        fastrand::u64(..upper_exclusive)
+    }
+}
+
+/// Test RNG seeded with a fixed value so every backoff calculation is
+/// reproducible across runs.
+#[cfg(test)]
+pub(crate) struct SeededRng(pub fastrand::Rng);
+
+#[cfg(test)]
+impl SeededRng {
+    pub fn new(seed: u64) -> Self {
+        Self(fastrand::Rng::with_seed(seed))
+    }
+}
+
+#[cfg(test)]
+impl Rng for SeededRng {
+    fn u64_below(&self, upper_exclusive: u64) -> u64 {
+        self.0.clone().u64(..upper_exclusive)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// [T-RNG001] FastrandRng draws within the requested half-open range.
+    /// 100 samples is enough to catch an off-by-one in the upper bound.
+    #[test]
+    fn fastrand_rng_stays_below_upper_bound() {
+        let rng = FastrandRng;
+        for _ in 0..100 {
+            let v = rng.u64_below(10);
+            assert!(v < 10, "fastrand returned {v} for upper_exclusive=10");
+        }
+    }
+
+    /// [T-RNG002] Two SeededRng with the same seed produce the same sequence,
+    /// proving the deterministic test seam.
+    #[test]
+    fn seeded_rng_is_reproducible_under_identical_seed() {
+        let a = SeededRng::new(42);
+        let b = SeededRng::new(42);
+        for _ in 0..5 {
+            assert_eq!(a.u64_below(1_000_000), b.u64_below(1_000_000));
+        }
+    }
+}

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -14,6 +14,7 @@ use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
     is_schema_decode_fail, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
+use crate::rng::FastrandRng;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SlackError {
@@ -210,6 +211,7 @@ impl SlackClient {
                 _ => None,
             },
             || SlackError::RateLimited { retry_after: None },
+            &FastrandRng,
         )
         .await
     }


### PR DESCRIPTION
## 概要

- `retry::jittered_backoff` が `fastrand::u64` のプロセスグローバル状態を直接叩いていたため、backoff envelope の assertion がグローバル状態と race し、seed 再現も不可能だった。
- `rng` module を新設し、`Rng` trait + 本番用 `FastrandRng` + test 用 `SeededRng(Mutex<fastrand::Rng>)` を追加。
- `jittered_backoff` / `retry_after_or_backoff` / `retry_with_rate_limit` の signature に `rng: &dyn Rng` を thread through。
- 3 backend client (github / brave / slack) の callsite で `&FastrandRng` を渡す。各 client struct の rng field 化は ScoutBuilder PR (PR 4) で対応予定。
- issue #103 全体 6 PR のうち 3 本目 (PR 0/1 = #127 / #128 マージ済み)。

## 変更

| ファイル | 内容 |
|---|---|
| `src/rng.rs` (新規) | `Rng` trait + `FastrandRng` + `SeededRng(Mutex<fastrand::Rng>)` + unit test 3 |
| `src/retry.rs` | jittered_backoff/retry_after_or_backoff/retry_with_rate_limit に `rng: &dyn Rng` 追加、T-R007 deterministic backoff test を追加 |
| `src/lib.rs` | `mod rng;` 1 行 |
| `src/github.rs` / `src/brave/client.rs` / `src/slack.rs` | `use crate::rng::FastrandRng;` + `retry_with_rate_limit(..., &FastrandRng)` |

## テスト

- [x] `cargo test --offline` (lib 383 + integration 11 = 全 pass、Rng 関連 4 新規 test を含む)
- [x] `cargo fmt --check`
- [x] `cargo clippy --offline --all-targets -- -D warnings`

## polish 履歴

- 2 commit 構成 (`59aee32` Rng 導入、`94988d9` polish 反映)
- simplify (reuse/quality/efficiency) + codex + coderabbit + gemini + enhancer-code で review 済み
- 修正点:
  - **SeededRng clone bug**: `self.0.clone().u64(...)` で state progression が消える bug を `Mutex<fastrand::Rng>` 化で修正。T-RNG003 で state advance を assert
  - **pub field exposure**: `SeededRng(pub fastrand::Rng)` → private に
  - **clippy absolute_paths**: `std::collections::HashSet` を use 経由に
  - **doc 簡素化**: trait/関数 doc の冗長 echo を削減

## 関連

- Issue #103 — AC: 「Rng trait + `FastrandRng` / `SeededRng(u64)` 実装」