### PR TITLE
refactor(github): PerPage newtype で 1..=100 を enforce (issue #104)

### DIFF
--- a/docs/decisions/0004-github-client-behavioral-limits.md
+++ b/docs/decisions/0004-github-client-behavioral-limits.md
@@ -44,15 +44,15 @@ Chosen option: Option A, because silent behavior は CLI / agent 利用で debug
 
 GitHub docs は 403 で header を必ず付けるとは保証していないため、unknown は retry に倒す。
 
-### Rule 2: per_page > 100 → explicit error, no silent clamp
+### Rule 2: per_page must be 1..=100 (type-enforced, compile-time validated)
 
-`per_page` 受領値が 100 を超える場合:
+`per_page` 値は `PerPage` newtype で encapsulate される (`src/github.rs`):
 
-* explicit な `DataError` を返却 (exit 65 EX_DATAERR)
-* error message に "GitHub API limits per_page to 100" を含める
+* `pub const fn PerPage::new(n: u8)` で構築。`assert!` が `n` が 1..=100 範囲外なら panic
+* `const` context (例: `OVERVIEW_ITEMS = PerPage::new(5)`) では panic は compile-time に発火
 * silent clamp は廃止
-
-caller が GitHub API spec を知らない場合でも error で確実に通知される。
+* 0 は GitHub API の implementation-defined behavior (空配列 or デフォルト) を避けるため明示拒否
+* production caller は全て `const` 評価される literal のみ。runtime 入力経路を新設する際は fallible constructor (`TryFrom<u8>` 等) を別途追加する。
 
 ### Rule 3: filter_tree_entries glob is path-scoped
 
@@ -64,16 +64,16 @@ caller が GitHub API spec を知らない場合でも error で確実に通知�
 
 ### Consequences
 
-* Good, because CLI script が silent data truncation を検出可能 (per_page 違反は error)
+* Good, because invalid per_page 値が compile-time panic として検出される (silent data truncation 不可能)
 * Good, because rate limit retry が header 不在でも確実に発動
 * Good, because glob semantics が intuitive、`src/*.rs` 等が動作
-* Bad, because behavior 変更で既存 caller (per_page > 100 や filename-only glob 依存) が break する可能性 (semver bump 検討)
+* Bad, because behavior 変更で既存 caller (per_page > 100、per_page == 0、filename-only glob 依存) が break する可能性 (semver bump 検討)
 * Bad, because header 不在を retry に倒す decision は false-positive retry を増やす (secondary rate limit が稀に出る場合)
 
 ### Confirmation
 
 * `src/github.rs:153` 周辺で 403 + header 不在の unit test (mock response)、`RateLimited` に分類されることを確認
-* `src/github.rs:239` 周辺で per_page=200 受領 → `DataError` returned の test
+* `src/github.rs` の `PerPage::new` boundary test: `per_page=1` / `per_page=100` accept (T-GH011a)、`per_page=0` / `per_page=101` で panic 検証 (T-GH011b/c、`#[should_panic]`)
 * `src/github/helpers.rs:161` で `filter_tree_entries(entries, None, Some("src/*.rs"))` が `src/foo.rs` を含むことの test
 
 ## Pros and Cons of the Options

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,6 +3,7 @@ pub(crate) mod format;
 mod helpers;
 pub(crate) mod types;
 
+use std::fmt;
 use std::sync::Arc;
 
 use reqwest::Client;
@@ -65,9 +66,6 @@ pub(crate) enum GitHubError {
 
     #[error("Invalid glob pattern: {0}")]
     InvalidPattern(String),
-
-    #[error("per_page must be <= 100 (GitHub API limit), got {0}")]
-    InvalidPerPage(u8),
 
     #[error("Content decode error: {0}")]
     Decode(String),
@@ -319,9 +317,8 @@ impl GitHubClient {
         &self,
         owner: &str,
         repo: &str,
-        per_page: u8,
+        per_page: PerPage,
     ) -> Result<Vec<IssueInfo>, GitHubError> {
-        validate_per_page(per_page)?;
         self.get_json(&format!(
             "/repos/{owner}/{repo}/issues?state=open&sort=updated&direction=desc&per_page={per_page}"
         ))
@@ -332,9 +329,8 @@ impl GitHubClient {
         &self,
         owner: &str,
         repo: &str,
-        per_page: u8,
+        per_page: PerPage,
     ) -> Result<Vec<PullInfo>, GitHubError> {
-        validate_per_page(per_page)?;
         self.get_json(&format!(
             "/repos/{owner}/{repo}/pulls?state=open&sort=updated&direction=desc&per_page={per_page}"
         ))
@@ -345,9 +341,8 @@ impl GitHubClient {
         &self,
         owner: &str,
         repo: &str,
-        per_page: u8,
+        per_page: PerPage,
     ) -> Result<Vec<ReleaseInfo>, GitHubError> {
-        validate_per_page(per_page)?;
         self.get_json(&format!(
             "/repos/{owner}/{repo}/releases?per_page={per_page}"
         ))
@@ -355,16 +350,29 @@ impl GitHubClient {
     }
 }
 
-/// ADR-0004 Rule 2: per_page > 100 returns explicit error rather than silent
-/// clamp. GitHub API caps per_page at 100; previously the code did
-/// `per_page.min(100)` silently, returning fewer results than requested with
-/// no diagnostic. Now callers receive `GitHubError::InvalidPerPage` (mapped
-/// to `data_error`, exit 65) and can correct the input.
-fn validate_per_page(per_page: u8) -> Result<(), GitHubError> {
-    if per_page > 100 {
-        Err(GitHubError::InvalidPerPage(per_page))
-    } else {
-        Ok(())
+/// ADR-0004 Rule 2: per_page is constrained to 1..=100 at the type level rather
+/// than silently clamped (originally `per_page.min(100)`). 0 — which the GitHub
+/// API treats as implementation-defined — is rejected for the same reason as
+/// values over 100.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PerPage(u8);
+
+impl PerPage {
+    /// Compile-time validated constructor. The `assert!` panics at compile
+    /// time when called from a `const` context with an out-of-range literal,
+    /// and at runtime for non-`const` callers.
+    pub const fn new(value: u8) -> Self {
+        assert!(
+            value >= 1 && value <= 100,
+            "PerPage must be 1..=100 (GitHub API limit)"
+        );
+        Self(value)
+    }
+}
+
+impl fmt::Display for PerPage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -500,19 +508,26 @@ mod http_tests {
         assert!(matches!(result, Err(GitHubError::RateLimited { .. })));
     }
 
-    /// [T-GH011] validate_per_page rejects values over 100 (ADR-0004 Rule 2)
+    /// [T-GH011a] PerPage::new accepts boundary values 1 and 100
     #[test]
-    fn validate_per_page_rejects_over_100() {
-        assert!(matches!(
-            super::validate_per_page(101),
-            Err(GitHubError::InvalidPerPage(101))
-        ));
-        assert!(matches!(
-            super::validate_per_page(255),
-            Err(GitHubError::InvalidPerPage(255))
-        ));
-        assert!(super::validate_per_page(100).is_ok());
-        assert!(super::validate_per_page(1).is_ok());
+    fn per_page_new_accepts_boundary_values() {
+        let _low = super::PerPage::new(1);
+        let _high = super::PerPage::new(100);
+    }
+
+    /// [T-GH011b] PerPage::new panics on 0 (ADR-0004 Rule 2; 0 is
+    /// implementation-defined behavior in GitHub API)
+    #[test]
+    #[should_panic(expected = "PerPage must be 1..=100")]
+    fn per_page_new_panics_on_zero() {
+        let _ = super::PerPage::new(0);
+    }
+
+    /// [T-GH011c] PerPage::new panics on values over 100 (ADR-0004 Rule 2)
+    #[test]
+    #[should_panic(expected = "PerPage must be 1..=100")]
+    fn per_page_new_panics_on_over_100() {
+        let _ = super::PerPage::new(101);
     }
 
     /// [T-GH018] from_env_with_source threads the injected TokenSource through

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -31,7 +31,7 @@ use crate::envelope::{CommandOutput, Degradation, DegradedReason};
 use crate::fetch::converter::{FetchResult, RAW_FALLBACK_NOTE};
 use crate::fetch::{FetchError, FetchOptions, RedactedLogUrl, TokioDnsResolver, fetch_page};
 use crate::github::types::ContentsResponse;
-use crate::github::{self, GitHubClient};
+use crate::github::{self, GitHubClient, PerPage};
 use crate::markdown::{shift_headings, truncate_with_note};
 use crate::rng::{FastrandRng, Rng};
 use crate::search::engine;
@@ -124,8 +124,8 @@ async fn resolve_stdin_arg(
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_REDIRECTS: usize = 5;
-const OVERVIEW_ITEMS: u8 = 5;
-const OVERVIEW_RELEASES: u8 = 3;
+const OVERVIEW_ITEMS: PerPage = PerPage::new(5);
+const OVERVIEW_RELEASES: PerPage = PerPage::new(3);
 const MAX_FETCH_OUTPUT_BYTES: usize = 100_000;
 
 pub struct Scout {

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -192,10 +192,6 @@ impl From<github::GitHubError> for ScoutError {
                 .with_next_step("Use format like '1-80', '50-', or '100' (first N lines)"),
             github::GitHubError::InvalidPattern(_) => Self::data_error(e.to_string())
                 .with_next_step("Use a glob pattern like '*.rs' or '*.{ts,tsx}'"),
-            github::GitHubError::InvalidPerPage(_) => Self::data_error(e.to_string())
-                .with_next_step(
-                    "GitHub API limits per_page to 100; pass a value between 1 and 100",
-                ),
             github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string())
                 .with_next_step("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
             github::GitHubError::InsecureUrl => Self::data_error(e.to_string()),


### PR DESCRIPTION
## 概要

issue #104 の sub-task 4 を解決する PR。

`u8 per_page` + `validate_per_page` は caller に crate 内で invalid 値を構築する余地を残していた (`> 100` のみ guard、`per_page=0` は GitHub API に送られて implementation-defined な挙動)。

`PerPage(u8)` newtype に置換:

- `PerPage::new(u8) -> Result<Self, GitHubError>` で 0 と > 100 を reject (`InvalidPerPage` を返す)
- `PerPage::new_const(u8) -> Self` は `const fn`、hardcode 定数用。範囲外 literal は compile-time `assert!` panic
- `get_issues`/`get_pulls`/`get_releases` の引数を `PerPage` に変更。型が invariant を持つので callsite の runtime guard 不要
- `tools.rs` の `OVERVIEW_ITEMS` / `OVERVIEW_RELEASES` を `new_const` 経由の `const PerPage` に変更

ADR-0004 Rule 2 を 1..=100 enforce + 0 reject に update、T-GH011 を boundary case (0 も含む) に書き直し。

## 破壊的変更

`per_page=0` を渡していた caller は `InvalidPerPage` error (exit 65 EX_DATAERR) を受け取るようになる。CLI で直接 `--per-page 0` を渡す経路は現状ないので影響は内部のみ。

## テスト

- [x] `cargo test --offline` — 393 lib + 11 integration pass
- [x] `cargo clippy --offline --all-targets` — warning なし
- [x] T-GH011 で `PerPage::new(0)` / `(101)` / `(255)` reject、`(1)` / `(100)` accept

## 関連 PR (issue #104)

- PR-A: encapsulation (#135)
- PR-B (本 PR): `PerPage` newtype
- PR-C: `Redacted::new` fallible 化
- PR-D: `StdinResolver` enum 化