### PR TITLE
feat(token_source): TokenSource trait + GhCliSource/StaticTokenSource で gh auth token を test seam 化 (issue #103)

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -510,9 +510,6 @@ mod http_tests {
         assert!(super::validate_per_page(1).is_ok());
     }
 
-    // T-GH005 (resolve_token_with env-var lookup) moved to `token_source` module
-    // as T-TS001 / T-TS002 — env-resolution logic now lives there.
-
     /// [T-GH018] from_env_with_source threads the injected TokenSource through
     /// to the constructed client's token field. Proves the seam reaches the
     /// constructor without spawning `gh auth token`.

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,15 +3,11 @@ pub(crate) mod format;
 mod helpers;
 pub(crate) mod types;
 
-use std::env;
 use std::sync::Arc;
-use std::time::Duration;
 
 use reqwest::Client;
 use reqwest::header::HeaderMap;
 use serde::de::DeserializeOwned;
-use tokio::process::Command;
-use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
 use crate::clock::{Clock, SystemClock};
@@ -23,6 +19,7 @@ use crate::retry::{
     retry_with_rate_limit,
 };
 use crate::rng::FastrandRng;
+use crate::token_source::{GhCliSource, TokenSource};
 
 use helpers::encode_path;
 pub(crate) use helpers::{
@@ -34,7 +31,6 @@ use types::{
 };
 
 const API_BASE: &str = "https://api.github.com";
-const TOKEN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum GitHubError {
@@ -106,7 +102,18 @@ pub(crate) struct GitHubClient {
 
 impl GitHubClient {
     pub async fn from_env(http: Client, max_retries: u32) -> Self {
-        let token = resolve_token().await;
+        Self::from_env_with_source(http, max_retries, &GhCliSource).await
+    }
+
+    /// Production constructor parameterized by the `TokenSource`. `from_env`
+    /// is the thin wrapper that picks `GhCliSource`; tests pick
+    /// `StaticTokenSource(...)` to avoid spawning `gh auth token`.
+    pub(crate) async fn from_env_with_source(
+        http: Client,
+        max_retries: u32,
+        source: &dyn TokenSource,
+    ) -> Self {
+        let token = source.fetch().await;
         if token.is_some() {
             debug!("GitHub token configured");
         } else {
@@ -382,55 +389,6 @@ fn secs_until_ratelimit_reset(headers: &HeaderMap, clock: &dyn Clock) -> Option<
     Some(reset_ts.saturating_sub(clock.now_secs()))
 }
 
-async fn resolve_token() -> Option<Redacted> {
-    resolve_token_with(|var| env::var(var).ok()).await
-}
-
-async fn resolve_token_with(env_reader: impl Fn(&str) -> Option<String>) -> Option<Redacted> {
-    let from_env = ["GITHUB_TOKEN", "GH_TOKEN"]
-        .iter()
-        .filter_map(|var| env_reader(var))
-        .map(|t| t.trim().to_owned())
-        .find(|t| !t.is_empty());
-
-    if let Some(token) = from_env {
-        return Some(Redacted::new(&token));
-    }
-
-    let output = timeout(
-        TOKEN_RESOLVE_TIMEOUT,
-        Command::new("gh")
-            .args(["auth", "token"])
-            .kill_on_drop(true)
-            .output(),
-    )
-    .await
-    .inspect_err(|_| {
-        info!(
-            "gh auth token timed out after {}s",
-            TOKEN_RESOLVE_TIMEOUT.as_secs()
-        )
-    })
-    .ok()?
-    .inspect_err(|e| info!("gh auth token command failed: {e}"))
-    .ok()?;
-
-    if !output.status.success() {
-        info!(
-            stderr = %String::from_utf8_lossy(&output.stderr).trim(),
-            "gh auth token failed"
-        );
-        return None;
-    }
-
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    if token.is_empty() {
-        None
-    } else {
-        Some(Redacted::new(&token))
-    }
-}
-
 #[cfg(test)]
 mod http_tests {
     use std::sync::atomic::Ordering;
@@ -552,21 +510,31 @@ mod http_tests {
         assert!(super::validate_per_page(1).is_ok());
     }
 
-    /// [T-GH005] resolve_token_with reads token from GITHUB_TOKEN env var
+    // T-GH005 (resolve_token_with env-var lookup) moved to `token_source` module
+    // as T-TS001 / T-TS002 — env-resolution logic now lives there.
+
+    /// [T-GH018] from_env_with_source threads the injected TokenSource through
+    /// to the constructed client's token field. Proves the seam reaches the
+    /// constructor without spawning `gh auth token`.
     #[tokio::test]
-    async fn resolve_token_reads_env_var() {
-        let token = resolve_token_with(|key| {
-            if key == "GITHUB_TOKEN" {
-                Some("test-token-from-env".into())
-            } else {
-                None
-            }
-        })
-        .await;
+    async fn from_env_with_static_source_installs_token() {
+        use crate::token_source::StaticTokenSource;
+        let source = StaticTokenSource(Some(Redacted::new("injected-token")));
+        let client = GitHubClient::from_env_with_source(Client::new(), 0, &source).await;
         assert_eq!(
-            token.as_ref().map(super::super::redacted::Redacted::expose),
-            Some("test-token-from-env")
+            client.token.as_ref().map(Redacted::expose),
+            Some("injected-token")
         );
+    }
+
+    /// [T-GH019] from_env_with_source propagates a None source so callers can
+    /// simulate the unauthenticated path without env-var manipulation.
+    #[tokio::test]
+    async fn from_env_with_none_source_leaves_token_empty() {
+        use crate::token_source::StaticTokenSource;
+        let client =
+            GitHubClient::from_env_with_source(Client::new(), 0, &StaticTokenSource(None)).await;
+        assert!(client.token.is_none());
     }
 
     /// [T-GH006] get_json maps 500 responses to generic Api error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod signals;
 mod slack;
 #[cfg(test)]
 mod test_support;
+mod token_source;
 mod tools;
 
 pub(crate) const USER_AGENT: &str = concat!("scout/", env!("CARGO_PKG_VERSION"));

--- a/src/token_source.rs
+++ b/src/token_source.rs
@@ -1,6 +1,5 @@
-//! GitHub token resolution abstraction. `GhCliSource` walks env vars then
-//! falls back to `gh auth token`; `StaticTokenSource` lets tests inject a
-//! pre-resolved value without spawning a subprocess.
+//! Resolves a GitHub bearer token from env vars or `gh auth token`, behind a
+//! trait so tests can skip the subprocess.
 
 use std::env;
 use std::future::Future;
@@ -15,17 +14,20 @@ use crate::redacted::Redacted;
 
 const TOKEN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Object-safe boxed future returned by [`TokenSource::fetch`].
+pub(crate) type TokenFuture<'a> = Pin<Box<dyn Future<Output = Option<Redacted>> + Send + 'a>>;
+
 /// Resolves an optional GitHub bearer token. `Send + Sync` so implementations
 /// can sit behind an `Arc<dyn TokenSource>` shared across async tasks.
 pub(crate) trait TokenSource: Send + Sync {
-    fn fetch(&self) -> Pin<Box<dyn Future<Output = Option<Redacted>> + Send + '_>>;
+    fn fetch(&self) -> TokenFuture<'_>;
 }
 
 /// Production source: `GITHUB_TOKEN` env → `GH_TOKEN` env → `gh auth token`.
 pub(crate) struct GhCliSource;
 
 impl TokenSource for GhCliSource {
-    fn fetch(&self) -> Pin<Box<dyn Future<Output = Option<Redacted>> + Send + '_>> {
+    fn fetch(&self) -> TokenFuture<'_> {
         Box::pin(resolve_from_env_or_gh(|var| env::var(var).ok()))
     }
 }
@@ -36,7 +38,7 @@ pub(crate) struct StaticTokenSource(pub Option<Redacted>);
 
 #[cfg(test)]
 impl TokenSource for StaticTokenSource {
-    fn fetch(&self) -> Pin<Box<dyn Future<Output = Option<Redacted>> + Send + '_>> {
+    fn fetch(&self) -> TokenFuture<'_> {
         let token = self.0.clone();
         Box::pin(async move { token })
     }
@@ -90,11 +92,11 @@ where
 mod tests {
     use super::*;
 
-    // T-TS001: gh_cli_source_reads_github_token_env
-    // GhCliSource short-circuits to the GITHUB_TOKEN value when the env reader
-    // returns one, without falling through to the gh CLI subprocess.
+    /// [T-TS001] resolve_from_env_or_gh short-circuits to the GITHUB_TOKEN
+    /// value when the env reader returns one, without falling through to the
+    /// gh CLI subprocess.
     #[tokio::test]
-    async fn gh_cli_source_reads_github_token_env() {
+    async fn resolve_from_env_or_gh_reads_github_token_env() {
         let token = resolve_from_env_or_gh(|key| {
             (key == "GITHUB_TOKEN").then(|| "test-token-from-env".to_owned())
         })
@@ -105,11 +107,10 @@ mod tests {
         );
     }
 
-    // T-TS002: gh_cli_source_skips_whitespace_env
-    // Empty/whitespace env values must not register as "set"; the resolver
-    // falls through to the next candidate in the chain.
+    /// [T-TS002] Empty/whitespace env values must not register as "set"; the
+    /// resolver falls through to the next candidate in the chain.
     #[tokio::test]
-    async fn gh_cli_source_skips_whitespace_env() {
+    async fn resolve_from_env_or_gh_skips_whitespace_env() {
         let token = resolve_from_env_or_gh(|key| match key {
             "GITHUB_TOKEN" => Some("   ".to_owned()),
             "GH_TOKEN" => Some("real-token".to_owned()),
@@ -119,9 +120,8 @@ mod tests {
         assert_eq!(token.as_ref().map(Redacted::expose), Some("real-token"));
     }
 
-    // T-TS003: static_token_source_returns_constructor_value
-    // Test seam: a static Some(...) is propagated to fetch() callers without
-    // ever spawning the gh subprocess.
+    /// [T-TS003] StaticTokenSource(Some(...)) propagates the constructor value
+    /// to fetch() callers without ever spawning the gh subprocess.
     #[tokio::test]
     async fn static_token_source_returns_constructor_value() {
         let source = StaticTokenSource(Some(Redacted::new("fixed")));
@@ -129,9 +129,8 @@ mod tests {
         assert_eq!(token.as_ref().map(Redacted::expose), Some("fixed"));
     }
 
-    // T-TS004: static_token_source_none_returns_none
-    // Test seam: StaticTokenSource(None) simulates the unauthenticated path
-    // so callers can verify rate-limit-tier handling.
+    /// [T-TS004] StaticTokenSource(None) simulates the unauthenticated path so
+    /// callers can verify rate-limit-tier handling.
     #[tokio::test]
     async fn static_token_source_none_returns_none() {
         let source = StaticTokenSource(None);

--- a/src/token_source.rs
+++ b/src/token_source.rs
@@ -1,0 +1,141 @@
+//! GitHub token resolution abstraction. `GhCliSource` walks env vars then
+//! falls back to `gh auth token`; `StaticTokenSource` lets tests inject a
+//! pre-resolved value without spawning a subprocess.
+
+use std::env;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+use tracing::info;
+
+use crate::redacted::Redacted;
+
+const TOKEN_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Resolves an optional GitHub bearer token. `Send + Sync` so implementations
+/// can sit behind an `Arc<dyn TokenSource>` shared across async tasks.
+pub(crate) trait TokenSource: Send + Sync {
+    fn fetch(&self) -> Pin<Box<dyn Future<Output = Option<Redacted>> + Send + '_>>;
+}
+
+/// Production source: `GITHUB_TOKEN` env → `GH_TOKEN` env → `gh auth token`.
+pub(crate) struct GhCliSource;
+
+impl TokenSource for GhCliSource {
+    fn fetch(&self) -> Pin<Box<dyn Future<Output = Option<Redacted>> + Send + '_>> {
+        Box::pin(resolve_from_env_or_gh(|var| env::var(var).ok()))
+    }
+}
+
+/// Test source that returns its constructor argument verbatim.
+#[cfg(test)]
+pub(crate) struct StaticTokenSource(pub Option<Redacted>);
+
+#[cfg(test)]
+impl TokenSource for StaticTokenSource {
+    fn fetch(&self) -> Pin<Box<dyn Future<Output = Option<Redacted>> + Send + '_>> {
+        let token = self.0.clone();
+        Box::pin(async move { token })
+    }
+}
+
+async fn resolve_from_env_or_gh<F>(env_reader: F) -> Option<Redacted>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let from_env = ["GITHUB_TOKEN", "GH_TOKEN"]
+        .iter()
+        .filter_map(|var| env_reader(var))
+        .map(|t| t.trim().to_owned())
+        .find(|t| !t.is_empty());
+
+    if let Some(token) = from_env {
+        return Some(Redacted::new(&token));
+    }
+
+    let output = timeout(
+        TOKEN_RESOLVE_TIMEOUT,
+        Command::new("gh")
+            .args(["auth", "token"])
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .inspect_err(|_| {
+        info!(
+            "gh auth token timed out after {}s",
+            TOKEN_RESOLVE_TIMEOUT.as_secs()
+        )
+    })
+    .ok()?
+    .inspect_err(|e| info!("gh auth token command failed: {e}"))
+    .ok()?;
+
+    if !output.status.success() {
+        info!(
+            stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+            "gh auth token failed"
+        );
+        return None;
+    }
+
+    let token = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (!token.is_empty()).then(|| Redacted::new(&token))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-TS001: gh_cli_source_reads_github_token_env
+    // GhCliSource short-circuits to the GITHUB_TOKEN value when the env reader
+    // returns one, without falling through to the gh CLI subprocess.
+    #[tokio::test]
+    async fn gh_cli_source_reads_github_token_env() {
+        let token = resolve_from_env_or_gh(|key| {
+            (key == "GITHUB_TOKEN").then(|| "test-token-from-env".to_owned())
+        })
+        .await;
+        assert_eq!(
+            token.as_ref().map(Redacted::expose),
+            Some("test-token-from-env")
+        );
+    }
+
+    // T-TS002: gh_cli_source_skips_whitespace_env
+    // Empty/whitespace env values must not register as "set"; the resolver
+    // falls through to the next candidate in the chain.
+    #[tokio::test]
+    async fn gh_cli_source_skips_whitespace_env() {
+        let token = resolve_from_env_or_gh(|key| match key {
+            "GITHUB_TOKEN" => Some("   ".to_owned()),
+            "GH_TOKEN" => Some("real-token".to_owned()),
+            _ => None,
+        })
+        .await;
+        assert_eq!(token.as_ref().map(Redacted::expose), Some("real-token"));
+    }
+
+    // T-TS003: static_token_source_returns_constructor_value
+    // Test seam: a static Some(...) is propagated to fetch() callers without
+    // ever spawning the gh subprocess.
+    #[tokio::test]
+    async fn static_token_source_returns_constructor_value() {
+        let source = StaticTokenSource(Some(Redacted::new("fixed")));
+        let token = source.fetch().await;
+        assert_eq!(token.as_ref().map(Redacted::expose), Some("fixed"));
+    }
+
+    // T-TS004: static_token_source_none_returns_none
+    // Test seam: StaticTokenSource(None) simulates the unauthenticated path
+    // so callers can verify rate-limit-tier handling.
+    #[tokio::test]
+    async fn static_token_source_none_returns_none() {
+        let source = StaticTokenSource(None);
+        let token = source.fetch().await;
+        assert!(token.is_none());
+    }
+}


### PR DESCRIPTION
## 概要

- `resolve_token` (env vars + `gh auth token` 連鎖) が github.rs 内の自由関数だったため、token を inject したいテストは実環境 env を触るか `gh` を spawn するしかなかった。
- `token_source` module を新設し、`TokenSource` trait + 本番用 `GhCliSource` (env → gh CLI) + test 用 `StaticTokenSource(Option<Redacted>)` を追加。
- env vars + `gh auth token` 解決ロジックを `github` から `token_source` に移動。`GitHubClient::from_env` は `from_env_with_source(http, max_retries, &dyn TokenSource)` の薄い wrapper に。
- trait method は object-safe のため `Pin<Box<dyn Future<...> + Send + '_>>` を返す (`TokenFuture<'_>` type alias 経由)。`async_trait` 依存追加なし。
- issue #103 全体 6 PR のうち 4 本目 (PR 0/1/2 = #127 / #128 / #129 マージ済み)。

## 変更

| ファイル | 内容 |
|---|---|
| `src/token_source.rs` (新規) | `TokenSource` trait + `TokenFuture<'_>` alias + `GhCliSource` (env vars → gh CLI fallback) + `StaticTokenSource` + unit test 4 |
| `src/github.rs` | `resolve_token` / `resolve_token_with` / `TOKEN_RESOLVE_TIMEOUT` を削除、`from_env_with_source` を追加、`from_env` は thin wrapper に、test 2 個追加 (T-GH018/T-GH019) |
| `src/lib.rs` | `mod token_source;` 1 行 |

## テスト

- [x] `cargo test --offline` (lib 388 + integration 11 = 全 pass、TokenSource 関連 6 新規 test を含む)
- [x] `cargo fmt --check`
- [x] `cargo clippy --offline --all-targets -- -D warnings`

## polish 履歴

- 2 commit 構成 (`ce95260` TokenSource 導入、`f4b8b10` polish 反映)
- simplify (reuse/quality/efficiency) + codex + coderabbit + gemini + enhancer-code で review 済み
- 修正点:
  - `Pin<Box<dyn Future<...> + Send + '_>>` を `TokenFuture<'_>` type alias に
  - module doc を What→Why に
  - 旧 T-GH005 stub comment 削除、test 名を free function 名に合わせて renaming

## 関連

- Issue #103 — AC: 「TokenSource trait + `GhCliSource` / `StaticTokenSource(Option<String>)` 実装」(scout 側では `Option<Redacted>` に置換)