### PR TITLE
refactor: CommandOutput/SlackUrl/FetchResult のフィールドを private 化 (issue #104)

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -79,13 +79,17 @@ impl Degradation {
 /// Internal command output: holds both the Markdown rendering and the
 /// structured `data` payload, plus degradation signals. Each handler builds
 /// one of these; `lib::run` picks the path (Markdown or JSON) at the boundary.
+///
+/// Fields are private to enforce the `(degraded, notes, degraded_reasons)`
+/// invariant: a literal `degraded: false` paired with non-empty `notes`
+/// cannot be constructed. Use [`Self::ok`] or [`Self::with_degradation`].
 #[derive(Debug)]
 pub(crate) struct CommandOutput {
-    pub markdown: String,
-    pub data: serde_json::Value,
-    pub notes: Vec<String>,
-    pub degraded_reasons: Vec<DegradedReason>,
-    pub degraded: bool,
+    markdown: String,
+    data: serde_json::Value,
+    notes: Vec<String>,
+    degraded_reasons: Vec<DegradedReason>,
+    degraded: bool,
 }
 
 impl CommandOutput {
@@ -116,6 +120,40 @@ impl CommandOutput {
             degraded_reasons,
             degraded,
         }
+    }
+
+    /// Consume self and return the rendered Markdown body.
+    pub(crate) fn into_markdown(self) -> String {
+        self.markdown
+    }
+
+    /// Consume self into a [`SuccessEnvelope`]. Moves `data`, `notes`, and
+    /// `degraded_reasons` without cloning.
+    pub(crate) fn into_envelope(self) -> SuccessEnvelope {
+        SuccessEnvelope {
+            data: self.data,
+            degraded: self.degraded,
+            notes: self.notes,
+            degraded_reasons: self.degraded_reasons,
+        }
+    }
+}
+
+/// Test-only accessors. Production paths consume via [`CommandOutput::into_markdown`]
+/// or [`CommandOutput::into_envelope`]; tests need to assert multiple fields
+/// without consuming the value.
+#[cfg(test)]
+impl CommandOutput {
+    pub(crate) fn markdown(&self) -> &str {
+        &self.markdown
+    }
+
+    pub(crate) fn data(&self) -> &serde_json::Value {
+        &self.data
+    }
+
+    pub(crate) fn degraded_reasons(&self) -> &[DegradedReason] {
+        &self.degraded_reasons
     }
 }
 
@@ -321,12 +359,19 @@ mod tests {
     /// [T-EN007] CommandOutput::ok produces non-degraded with empty notes
     #[test]
     fn command_output_ok_is_not_degraded() {
-        let out = CommandOutput::ok(String::from("md"), serde_json::json!({"a": 1}));
-        assert_eq!(out.markdown, "md");
-        assert_eq!(out.data, serde_json::json!({"a": 1}));
-        assert!(out.notes.is_empty());
-        assert!(out.degraded_reasons.is_empty());
-        assert!(!out.degraded);
+        let env =
+            CommandOutput::ok(String::from("md"), serde_json::json!({"a": 1})).into_envelope();
+        assert_eq!(env.data, serde_json::json!({"a": 1}));
+        assert!(env.notes.is_empty());
+        assert!(env.degraded_reasons.is_empty());
+        assert!(!env.degraded);
+    }
+
+    /// [T-EN015] CommandOutput preserves the markdown body across into_markdown
+    #[test]
+    fn command_output_into_markdown_returns_body() {
+        let out = CommandOutput::ok(String::from("md body"), serde_json::Value::Null);
+        assert_eq!(out.into_markdown(), "md body");
     }
 
     /// [T-EN008] CommandOutput::with_degradation sets degraded=true when degradation non-empty
@@ -338,10 +383,11 @@ mod tests {
             DegradedReason::IssuesFetchFailed,
         );
         let out = CommandOutput::with_degradation(String::from("md"), serde_json::Value::Null, deg);
-        assert!(out.degraded);
-        assert_eq!(out.notes, vec!["partial fetch"]);
+        let env = out.into_envelope();
+        assert!(env.degraded);
+        assert_eq!(env.notes, vec!["partial fetch"]);
         assert_eq!(
-            out.degraded_reasons,
+            env.degraded_reasons,
             vec![DegradedReason::IssuesFetchFailed]
         );
     }
@@ -354,8 +400,9 @@ mod tests {
             serde_json::Value::Null,
             Degradation::default(),
         );
-        assert!(!out.degraded);
-        assert!(out.degraded_reasons.is_empty());
+        let env = out.into_envelope();
+        assert!(!env.degraded);
+        assert!(env.degraded_reasons.is_empty());
     }
 
     /// [T-EN010] ErrorCode serializes per ADR-0065 SCREAMING_SNAKE_CASE

--- a/src/fetch/converter.rs
+++ b/src/fetch/converter.rs
@@ -4,14 +4,41 @@ use serde::Serialize;
 
 use super::extractor::ExtractedArticle;
 
-/// Fetched page content converted to Markdown.
+/// Fetched page content converted to Markdown. Fields are private so the only
+/// construction paths are [`to_fetch_result`] (production) and
+/// [`FetchResult::for_test`] (test fixtures); callers cannot build a result
+/// that bypasses Readability extraction or skips frontmatter rendering.
 #[derive(Debug, Serialize)]
 pub(crate) struct FetchResult {
-    pub url: String,
-    pub markdown: String,
+    url: String,
+    markdown: String,
     /// Internal flag: surfaced as a `notes` entry in scout's JSON output, not as data.
     #[serde(skip_serializing)]
-    pub used_raw_fallback: bool,
+    used_raw_fallback: bool,
+}
+
+impl FetchResult {
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub(crate) fn markdown(&self) -> &str {
+        &self.markdown
+    }
+
+    pub(crate) fn used_raw_fallback(&self) -> bool {
+        self.used_raw_fallback
+    }
+
+    /// Test-only constructor. Production code goes through [`to_fetch_result`].
+    #[cfg(test)]
+    pub(crate) fn for_test(url: String, markdown: String, used_raw_fallback: bool) -> Self {
+        Self {
+            url,
+            markdown,
+            used_raw_fallback,
+        }
+    }
 }
 
 pub(crate) const RAW_FALLBACK_NOTE: &str =
@@ -73,12 +100,12 @@ mod tests {
 
         let result = to_fetch_result(&article, "https://example.com".into());
 
-        assert!(result.markdown.starts_with("---\n"));
-        assert!(result.markdown.contains("\n---\n\n"));
-        assert!(result.markdown.contains("title: \"My Title\""));
-        assert!(result.markdown.contains("author: \"Jane Doe\""));
-        assert!(result.markdown.contains("date: \"2026-01-15\""));
-        assert!(result.markdown.contains("Body text"));
+        assert!(result.markdown().starts_with("---\n"));
+        assert!(result.markdown().contains("\n---\n\n"));
+        assert!(result.markdown().contains("title: \"My Title\""));
+        assert!(result.markdown().contains("author: \"Jane Doe\""));
+        assert!(result.markdown().contains("date: \"2026-01-15\""));
+        assert!(result.markdown().contains("Body text"));
     }
 
     /// [T-FC002] frontmatter_omits_missing_fields
@@ -94,9 +121,9 @@ mod tests {
 
         let result = to_fetch_result(&article, "https://example.com".into());
 
-        assert!(result.markdown.contains("title: \"Only Title\""));
-        assert!(!result.markdown.contains("author:"));
-        assert!(!result.markdown.contains("date:"));
+        assert!(result.markdown().contains("title: \"Only Title\""));
+        assert!(!result.markdown().contains("author:"));
+        assert!(!result.markdown().contains("date:"));
     }
 
     /// [T-FC003] escapes_yaml_special_chars

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Parser;
-use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload, SuccessEnvelope};
+use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload};
 use signals::{InterruptSignal, wait_for_signal};
 use tokio::time::timeout;
 use tools::{Command, Scout, ScoutError};
@@ -153,7 +153,7 @@ pub async fn run() -> ExitCode {
             let rendered = if json_mode {
                 render_json_success(output)
             } else {
-                output.markdown
+                output.into_markdown()
             };
             let mut handle = stdout().lock();
             match write_output(&mut handle, &rendered) {
@@ -177,13 +177,7 @@ pub async fn run() -> ExitCode {
 /// Takes `CommandOutput` by value so `data` and `notes` move into the envelope
 /// instead of being deep-cloned.
 fn render_json_success(output: CommandOutput) -> String {
-    let envelope = SuccessEnvelope {
-        data: output.data,
-        degraded: output.degraded,
-        notes: output.notes,
-        degraded_reasons: output.degraded_reasons,
-    };
-    serde_json::to_string(&envelope).expect("envelope is Serialize")
+    serde_json::to_string(&output.into_envelope()).expect("envelope is Serialize")
 }
 
 /// Serialize a `ScoutError` as a one-line JSON envelope per ADR-0065.

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -131,13 +131,13 @@ fn format_fetched_pages(pages: &[FetchResult], out: &mut String) {
     }
     out.push_str("---\n\n## Fetched Pages\n\n");
     for page in pages {
-        let _ = writeln!(out, "### {}\n", sanitize_heading(&page.url));
-        if page.used_raw_fallback {
+        let _ = writeln!(out, "### {}\n", sanitize_heading(page.url()));
+        if page.used_raw_fallback() {
             out.push_str(fetch::converter::RAW_FALLBACK_NOTE);
         }
         // Shift headings by 3 levels so page content (h1->h4, h2->h5, ...)
         // does not collide with the report's own heading hierarchy.
-        let content = shift_headings(&page.markdown, 3);
+        let content = shift_headings(page.markdown(), 3);
         out.push_str(&truncate_with_note(&content, MAX_PAGE_BYTES));
         out.push_str("\n\n");
     }
@@ -271,11 +271,11 @@ mod tests {
     #[test]
     fn format_report_includes_fetched_pages() {
         let report = ResearchReport {
-            fetched_pages: vec![FetchResult {
-                url: "https://example.com".into(),
-                markdown: "# Example Page\n\n## Section\n\nSome content here.".into(),
-                used_raw_fallback: false,
-            }],
+            fetched_pages: vec![FetchResult::for_test(
+                "https://example.com".into(),
+                "# Example Page\n\n## Section\n\nSome content here.".into(),
+                false,
+            )],
             failed_urls: vec![],
             sources: vec![],
         };
@@ -300,11 +300,11 @@ mod tests {
         let total = MAX_PAGE_BYTES + 2_000;
         let long_content = "x".repeat(total);
         let report = ResearchReport {
-            fetched_pages: vec![FetchResult {
-                url: "https://long.com".into(),
-                markdown: long_content,
-                used_raw_fallback: false,
-            }],
+            fetched_pages: vec![FetchResult::for_test(
+                "https://long.com".into(),
+                long_content,
+                false,
+            )],
             failed_urls: vec![],
             sources: vec![],
         };
@@ -420,35 +420,23 @@ mod tests {
         let mut indexed_pages: Vec<(usize, FetchResult)> = vec![
             (
                 2,
-                FetchResult {
-                    url: "https://c.com".into(),
-                    markdown: String::new(),
-                    used_raw_fallback: false,
-                },
+                FetchResult::for_test("https://c.com".into(), String::new(), false),
             ),
             (
                 0,
-                FetchResult {
-                    url: "https://a.com".into(),
-                    markdown: String::new(),
-                    used_raw_fallback: false,
-                },
+                FetchResult::for_test("https://a.com".into(), String::new(), false),
             ),
             (
                 1,
-                FetchResult {
-                    url: "https://b.com".into(),
-                    markdown: String::new(),
-                    used_raw_fallback: false,
-                },
+                FetchResult::for_test("https://b.com".into(), String::new(), false),
             ),
         ];
 
         indexed_pages.sort_by_key(|(idx, _)| *idx);
         let pages: Vec<_> = indexed_pages.into_iter().map(|(_, page)| page).collect();
 
-        assert_eq!(pages[0].url, "https://a.com");
-        assert_eq!(pages[1].url, "https://b.com");
-        assert_eq!(pages[2].url, "https://c.com");
+        assert_eq!(pages[0].url(), "https://a.com");
+        assert_eq!(pages[1].url(), "https://b.com");
+        assert_eq!(pages[2].url(), "https://c.com");
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -40,13 +40,30 @@ pub(crate) enum SlackError {
     InsecureUrl,
 }
 
+/// Parsed Slack message URL. Fields are private so the only construction path
+/// is [`parse_slack_url`]; this guarantees `workspace`/`channel`/`ts` carry the
+/// shape that path established (non-empty workspace, `<secs>.<micros>` ts).
 #[derive(Debug, Clone)]
 pub(crate) struct SlackUrl {
-    pub workspace: String,
-    pub channel: String,
-    pub ts: String,
-    pub thread_ts: Option<String>,
-    pub raw_url: String,
+    workspace: String,
+    channel: String,
+    ts: String,
+    thread_ts: Option<String>,
+    raw_url: String,
+}
+
+impl SlackUrl {
+    pub(crate) fn workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    pub(crate) fn channel(&self) -> &str {
+        &self.channel
+    }
+
+    pub(crate) fn raw_url(&self) -> &str {
+        &self.raw_url
+    }
 }
 
 /// Parse a Slack message URL into its components.
@@ -746,15 +763,10 @@ mod tests {
     /// [T-SK008] format_slack_output uses targeted reply as primary message
     #[test]
     fn format_output_uses_reply_as_primary_when_targeted() {
-        let slack_url = SlackUrl {
-            workspace: "team".into(),
-            channel: "C123".into(),
-            ts: "1111111111.222222".into(),
-            thread_ts: Some("1234567890.123456".into()),
-            raw_url:
-                "https://team.slack.com/archives/C123/p1111111111222222?thread_ts=1234567890.123456"
-                    .into(),
-        };
+        let slack_url = parse_slack_url(
+            "https://team.slack.com/archives/C123/p1111111111222222?thread_ts=1234567890.123456",
+        )
+        .expect("URL fixture should parse");
         let reply = ResolvedMessage {
             author: "reply-author".into(),
             text: "reply body".into(),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -267,7 +267,7 @@ impl Scout {
             )))
         })?;
 
-        if result.used_raw_fallback {
+        if result.used_raw_fallback() {
             warn!(url = %RedactedLogUrl(&url), "readability extraction failed, using raw fallback");
         }
 
@@ -275,7 +275,7 @@ impl Scout {
         let markdown = format_fetch_output(&result);
         let data = serde_json::to_value(&result).expect("FetchResult is Serialize");
         let mut degradation = Degradation::default();
-        if result.used_raw_fallback {
+        if result.used_raw_fallback() {
             degradation.push(
                 String::from(
                     "Readability extraction failed; raw page conversion was used instead.",
@@ -287,7 +287,7 @@ impl Scout {
     }
 
     async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<CommandOutput, ScoutError> {
-        info!(workspace = %slack_url.workspace, channel = %slack_url.channel, "fetch (slack)");
+        info!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), "fetch (slack)");
         let client = SlackClient::from_env(self.http.clone(), self.config.max_retries)?;
         let slack_timeout = self.config.slack_timeout;
         let output = timeout(slack_timeout, client.fetch_message(&slack_url))
@@ -299,12 +299,12 @@ impl Scout {
                 )))
             })
             .inspect_err(|e| {
-                warn!(workspace = %slack_url.workspace, channel = %slack_url.channel, error = %e, "slack fetch failed");
+                warn!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), error = %e, "slack fetch failed");
             })?;
-        info!(workspace = %slack_url.workspace, channel = %slack_url.channel, "fetch (slack) complete");
+        info!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), "fetch (slack) complete");
         let markdown = truncate_with_note(&output, MAX_FETCH_OUTPUT_BYTES).into_owned();
         let data = serde_json::json!({
-            "url": slack_url.raw_url,
+            "url": slack_url.raw_url(),
             "markdown": markdown,
         });
         Ok(CommandOutput::ok(markdown, data))
@@ -825,8 +825,8 @@ fn collect_research_degradations(report: &engine::ResearchReport, degradation: &
     let raw_fallback_pages: Vec<&str> = report
         .fetched_pages
         .iter()
-        .filter(|p| p.used_raw_fallback)
-        .map(|p| p.url.as_str())
+        .filter(|p| p.used_raw_fallback())
+        .map(FetchResult::url)
         .collect();
     if !raw_fallback_pages.is_empty() {
         degradation.push(
@@ -840,8 +840,8 @@ fn collect_research_degradations(report: &engine::ResearchReport, degradation: &
 }
 
 fn format_fetch_output(result: &FetchResult) -> String {
-    let shifted = shift_headings(&result.markdown, 2);
-    let output = if result.used_raw_fallback {
+    let shifted = shift_headings(result.markdown(), 2);
+    let output = if result.used_raw_fallback() {
         format!("{RAW_FALLBACK_NOTE}{shifted}")
     } else {
         shifted
@@ -892,7 +892,8 @@ mod tests {
 
         let result = s.search(params).await.unwrap();
         assert_eq!(
-            result.markdown, "https://rust-lang.org\nhttps://doc.rust-lang.org",
+            result.markdown(),
+            "https://rust-lang.org\nhttps://doc.rust-lang.org",
             "stdout should be one URL per line, no markdown decoration"
         );
     }
@@ -922,7 +923,7 @@ mod tests {
         };
 
         let result = s.search(params).await.unwrap();
-        let data = &result.data;
+        let data = result.data();
         assert!(data.get("answer").is_none(), "answer field must be absent");
         assert_eq!(data["query"], "foo");
         assert!(data["sources"].is_array());
@@ -975,8 +976,8 @@ mod tests {
             lang: Lang::Auto,
         };
         let result = s.search(params).await.unwrap();
-        assert_eq!(result.markdown, "", "empty stdout for zero results");
-        assert_eq!(result.data["sources"].as_array().unwrap().len(), 0);
+        assert_eq!(result.markdown(), "", "empty stdout for zero results");
+        assert_eq!(result.data()["sources"].as_array().unwrap().len(), 0);
     }
 
     /// [T-TS002] research returns report with Brave sources and no obsolete Search Result header
@@ -1008,15 +1009,17 @@ mod tests {
 
         let result = s.research(params).await.unwrap();
         assert!(
-            result.markdown.contains("rust-lang.test"),
+            result.markdown().contains("rust-lang.test"),
             "report should reference Brave source URL, got: {result:?}"
         );
         assert!(
-            !result.markdown.contains("## Search Result"),
+            !result.markdown().contains("## Search Result"),
             "AC-3.1: report must not contain the obsolete Search Result header"
         );
         assert!(
-            !result.markdown.contains("vertexaisearch.cloud.google.com"),
+            !result
+                .markdown()
+                .contains("vertexaisearch.cloud.google.com"),
             "AC-3.2: Sources must not contain Google redirect URLs"
         );
     }
@@ -1046,7 +1049,7 @@ mod tests {
             lang: Lang::Auto,
         };
         let result = s.research(params).await.unwrap();
-        let data = &result.data;
+        let data = result.data();
 
         assert_eq!(data["query"], "foo", "data.query must echo the request");
         assert!(data["sources"].is_array(), "data.sources must be an array");
@@ -1100,12 +1103,12 @@ mod tests {
 
         assert!(
             result
-                .degraded_reasons
+                .degraded_reasons()
                 .contains(&DegradedReason::BraveSearchFailed),
             "degraded_reasons must contain BraveSearchFailed; got: {:?}",
-            result.degraded_reasons
+            result.degraded_reasons()
         );
-        let data = &result.data;
+        let data = result.data();
         assert_eq!(
             data["sources"].as_array().unwrap().len(),
             0,
@@ -1166,7 +1169,7 @@ mod tests {
             lang: Lang::Auto,
         };
         let result = s.research(params).await.unwrap();
-        let data = &result.data;
+        let data = result.data();
 
         assert_eq!(
             data["sources"].as_array().unwrap().len(),
@@ -1188,11 +1191,11 @@ mod tests {
     /// [T-TS003] fetch_output_shifts_headings
     #[test]
     fn fetch_output_shifts_headings() {
-        let result = FetchResult {
-            url: "https://example.com".into(),
-            markdown: "# Title\n## Section\nContent".into(),
-            used_raw_fallback: false,
-        };
+        let result = FetchResult::for_test(
+            "https://example.com".into(),
+            "# Title\n## Section\nContent".into(),
+            false,
+        );
         let output = format_fetch_output(&result);
         assert!(output.contains("### Title"), "h1 should shift to h3");
         assert!(output.contains("#### Section"), "h2 should shift to h4");
@@ -1201,11 +1204,11 @@ mod tests {
     /// [T-TS004] fetch_output_shifts_headings_with_raw_fallback
     #[test]
     fn fetch_output_shifts_headings_with_raw_fallback() {
-        let result = FetchResult {
-            url: "https://example.com".into(),
-            markdown: "# Raw Title\nBody".into(),
-            used_raw_fallback: true,
-        };
+        let result = FetchResult::for_test(
+            "https://example.com".into(),
+            "# Raw Title\nBody".into(),
+            true,
+        );
         let output = format_fetch_output(&result);
         assert!(
             output.starts_with(RAW_FALLBACK_NOTE.trim_end()),
@@ -1217,11 +1220,11 @@ mod tests {
     /// [T-TS005] fetch_output_truncates_long_content
     #[test]
     fn fetch_output_truncates_long_content() {
-        let result = FetchResult {
-            url: "https://example.com".into(),
-            markdown: format!("# Title\n{}", "x".repeat(150_000)),
-            used_raw_fallback: false,
-        };
+        let result = FetchResult::for_test(
+            "https://example.com".into(),
+            format!("# Title\n{}", "x".repeat(150_000)),
+            false,
+        );
         let output = format_fetch_output(&result);
         assert!(
             output.len() < 150_000,
@@ -1584,11 +1587,11 @@ mod tests {
 
         let result = s.repo_read(params).await.unwrap();
         assert!(
-            result.markdown.contains("テスト"),
+            result.markdown().contains("テスト"),
             "output should contain decoded Shift_JIS text, got: {result:?}"
         );
         assert!(
-            result.markdown.contains("[encoding: shift_jis]"),
+            result.markdown().contains("[encoding: shift_jis]"),
             "header should include encoding label, got: {result:?}"
         );
     }
@@ -1642,15 +1645,15 @@ mod tests {
 
         let result = s.repo_tree(params).await.unwrap();
         assert!(
-            result.markdown.contains("src/main.rs"),
+            result.markdown().contains("src/main.rs"),
             "path filter should include src/main.rs, got:\n{result:?}"
         );
         assert!(
-            !result.markdown.contains("README.md"),
+            !result.markdown().contains("README.md"),
             "path filter should exclude README.md, got:\n{result:?}"
         );
         assert!(
-            !result.markdown.contains("Cargo.toml"),
+            !result.markdown().contains("Cargo.toml"),
             "path filter should exclude Cargo.toml, got:\n{result:?}"
         );
     }


### PR DESCRIPTION
## 概要

issue #104 の sub-task 1-3 を解決する PR。

3 つの DTO は constructor で validation していたが、`pub` field のままで crate 内 caller が struct literal 経由で invariant を bypass できる状態だった。フィールドを private 化し、accessor 経由のみ読めるように変更することで、`(degraded, notes, degraded_reasons)` の対応関係や Slack URL の parse 結果の shape が crate 内で drift しないようにする。

- **CommandOutput** (`src/envelope.rs`): フィールド private 化、`into_markdown` / `into_envelope` consumer + `#[cfg(test)]` accessor 追加。`lib::run` は envelope helper 経由で consume するように変更。
- **SlackUrl** (`src/slack.rs`): フィールド private 化、`workspace`/`channel`/`raw_url` accessor 追加。`tools::fetch_slack` と slack.rs の format test は `parse_slack_url` 経由に切り替え。
- **FetchResult** (`src/fetch/converter.rs`): フィールド private 化、`url`/`markdown`/`used_raw_fallback` accessor + `#[cfg(test)] for_test` constructor 追加。`tools::format_fetch_output`、`search::engine::format_fetched_pages`、8 つの test literal を accessor / for_test API 経由に置換。

挙動変化なし。

## テスト

- [x] `cargo test --offline` — 393 lib + 11 integration pass
- [x] `cargo clippy --offline --all-targets` — warning なし
- [ ] reviewer による production callsite の漏れチェック

## 関連 PR (issue #104)

issue #104 を 4 PR に分割。本 PR は 1/4。

- PR-A (本 PR): encapsulation
- PR-B: `PerPage` newtype (1..=100)
- PR-C: `Redacted::new` fallible 化
- PR-D: `StdinResolver` enum 化