### PR TITLE
refactor(redacted): Redacted::new を fallible 化して空入力を reject (issue #104)

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -108,12 +108,10 @@ impl BraveClient {
         F: Fn(&str) -> Result<String, env::VarError>,
     {
         let api_key = get_var("BRAVE_SEARCH_API_KEY").map_err(|_| BraveError::ApiKeyNotSet)?;
-        if api_key.trim().is_empty() {
-            return Err(BraveError::ApiKeyNotSet);
-        }
+        let api_key = Redacted::new(&api_key).ok_or(BraveError::ApiKeyNotSet)?;
         Ok(Self {
             http,
-            api_key: Redacted::new(&api_key),
+            api_key,
             base_url: API_BASE.to_owned(),
             max_retries,
             #[cfg(test)]
@@ -125,7 +123,7 @@ impl BraveClient {
     pub(crate) fn with_base_url(http: Client, base_url: &str) -> Self {
         Self {
             http,
-            api_key: Redacted::new("test-key"),
+            api_key: Redacted::new("test-key").expect("static literal is non-empty"),
             base_url: base_url.to_owned(),
             max_retries: DEFAULT_MAX_RETRIES,
             skip_https_check: true,

--- a/src/github.rs
+++ b/src/github.rs
@@ -521,7 +521,9 @@ mod http_tests {
     #[tokio::test]
     async fn from_env_with_static_source_installs_token() {
         use crate::token_source::StaticTokenSource;
-        let source = StaticTokenSource(Some(Redacted::new("injected-token")));
+        let source = StaticTokenSource(Some(
+            Redacted::new("injected-token").expect("static literal is non-empty"),
+        ));
         let client = GitHubClient::from_env_with_source(Client::new(), 0, &source).await;
         assert_eq!(
             client.token.as_ref().map(Redacted::expose),

--- a/src/redacted.rs
+++ b/src/redacted.rs
@@ -1,11 +1,21 @@
 use std::fmt;
 
+/// A secret value that hides its contents from `Debug` formatting.
+/// Construction returns `None` for empty/whitespace input so callers
+/// cannot store an effectively missing credential.
 #[derive(Clone)]
 pub(crate) struct Redacted(String);
 
 impl Redacted {
-    pub fn new(s: &str) -> Self {
-        Self(s.trim().to_owned())
+    /// Construct a redacted secret. Returns `None` when `s` is empty or
+    /// contains only whitespace; otherwise stores the trimmed value.
+    pub fn new(s: &str) -> Option<Self> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(Self(trimmed.to_owned()))
+        }
     }
 
     pub fn expose(&self) -> &str {
@@ -39,8 +49,28 @@ mod tests {
     /// [T-RD001] Redacted value hides contents in Debug output
     #[test]
     fn debug_is_redacted() {
-        let secret = Redacted::new("super-secret");
+        let secret = Redacted::new("super-secret").expect("static literal is non-empty");
         assert_eq!(format!("{secret:?}"), "[REDACTED]");
+    }
+
+    /// [T-RD002] Redacted::new rejects empty input
+    #[test]
+    fn new_rejects_empty_input() {
+        assert!(Redacted::new("").is_none());
+    }
+
+    /// [T-RD003] Redacted::new rejects whitespace-only input
+    #[test]
+    fn new_rejects_whitespace_only_input() {
+        assert!(Redacted::new("   ").is_none());
+        assert!(Redacted::new("\t\n").is_none());
+    }
+
+    /// [T-RD004] Redacted::new trims surrounding whitespace from accepted input
+    #[test]
+    fn new_trims_surrounding_whitespace() {
+        let secret = Redacted::new("  abc  ").expect("non-empty after trim");
+        assert_eq!(secret.expose(), "abc");
     }
 
     // T-RC007: validate_https_is_generic_over_caller_error_type

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -168,17 +168,15 @@ impl SlackClient {
 
     pub fn from_env(http: Client, max_retries: u32) -> Result<Self, SlackError> {
         let raw = env::var("SLACK_TOKEN").map_err(|_| SlackError::TokenNotSet)?;
-        if raw.trim().is_empty() {
-            return Err(SlackError::TokenNotSet);
-        }
-        Ok(Self::new(http, Redacted::new(&raw), max_retries))
+        let token = Redacted::new(&raw).ok_or(SlackError::TokenNotSet)?;
+        Ok(Self::new(http, token, max_retries))
     }
 
     #[cfg(test)]
     fn with_base_url(http: Client, base_url: &str) -> Self {
         Self {
             http,
-            token: Redacted::new("xoxp-test"),
+            token: Redacted::new("xoxp-test").expect("static literal is non-empty"),
             base_url: base_url.to_owned(),
             max_retries: DEFAULT_MAX_RETRIES,
             skip_https_check: true,

--- a/src/token_source.rs
+++ b/src/token_source.rs
@@ -48,14 +48,12 @@ async fn resolve_from_env_or_gh<F>(env_reader: F) -> Option<Redacted>
 where
     F: Fn(&str) -> Option<String>,
 {
-    let from_env = ["GITHUB_TOKEN", "GH_TOKEN"]
+    if let Some(token) = ["GITHUB_TOKEN", "GH_TOKEN"]
         .iter()
         .filter_map(|var| env_reader(var))
-        .map(|t| t.trim().to_owned())
-        .find(|t| !t.is_empty());
-
-    if let Some(token) = from_env {
-        return Some(Redacted::new(&token));
+        .find_map(|t| Redacted::new(&t))
+    {
+        return Some(token);
     }
 
     let output = timeout(
@@ -84,8 +82,7 @@ where
         return None;
     }
 
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    (!token.is_empty()).then(|| Redacted::new(&token))
+    Redacted::new(&String::from_utf8_lossy(&output.stdout))
 }
 
 #[cfg(test)]
@@ -124,7 +121,9 @@ mod tests {
     /// to fetch() callers without ever spawning the gh subprocess.
     #[tokio::test]
     async fn static_token_source_returns_constructor_value() {
-        let source = StaticTokenSource(Some(Redacted::new("fixed")));
+        let source = StaticTokenSource(Some(
+            Redacted::new("fixed").expect("static literal is non-empty"),
+        ));
         let token = source.fetch().await;
         assert_eq!(token.as_ref().map(Redacted::expose), Some("fixed"));
     }


### PR DESCRIPTION
## 概要

issue #104 の sub-task 5 を解決する PR。

3 つの backend (slack, brave, token_source) が `Redacted` 構築前にそれぞれ `trim().is_empty()` check を repeat していた。token-source の chain では「env var unset」と「env var が whitespace のみ」を手で区別。これら check が drift すると、実質 missing な credential が `Redacted` に入る余地が残る。

`Redacted::new(&str)` を `Option<Self>` に変更:

- 空 / whitespace-only 入力は `None` を返す。成功時は trim 済み値を保持
- `SlackClient::from_env` → `Redacted::new(&raw).ok_or(TokenNotSet)?` で 1 行に縮約
- `BraveClient::from_env_with` も同様
- `token_source::resolve_from_env_or_gh` の `map(trim).find(!empty)` を `find_map(|t| Redacted::new(&t))` に置換。gh CLI branch も明示 empty check 削除
- test 用 `with_base_url` / `StaticTokenSource(Some(...))` constructor は compile-time literal なので `.expect("static literal is non-empty")`

`Redacted` の新 test で empty / whitespace / trim の挙動を固定 (旧の per-callsite check が暗黙に依存していた部分)。

## テスト

- [x] `cargo test --offline` — 395 lib + 11 integration pass (T-RD002/3/4 が新規追加)
- [x] `cargo clippy --offline --all-targets` — warning なし

## 関連 PR (issue #104)

- PR-A: encapsulation (#135)
- PR-B: `PerPage` newtype (#136)
- PR-C (本 PR): `Redacted::new` fallible 化
- PR-D: `StdinResolver` enum 化