### PR TITLE
feat(fetch): DnsResolver trait を object-safe 化して Arc<dyn> で injectable に (issue #134)

### DIFF
--- a/docs/decisions/0008-trait-injection-and-scoutbuilder-for-test-seam.md
+++ b/docs/decisions/0008-trait-injection-and-scoutbuilder-for-test-seam.md
@@ -97,7 +97,7 @@ Skip `ScoutBuilder` entirely; add `#[cfg(test)] fn for_test()` and `#[cfg(test)]
 
 ### Deferred concerns
 
-- **`DnsResolver` `Arc<dyn ...>`-ification**: Issue #103 listed `dns: Arc<dyn DnsResolver>` as a proposed action, but the existing `DnsResolver` trait in `fetch/ssrf.rs` is generic-style (`fn lookup(&self, host: &str, port: u16) -> impl Future<Output = Result<Vec<IpAddr>, FetchError>> + Send`) with a `Clone + Send + Sync + 'static` bound. Object-safety requires changing the return type to `Pin<Box<...>>` and dropping `Clone`; the SSRF path's `Arc<TokioDnsResolver>` clone semantics need re-analysis. Captured as a separate issue rather than expanded into PR 4. The ScoutBuilder slot for it is already shaped by precedent.
+- **`DnsResolver` `Arc<dyn ...>`-ification**: Resolved by ADR-0009 (issue #134). The trait now returns `Pin<Box<dyn Future + Send + '_>>`, the `Clone` bound is dropped, and `Scout.dns: Arc<dyn DnsResolver>` is injected via `ScoutBuilder::with_dns`. See `docs/decisions/0009-object-safe-dns-resolver-and-arc-injection.md` for the full rationale.
 - **`with_brave` / `with_github`** that inject pre-built `BraveClient` / `GitHubClient` instances: not added. The `with_*_endpoint(&str)` setters cover every existing test case by re-using the builder's `http` client to construct the test double. If a future test needs a fully custom client (e.g. a recording proxy), the precedent is to add the setter then, not now.
 
 ### Reassessment Triggers

--- a/docs/decisions/0009-object-safe-dns-resolver-and-arc-injection.md
+++ b/docs/decisions/0009-object-safe-dns-resolver-and-arc-injection.md
@@ -1,0 +1,132 @@
+---
+status: "accepted"
+date: 2026-05-19
+decision-makers: thkt (project owner)
+---
+
+# Object-safe `DnsResolver` and `Arc<dyn DnsResolver>` injection via `ScoutBuilder`
+
+## Context and Problem Statement
+
+ADR-0008 unified test-seam injection across `Clock` / `Rng` / `TokenSource` through `Arc<dyn Trait>` fields on `Scout` and chainable `ScoutBuilder::for_test().with_*()` setters. The fourth proposed seam, `DnsResolver`, was left out and recorded under *Deferred concerns* because the existing trait shape required structural changes that did not fit inside the PR sequence #127–#132.
+
+Today the picture in `src/fetch/ssrf.rs` is:
+
+- `pub(crate) trait DnsResolver: Clone + Send + Sync + 'static { fn lookup(&self, ...) -> impl Future<Output = ...> + Send; }` — generic-style with a `Clone` bound, not object-safe.
+- `src/tools.rs::Scout::fetch` and `Scout::research` reach for `&TokioDnsResolver` literals; no `Scout.dns` slot exists.
+- `src/fetch.rs::fetch_with_cdp(..., resolver: impl ssrf::DnsResolver, ...)` consumes the resolver and re-clones it across a `tokio::spawn` boundary via `Clone::clone(resolver)` (`fetch.rs:146`), depending on the trait's `Clone` bound for the CDP intercept task.
+- `src/search/engine.rs` carries `&TokioDnsResolver` references into `engine::research` tests.
+
+Issue #134 asks for parity with ADR-0008 — object-safe trait, `Scout.dns: Arc<dyn DnsResolver>`, `ScoutBuilder::with_dns`, and a test double for resolution-strategy injection (private-IP fail-fast, NXDOMAIN, mixed results). Without injection, every SSRF-path test must either talk to a real DNS resolver or live with `TokioDnsResolver` and lose the ability to script outcomes.
+
+## Decision Drivers
+
+- `unsafe_code = "forbid"` prevents mocking DNS via `std::env::set_var` or `/etc/hosts` shims. Injection at the type level is the only sanctioned seam.
+- SSRF defense is a hard project constraint (`.claude/OUTCOME.md` Constraints: "全 fetch 経路で SSRF 防御を必須とする"). Any change must keep the contract that `fetch_page` / `engine::research` cannot reach private IPs.
+- `Arc<dyn DnsResolver>` requires object-safety: dropping `Clone` and replacing `impl Future` with `Pin<Box<dyn Future + Send + '_>>`. ADR-0008 already paid this cost for `TokenSource`; reusing the same pattern keeps the four traits visually uniform.
+- `fetch_with_cdp` spawns an intercept task that needs `resolver: Send + 'static`. The old `Clone + 'static` bound made an owned-clone trivial; with `Arc<dyn DnsResolver>` the clone is an `Arc::clone`, which is also cheap. The signature of internal helpers must allow this.
+- `ssrf_check` and `download` only read the resolver. Passing `Arc` everywhere would be over-budget; `&dyn DnsResolver` is enough for pure-read sites. The split (`Arc` at task-spawning sites, `&dyn` at pure-read sites) keeps overhead at one indirection per call without proliferating `Arc::clone`.
+- Tests must be able to inject `StaticDnsResolver(Vec<IpAddr>)` / `FailingDnsResolver(FetchError)` and prove the injected double was used by an end-to-end assertion, not just `Arc::ptr_eq`. ADR-0008's `T-SB004` is the precedent.
+
+## Considered Options
+
+- (Chosen) Object-safe `DnsResolver` with `Pin<Box<dyn Future + Send + '_>>` return, `Clone` bound removed. `Scout.dns: Arc<dyn DnsResolver>`, `ScoutBuilder::with_dns` setter. Internal helpers split: `Arc` at spawn sites, `&dyn` at pure-read sites.
+- Keep `DnsResolver` generic-style and pipe `TokioDnsResolver` through `Scout` as a plain field (no `dyn`). Inject via a generic `Scout<D: DnsResolver>` type parameter.
+- Skip injection. Mark `DnsResolver` as production-only and write SSRF-path tests against `TokioDnsResolver` + loopback / `example.com` fixtures.
+
+## Decision Outcome
+
+Chosen: object-safe `DnsResolver` trait with `Arc<dyn DnsResolver>` injection mirroring ADR-0008's `TokenSource` pattern.
+
+The trait becomes:
+
+```rust
+pub(crate) type DnsLookupFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<IpAddr>, FetchError>> + Send + 'a>>;
+
+pub(crate) trait DnsResolver: Send + Sync {
+    fn lookup(&self, host: &str, port: u16) -> DnsLookupFuture<'_>;
+}
+```
+
+`TokioDnsResolver` keeps the same async body but wraps it with `Box::pin(async move { ... })`. The test doubles `StaticDnsResolver(Vec<IpAddr>)` and `FailingDnsResolver(FetchError)` move into `#[cfg(test)]` inside `fetch/ssrf.rs` and replace the ad-hoc `AllowDns` / `FailDns` types in the same module.
+
+`Scout` gains `dns: Arc<dyn DnsResolver>`. `ScoutBuilder::for_test()` and `ScoutBuilder::from_env()` both default it to `Arc::new(TokioDnsResolver)` — production has only one implementation, so no env knob is added. `ScoutBuilder` exposes `#[cfg(test)] pub(crate) fn with_dns(self, dns: Arc<dyn DnsResolver>) -> Self`, matching the `#[cfg(test)] pub(crate)` visibility of `with_clock` / `with_rng` / `with_token_source` (`tools.rs:665-681`). The cfg gate prevents the injection surface from leaking into the production crate API.
+
+Internal helper signatures split by need:
+
+| Site | Old signature | New signature | Why |
+|---|---|---|---|
+| `ssrf_check` | `resolver: &impl DnsResolver` | `resolver: &dyn DnsResolver` | Pure read; one indirection acceptable |
+| `download` | `resolver: &impl DnsResolver` | `resolver: &dyn DnsResolver` | Pure read |
+| `check_browser_request` | `resolver: &impl ssrf::DnsResolver` | `resolver: &dyn ssrf::DnsResolver` | Pure read inside spawn body |
+| `fetch_page` | `resolver: &impl DnsResolver` | `resolver: Arc<dyn DnsResolver>` | Hands ownership to `fetch_with_cdp` via clone |
+| `fetch_with_cdp` | `resolver: impl ssrf::DnsResolver` (owned, `Clone` cloned) | `resolver: Arc<dyn ssrf::DnsResolver>` | Cloned across `tokio::spawn` move boundary |
+| `cdp_navigate` | `resolver: impl ssrf::DnsResolver` | `resolver: Arc<dyn ssrf::DnsResolver>` | Owned by spawned intercept task |
+| `engine::research` | `resolver: impl DnsResolver` | `resolver: Arc<dyn DnsResolver>` | Forwards into `fetch_page` |
+| `engine::fetch_one` | `resolver: &impl DnsResolver` | `resolver: &dyn DnsResolver` | Pure read in pre-fetch SSRF check |
+
+`Scout::fetch` and `Scout::research` pass `self.dns.clone()` (cheap `Arc::clone`) instead of `&TokioDnsResolver`.
+
+### Consequences
+
+- Good, because the four trait seams (`Clock` / `Rng` / `TokenSource` / `DnsResolver`) are now visually uniform: same `Arc<dyn Trait>` field, same `ScoutBuilder::with_*` setter, same `Pin<Box<dyn Future + Send + '_>>` future alias convention.
+- Good, because resolution-strategy scripting becomes a one-liner in tests: `ScoutBuilder::for_test().with_dns(Arc::new(StaticDnsResolver(vec![ip]))).build()` plugs the double into every fetch path without touching `tools.rs` internals.
+- Good, because `fetch_with_cdp` stops depending on the `Clone` bound — `Arc::clone` is the universal shared-ownership primitive across the rest of the codebase (ADR-0008 plumbing).
+- Bad, because `dyn` dispatch adds one indirection per `DnsResolver::lookup` call. DNS lookups are I/O-dominant (network round-trip in production, in-memory `Vec` lookup in tests), so the cost is negligible.
+- Bad, because the internal-helper signature split (`Arc` vs `&dyn`) is a judgment call that new contributors may not recognize. The rule is documented above and in the trait module's rustdoc.
+- Bad, because `Pin<Box<dyn Future + Send + '_>>` adds visual noise at every `DnsResolver::lookup` implementation. The `DnsLookupFuture<'a>` alias mitigates but does not erase the cost. Same trade-off ADR-0008 accepted for `TokenSource`.
+
+### Confirmation
+
+- `cargo test --offline` passes including the new injection e2e tests `T-DNS001` (private-IP block) and `T-DNS002` (resolver failure propagation).
+- `cargo test --offline --features js-rendering` also passes, exercising the `Arc<dyn DnsResolver>` flow through `fetch_with_cdp` / `cdp_navigate` / `check_browser_request`. The CDP path is gated behind the feature, so default-features builds do not surface its compile errors — verifying both is mandatory.
+- `cargo clippy --offline --all-targets` and `cargo clippy --offline --all-targets --features js-rendering` are clean (no `-D clippy::absolute-paths` violations from the new test paths).
+- `ScoutBuilder::for_test().with_dns(Arc::new(StaticDnsResolver(vec!["10.0.0.1".parse().unwrap()]))).build().fetch(FetchParams { url: Some("https://example.com".into()), .. }).await` returns a `ScoutError` mapped from `FetchError::InternalHost`. The injected resolver's `Ok(vec![10.0.0.1])` short-circuits inside `ssrf_check` before any HTTP connect, so the assertion holds independent of `fetch_timeout`.
+- `ugrep -rn 'Clone::clone\(resolver\)' src/` returns 0 hits.
+- ADR-0008 *Deferred concerns* now links to ADR-0009.
+
+## Pros and Cons of the Options
+
+### Object-safe `DnsResolver` + `Arc<dyn DnsResolver>` (chosen)
+
+`Scout` and internal helpers share one shape; tests inject through the same path that production uses.
+
+- Good, because seam uniformity with `Clock` / `Rng` / `TokenSource` lowers the cost of adding a fifth trait field later.
+- Good, because `Arc::ptr_eq` seam assertions become trivially writable (precedent: ADR-0008 `T-SB001`–`T-SB003`).
+- Bad, because the `Pin<Box<dyn Future>>` shape will look outdated once `async fn in dyn Trait` ships in stable Rust. Same reassessment trigger as ADR-0008.
+
+### Generic `Scout<D: DnsResolver>`
+
+Type parameter propagates through `Scout`'s methods; production is `Scout<TokioDnsResolver>`, tests pick a different type.
+
+- Good, because dispatch is fully static (zero-cost monomorphization).
+- Bad, because every caller of `Scout` (`lib::run`, integration tests, future subcommand modules) would have to either name `Scout<TokioDnsResolver>` or be generic itself. ADR-0008 rejected this path for the same reason and the rationale has not changed.
+- Bad, because mixing one generic parameter (`D`) with three `Arc<dyn Trait>` fields would make `Scout` look schizophrenic.
+
+### Skip injection
+
+Leave `DnsResolver` production-only; test SSRF paths against `TokioDnsResolver` and live hosts / loopback fixtures.
+
+- Good, because the diff is zero.
+- Bad, because resolution strategies like NXDOMAIN, partial-failure, or mixed public/private results cannot be scripted. Coverage of `ssrf_check`'s "any private IP in the address set" branch stays accidental.
+- Bad, because the deferred concern in ADR-0008 stays unresolved — the four-trait pattern remains a three-and-a-half-trait pattern.
+
+## More Information
+
+### Implementation order
+
+1. Rewrite `DnsResolver` to be object-safe; convert `TokioDnsResolver` and test doubles. Existing `ssrf::tests` and `dns_tests` modules compile against the new shape.
+2. Update internal helper signatures in `src/fetch.rs` and `src/search/engine.rs` per the table above. `fetch_with_cdp` switches from `Clone::clone(resolver)` to `Arc::clone(&resolver)`.
+3. Add `dns: Arc<dyn DnsResolver>` field to `Scout`; thread `Arc::new(TokioDnsResolver)` through `ScoutBuilder::{from_env, for_test, build_default_clients}`.
+4. Add `#[cfg(test)] fn with_dns(self, dns: Arc<dyn DnsResolver>) -> Self` to `ScoutBuilder`.
+5. Replace the two `&TokioDnsResolver` literals in `tools.rs::Scout::fetch` and `Scout::research` with `self.dns.clone()`.
+6. Add `StaticDnsResolver(Vec<IpAddr>)` and `FailingDnsResolver(FetchError)` under `#[cfg(test)]` in `fetch/ssrf.rs`; remove the now-redundant `AllowDns` / `FailDns` ad-hoc types and re-point existing T-FS004..T-FS007 tests.
+7. Add `T-DNS001` end-to-end test: `with_dns` + `Scout::fetch` → assert `FetchError::InternalHost` when the injected resolver returns a private IP.
+8. Update ADR-0008 *Deferred concerns* to link to ADR-0009.
+
+### Reassessment Triggers
+
+- `async fn in dyn Trait` becomes idiomatic in stable Rust without the `Send` auto-bound dance. At that point, simplify `DnsResolver::lookup` from `DnsLookupFuture<'_>` to a native `async fn` (same trigger ADR-0008 records for `TokenSource`).
+- A second SSRF strategy is added (e.g., per-request resolver override for proxy-aware fetches). Re-evaluate whether the single-`Arc<dyn DnsResolver>` slot is still enough or whether resolution should become per-request configuration.
+- `Scout` accumulates a fifth `Arc<dyn Trait>` field beyond `clock` / `rng` / `token_source` / `dns`. Reassess whether default-derived `ScoutBuilder` pays for itself (same trigger as ADR-0008).

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -7,11 +7,14 @@ mod extractor;
 mod ssrf;
 
 pub(crate) use ssrf::{DnsResolver, RedactedLogUrl, TokioDnsResolver};
+#[cfg(test)]
+pub(crate) use ssrf::{FailingDnsResolver, StaticDnsResolver};
 use ssrf::{ValidatedUrl, ssrf_check};
 
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 #[cfg(feature = "js-rendering")]
 use std::sync::OnceLock;
 #[cfg(feature = "js-rendering")]
@@ -101,7 +104,7 @@ pub(crate) async fn fetch_page(
     client: &Client,
     url: &str,
     opts: FetchOptions,
-    resolver: &impl DnsResolver,
+    resolver: Arc<dyn DnsResolver>,
     cancel: &watch::Sender<bool>,
 ) -> Result<FetchResult, FetchError> {
     // `cancel` is only consumed on the CDP path. Silence the unused-arg
@@ -123,12 +126,13 @@ pub(crate) async fn fetch_page(
     //
     // The returned `ValidatedUrl` is the only constructor for SSRF-checked URLs;
     // `download` requires `&ValidatedUrl` so the redirect loop cannot bypass it.
-    let validated = ssrf_check(url, resolver).await?;
+    let validated = ssrf_check(url, resolver.as_ref()).await?;
 
     #[cfg(feature = "js-rendering")]
-    let (final_url, mut html) = download(client, &validated, MAX_REDIRECTS, resolver).await?;
+    let (final_url, mut html) =
+        download(client, &validated, MAX_REDIRECTS, resolver.as_ref()).await?;
     #[cfg(not(feature = "js-rendering"))]
-    let (final_url, html) = download(client, &validated, MAX_REDIRECTS, resolver).await?;
+    let (final_url, html) = download(client, &validated, MAX_REDIRECTS, resolver.as_ref()).await?;
 
     let need_js = if opts.js {
         info!("--js flag set, requesting JS rendering");
@@ -143,7 +147,7 @@ pub(crate) async fn fetch_page(
     if need_js {
         #[cfg(feature = "js-rendering")]
         {
-            match fetch_with_cdp(&final_url, Clone::clone(resolver), cancel).await {
+            match fetch_with_cdp(&final_url, Arc::clone(&resolver), cancel).await {
                 Ok(js_html) => {
                     debug!("JS rendering succeeded via CDP");
                     html = js_html;
@@ -174,7 +178,7 @@ pub(crate) async fn fetch_page(
     #[cfg(feature = "js-rendering")]
     let article = if need_thin_fallback {
         warn!(url = %RedactedLogUrl(final_url.as_str()), "extraction yielded too little content, trying JS rendering fallback");
-        match fetch_with_cdp(&final_url, Clone::clone(resolver), cancel).await {
+        match fetch_with_cdp(&final_url, Arc::clone(&resolver), cancel).await {
             Ok(js_html) => {
                 let re_extracted = extract_article(&js_html, Some(final_url.as_str()));
                 if is_thin_extract(&re_extracted) {
@@ -420,7 +424,7 @@ fn build_launch_args() -> Vec<&'static str> {
 ///
 /// See ADR-0001 for the SSRF defense architecture.
 #[cfg_attr(not(feature = "js-rendering"), allow(dead_code))]
-pub(crate) async fn check_browser_request(url: &str, resolver: &impl ssrf::DnsResolver) -> bool {
+pub(crate) async fn check_browser_request(url: &str, resolver: &dyn ssrf::DnsResolver) -> bool {
     let check_url = if url.starts_with("http://") || url.starts_with("https://") {
         Cow::Borrowed(url)
     } else if let Some(rest) = url.strip_prefix("ws://") {
@@ -452,7 +456,7 @@ const PGROUP_SIGTERM_GRACE: Duration = Duration::from_millis(50);
 #[cfg(feature = "js-rendering")]
 async fn fetch_with_cdp(
     url: &ValidatedUrl,
-    resolver: impl ssrf::DnsResolver,
+    resolver: Arc<dyn ssrf::DnsResolver>,
     cancel: &watch::Sender<bool>,
 ) -> Result<String, BrowserError> {
     use chromiumoxide::Browser;
@@ -644,7 +648,7 @@ async fn reap_pgroup(pgid: Pid, child: &mut TokioChild) {
 async fn cdp_navigate(
     browser: &mut chromiumoxide::Browser,
     url: &ValidatedUrl,
-    resolver: impl ssrf::DnsResolver,
+    resolver: Arc<dyn ssrf::DnsResolver>,
 ) -> Result<String, BrowserError> {
     use chromiumoxide::cdp::browser_protocol::fetch::{
         ContinueRequestParams, EnableParams, EventRequestPaused, FailRequestParams,
@@ -673,7 +677,7 @@ async fn cdp_navigate(
         let mut intercept_err_tx = Some(intercept_err_tx);
         while let Some(event) = events.next().await {
             let req_url = &event.request.url;
-            let allowed = check_browser_request(req_url, &resolver).await;
+            let allowed = check_browser_request(req_url, resolver.as_ref()).await;
             let exec_result: Result<(), CdpError> = if allowed {
                 intercept_page
                     .execute(ContinueRequestParams::new(event.request_id.clone()))
@@ -766,7 +770,7 @@ async fn download(
     client: &Client,
     url: &ValidatedUrl,
     max_redirects: usize,
-    resolver: &impl DnsResolver,
+    resolver: &dyn DnsResolver,
 ) -> Result<(ValidatedUrl, String), FetchError> {
     let mut current_url = url.clone();
 
@@ -988,7 +992,6 @@ mod download_tests {
     use super::*;
     use crate::test_support::try_spawn_mock_server;
     use reqwest::redirect::Policy;
-    use std::net::IpAddr;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
@@ -1000,12 +1003,8 @@ mod download_tests {
         ValidatedUrl::for_test(url)
     }
 
-    #[derive(Clone, Copy)]
-    struct PublicResolver;
-    impl DnsResolver for PublicResolver {
-        async fn lookup(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, FetchError> {
-            Ok(vec!["8.8.8.8".parse().unwrap()])
-        }
+    fn public_resolver() -> ssrf::StaticDnsResolver {
+        ssrf::StaticDnsResolver::single("8.8.8.8")
     }
 
     /// [T-F009] download_success_returns_html
@@ -1028,7 +1027,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/page", server.uri())),
             MAX_REDIRECTS,
-            &PublicResolver,
+            &public_resolver(),
         )
         .await
         .unwrap();
@@ -1060,7 +1059,7 @@ mod download_tests {
                 &client,
                 &validated(&format!("{}/404", server.uri())),
                 MAX_REDIRECTS,
-                &PublicResolver
+                &public_resolver()
             )
             .await,
             Err(FetchError::Status(404))
@@ -1070,7 +1069,7 @@ mod download_tests {
                 &client,
                 &validated(&format!("{}/500", server.uri())),
                 MAX_REDIRECTS,
-                &PublicResolver
+                &public_resolver()
             )
             .await,
             Err(FetchError::Status(500))
@@ -1095,7 +1094,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/huge", server.uri())),
             MAX_REDIRECTS,
-            &PublicResolver,
+            &public_resolver(),
         )
         .await;
         assert!(matches!(result, Err(FetchError::TooLarge)));
@@ -1122,7 +1121,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/binary", server.uri())),
             MAX_REDIRECTS,
-            &PublicResolver,
+            &public_resolver(),
         )
         .await;
         assert!(
@@ -1150,7 +1149,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/redir", server.uri())),
             MAX_REDIRECTS,
-            &PublicResolver,
+            &public_resolver(),
         )
         .await;
         assert!(
@@ -1162,13 +1161,7 @@ mod download_tests {
     /// [T-F014] redirect_to_dns_private_ip_blocked
     #[tokio::test]
     async fn redirect_to_dns_private_ip_blocked() {
-        #[derive(Clone, Copy)]
-        struct PrivateResolver;
-        impl DnsResolver for PrivateResolver {
-            async fn lookup(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, FetchError> {
-                Ok(vec!["10.0.0.1".parse().unwrap()])
-            }
-        }
+        let private_resolver = ssrf::StaticDnsResolver::single("10.0.0.1");
 
         let Some(server) = try_spawn_mock_server("fetch::download").await else {
             return;
@@ -1186,7 +1179,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/redir", server.uri())),
             MAX_REDIRECTS,
-            &PrivateResolver,
+            &private_resolver,
         )
         .await;
         assert!(
@@ -1214,7 +1207,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/redir", server.uri())),
             0, // max_redirects = 0
-            &PublicResolver,
+            &public_resolver(),
         )
         .await;
         assert!(
@@ -1240,7 +1233,7 @@ mod download_tests {
             &client,
             &validated(&format!("{}/bad-redir", server.uri())),
             MAX_REDIRECTS,
-            &PublicResolver,
+            &public_resolver(),
         )
         .await;
         assert!(
@@ -1262,6 +1255,10 @@ mod fetch_page_tests {
         Client::builder().redirect(Policy::none()).build().unwrap()
     }
 
+    fn real_resolver() -> Arc<dyn DnsResolver> {
+        Arc::new(TokioDnsResolver)
+    }
+
     /// [T-F017] blocks_ssrf_to_localhost
     #[tokio::test]
     async fn blocks_ssrf_to_localhost() {
@@ -1271,7 +1268,7 @@ mod fetch_page_tests {
             &client,
             "http://127.0.0.1/secret",
             FetchOptions::default(),
-            &TokioDnsResolver,
+            real_resolver(),
             &cancel,
         )
         .await;
@@ -1292,7 +1289,7 @@ mod fetch_page_tests {
             &client,
             "http://user:supersecret@127.0.0.1/private",
             FetchOptions::default(),
-            &TokioDnsResolver,
+            real_resolver(),
             &cancel,
         )
         .await;
@@ -1342,7 +1339,7 @@ mod fetch_page_tests {
             &client,
             &format!("{}/rich", server.uri()),
             opts,
-            &TokioDnsResolver,
+            real_resolver(),
             &cancel,
         )
         .await;
@@ -1367,7 +1364,7 @@ mod fetch_page_tests {
             &client,
             "https://example.com/page",
             opts,
-            &TokioDnsResolver,
+            real_resolver(),
             &cancel,
         )
         .await;
@@ -1614,30 +1611,21 @@ mod cdp_launch_tests {
 
 #[cfg(test)]
 mod browser_request_tests {
-    use super::ssrf::DnsResolver;
+    use super::ssrf::StaticDnsResolver;
     use super::*;
-    use std::net::IpAddr;
 
-    #[derive(Clone, Copy)]
-    struct MockPrivateDns;
-    impl DnsResolver for MockPrivateDns {
-        async fn lookup(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, FetchError> {
-            Ok(vec!["10.0.0.1".parse().unwrap()])
-        }
+    fn private_dns() -> StaticDnsResolver {
+        StaticDnsResolver::single("10.0.0.1")
     }
 
-    #[derive(Clone, Copy)]
-    struct MockPublicDns;
-    impl DnsResolver for MockPublicDns {
-        async fn lookup(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, FetchError> {
-            Ok(vec!["93.184.216.34".parse().unwrap()])
-        }
+    fn public_dns() -> StaticDnsResolver {
+        StaticDnsResolver::single("93.184.216.34")
     }
 
     /// [T-F044] t004_blocks_dns_resolving_to_private_ip
     #[tokio::test]
     async fn t004_blocks_dns_resolving_to_private_ip() {
-        let resolver = MockPrivateDns;
+        let resolver = private_dns();
         assert!(
             !check_browser_request("https://evil.example/secret", &resolver).await,
             "must block when DNS resolves to private IP"
@@ -1647,7 +1635,7 @@ mod browser_request_tests {
     /// [T-F045] t004_blocks_internal_ip_literal
     #[tokio::test]
     async fn t004_blocks_internal_ip_literal() {
-        let resolver = MockPublicDns;
+        let resolver = public_dns();
         assert!(
             !check_browser_request("http://127.0.0.1/secret", &resolver).await,
             "must block loopback IP"
@@ -1657,7 +1645,7 @@ mod browser_request_tests {
     /// [T-F046] t004_allows_public_url
     #[tokio::test]
     async fn t004_allows_public_url() {
-        let resolver = MockPublicDns;
+        let resolver = public_dns();
         assert!(
             check_browser_request("https://example.com/page", &resolver).await,
             "must allow public URL"
@@ -1667,7 +1655,7 @@ mod browser_request_tests {
     /// [T-F047] t004_allows_non_network_urls
     #[tokio::test]
     async fn t004_allows_non_network_urls() {
-        let resolver = MockPublicDns;
+        let resolver = public_dns();
         for url in [
             "data:text/html,<p>test</p>",
             "about:blank",
@@ -1684,7 +1672,7 @@ mod browser_request_tests {
     /// [T-F048] t004_blocks_unknown_schemes
     #[tokio::test]
     async fn t004_blocks_unknown_schemes() {
-        let resolver = MockPublicDns;
+        let resolver = public_dns();
         for url in ["file:///etc/passwd", "ftp://internal/data", "gopher://x"] {
             assert!(
                 !check_browser_request(url, &resolver).await,
@@ -1696,7 +1684,7 @@ mod browser_request_tests {
     /// [T-F049] t004_blocks_websocket_to_internal
     #[tokio::test]
     async fn t004_blocks_websocket_to_internal() {
-        let resolver = MockPublicDns;
+        let resolver = public_dns();
         assert!(
             !check_browser_request("ws://127.0.0.1:8080/ws", &resolver).await,
             "must block ws:// to loopback"
@@ -1710,7 +1698,7 @@ mod browser_request_tests {
     /// [T-F050] t004_blocks_websocket_dns_to_private
     #[tokio::test]
     async fn t004_blocks_websocket_dns_to_private() {
-        let resolver = MockPrivateDns;
+        let resolver = private_dns();
         assert!(
             !check_browser_request("ws://evil.example/ws", &resolver).await,
             "must block ws:// when DNS resolves to private IP"
@@ -1798,7 +1786,7 @@ mod cdp_integration_tests {
         let (cancel, _) = watch::channel(false);
         let html = fetch_with_cdp(
             &ValidatedUrl::for_test("https://example.com"),
-            TokioDnsResolver,
+            Arc::new(TokioDnsResolver),
             &cancel,
         )
         .await

--- a/src/fetch/ssrf.rs
+++ b/src/fetch/ssrf.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::pin::Pin;
 use std::time::Duration;
 
 use tokio::net::lookup_host;
@@ -14,24 +15,29 @@ use super::FetchError;
 
 const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub(crate) trait DnsResolver: Clone + Send + Sync + 'static {
-    fn lookup(
-        &self,
-        host: &str,
-        port: u16,
-    ) -> impl Future<Output = Result<Vec<IpAddr>, FetchError>> + Send;
+/// Object-safe boxed future returned by [`DnsResolver::lookup`].
+pub(crate) type DnsLookupFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<IpAddr>, FetchError>> + Send + 'a>>;
+
+/// Resolves a host to one or more IP addresses. `Send + Sync` so implementations
+/// can sit behind an `Arc<dyn DnsResolver>` shared across async tasks.
+pub(crate) trait DnsResolver: Send + Sync {
+    fn lookup(&self, host: &str, port: u16) -> DnsLookupFuture<'_>;
 }
 
-#[derive(Clone, Copy)]
+/// Production resolver: `tokio::net::lookup_host` with a 5s timeout.
 pub(crate) struct TokioDnsResolver;
 
 impl DnsResolver for TokioDnsResolver {
-    async fn lookup(&self, host: &str, port: u16) -> Result<Vec<IpAddr>, FetchError> {
-        let addrs = timeout(DNS_LOOKUP_TIMEOUT, lookup_host(format!("{host}:{port}")))
-            .await
-            .map_err(|_| FetchError::DnsResolution("DNS lookup timed out".to_owned()))?
-            .map_err(|e| FetchError::DnsResolution(e.to_string()))?;
-        Ok(addrs.map(|a| a.ip()).collect())
+    fn lookup(&self, host: &str, port: u16) -> DnsLookupFuture<'_> {
+        let target = format!("{host}:{port}");
+        Box::pin(async move {
+            let addrs = timeout(DNS_LOOKUP_TIMEOUT, lookup_host(target))
+                .await
+                .map_err(|_| FetchError::DnsResolution("DNS lookup timed out".to_owned()))?
+                .map_err(|e| FetchError::DnsResolution(e.to_string()))?;
+            Ok(addrs.map(|a| a.ip()).collect())
+        })
     }
 }
 
@@ -92,7 +98,7 @@ impl fmt::Display for ValidatedUrl {
 
 pub(crate) async fn ssrf_check(
     raw: &str,
-    resolver: &impl DnsResolver,
+    resolver: &dyn DnsResolver,
 ) -> Result<ValidatedUrl, FetchError> {
     let parsed = validate_url_sync(raw).map_err(|e| {
         if matches!(e, FetchError::InternalHost) {
@@ -241,32 +247,46 @@ mod tests {
     }
 }
 
+/// Resolver test double returning a fixed IP list.
+#[cfg(test)]
+pub(crate) struct StaticDnsResolver(pub Vec<IpAddr>);
+
+#[cfg(test)]
+impl StaticDnsResolver {
+    /// Construct from a single IP literal. Panics if `ip` is not a valid `IpAddr`.
+    pub(crate) fn single(ip: &str) -> Self {
+        Self(vec![ip.parse().expect("test IP must parse")])
+    }
+}
+
+#[cfg(test)]
+impl DnsResolver for StaticDnsResolver {
+    fn lookup(&self, _host: &str, _port: u16) -> DnsLookupFuture<'_> {
+        let addrs = self.0.clone();
+        Box::pin(async move { Ok(addrs) })
+    }
+}
+
+/// Resolver test double that always fails with the given message.
+#[cfg(test)]
+pub(crate) struct FailingDnsResolver(pub String);
+
+#[cfg(test)]
+impl DnsResolver for FailingDnsResolver {
+    fn lookup(&self, _host: &str, _port: u16) -> DnsLookupFuture<'_> {
+        let message = self.0.clone();
+        Box::pin(async move { Err(FetchError::DnsResolution(message)) })
+    }
+}
+
 #[cfg(test)]
 mod dns_tests {
     use super::*;
 
-    #[derive(Clone)]
-    struct AllowDns(Vec<IpAddr>);
-
-    impl DnsResolver for AllowDns {
-        async fn lookup(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, FetchError> {
-            Ok(self.0.clone())
-        }
-    }
-
-    #[derive(Clone)]
-    struct FailDns(String);
-
-    impl DnsResolver for FailDns {
-        async fn lookup(&self, _host: &str, _port: u16) -> Result<Vec<IpAddr>, FetchError> {
-            Err(FetchError::DnsResolution(self.0.clone()))
-        }
-    }
-
     /// [T-FS004] ssrf_blocks_dns_resolving_to_private_ip
     #[tokio::test]
     async fn ssrf_blocks_dns_resolving_to_private_ip() {
-        let resolver = AllowDns(vec!["127.0.0.1".parse().unwrap()]);
+        let resolver = StaticDnsResolver::single("127.0.0.1");
         let result = ssrf_check("https://evil.com/secret", &resolver).await;
         assert!(matches!(result, Err(FetchError::InternalHost)));
     }
@@ -274,7 +294,7 @@ mod dns_tests {
     /// [T-FS005] ssrf_allows_dns_resolving_to_public_ip
     #[tokio::test]
     async fn ssrf_allows_dns_resolving_to_public_ip() {
-        let resolver = AllowDns(vec!["8.8.8.8".parse().unwrap()]);
+        let resolver = StaticDnsResolver::single("8.8.8.8");
         let result = ssrf_check("https://example.com/page", &resolver).await;
         assert!(result.is_ok());
     }
@@ -282,7 +302,7 @@ mod dns_tests {
     /// [T-FS006] ssrf_returns_error_on_dns_failure
     #[tokio::test]
     async fn ssrf_returns_error_on_dns_failure() {
-        let resolver = FailDns("lookup failed".into());
+        let resolver = FailingDnsResolver("lookup failed".into());
         let result = ssrf_check("https://example.com/page", &resolver).await;
         assert!(matches!(result, Err(FetchError::DnsResolution(_))));
     }
@@ -290,7 +310,7 @@ mod dns_tests {
     /// [T-FS007] ssrf_skips_dns_for_ip_literals
     #[tokio::test]
     async fn ssrf_skips_dns_for_ip_literals() {
-        let resolver = AllowDns(vec![]);
+        let resolver = StaticDnsResolver(vec![]);
         let result = ssrf_check("https://8.8.8.8/page", &resolver).await;
         assert!(result.is_ok());
     }

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
@@ -45,7 +46,7 @@ pub(crate) async fn research(
     brave: &impl SearchClient,
     http: &Client,
     req: &ResearchRequest<'_>,
-    resolver: &impl DnsResolver,
+    resolver: Arc<dyn DnsResolver>,
     cancel: &watch::Sender<bool>,
 ) -> Result<ResearchReport, BraveError> {
     let search_lang = req.lang.to_brave_param();
@@ -65,25 +66,28 @@ async fn fetch_sources(
     http: &Client,
     sources: &[SearchResult],
     depth: usize,
-    resolver: &impl DnsResolver,
+    resolver: Arc<dyn DnsResolver>,
     cancel: &watch::Sender<bool>,
 ) -> (Vec<FetchResult>, Vec<FailedUrl>) {
     let fetch_outcomes: Vec<_> = stream::iter(sources.iter().take(depth).enumerate())
-        .map(|(idx, source)| async move {
-            let url = source.url.as_str();
-            let result = timeout(
-                FETCH_TIMEOUT,
-                fetch::fetch_page(http, url, fetch::FetchOptions::default(), resolver, cancel),
-            )
-            .await;
-            let result = match result {
-                Ok(inner) => inner,
-                Err(_) => Err(fetch::FetchError::Timeout(format!(
-                    "page fetch timed out after {}s",
-                    FETCH_TIMEOUT.as_secs()
-                ))),
-            };
-            (idx, url, result)
+        .map(|(idx, source)| {
+            let resolver = Arc::clone(&resolver);
+            async move {
+                let url = source.url.as_str();
+                let result = timeout(
+                    FETCH_TIMEOUT,
+                    fetch::fetch_page(http, url, fetch::FetchOptions::default(), resolver, cancel),
+                )
+                .await;
+                let result = match result {
+                    Ok(inner) => inner,
+                    Err(_) => Err(fetch::FetchError::Timeout(format!(
+                        "page fetch timed out after {}s",
+                        FETCH_TIMEOUT.as_secs()
+                    ))),
+                };
+                (idx, url, result)
+            }
         })
         // Concurrency cap = 5: balances fetch parallelism (faster overall research)
         // against per-host rate limits (multiple URLs in one query may share an origin).
@@ -179,6 +183,10 @@ mod tests {
     use super::*;
     use std::collections::VecDeque;
     use std::sync::Mutex;
+
+    fn real_resolver() -> Arc<dyn DnsResolver> {
+        Arc::new(fetch::TokioDnsResolver)
+    }
 
     struct MockSearch {
         responses: Mutex<VecDeque<Result<Vec<SearchResult>, BraveError>>>,
@@ -337,7 +345,7 @@ mod tests {
     async fn research_with_mock_returns_report() {
         let mock = MockSearch::with_results(vec![make_source("https://a.com", "A")]);
         let http = Client::new();
-        let resolver = fetch::TokioDnsResolver;
+        let resolver = real_resolver();
 
         let req = ResearchRequest {
             query: "test",
@@ -345,7 +353,7 @@ mod tests {
             lang: Lang::En,
         };
         let (cancel, _) = watch::channel(false);
-        let report = research(&mock, &http, &req, &resolver, &cancel)
+        let report = research(&mock, &http, &req, resolver, &cancel)
             .await
             .unwrap();
 
@@ -370,7 +378,7 @@ mod tests {
     async fn research_auto_lang_issues_single_call() {
         let mock = MockSearch::with_results(vec![make_source("https://a.com", "A")]);
         let http = Client::new();
-        let resolver = fetch::TokioDnsResolver;
+        let resolver = real_resolver();
 
         let req = ResearchRequest {
             query: "型安全 TypeScript",
@@ -378,7 +386,7 @@ mod tests {
             lang: Lang::Auto,
         };
         let (cancel, _) = watch::channel(false);
-        let _ = research(&mock, &http, &req, &resolver, &cancel)
+        let _ = research(&mock, &http, &req, resolver, &cancel)
             .await
             .unwrap();
 
@@ -400,7 +408,7 @@ mod tests {
     async fn research_search_failure_returns_error() {
         let mock = MockSearch::all_fail(BraveError::RateLimited { retry_after: None });
         let http = Client::new();
-        let resolver = fetch::TokioDnsResolver;
+        let resolver = real_resolver();
 
         let req = ResearchRequest {
             query: "test",
@@ -408,7 +416,7 @@ mod tests {
             lang: Lang::En,
         };
         let (cancel, _) = watch::channel(false);
-        let err = research(&mock, &http, &req, &resolver, &cancel)
+        let err = research(&mock, &http, &req, resolver, &cancel)
             .await
             .unwrap_err();
         assert!(matches!(err, BraveError::RateLimited { .. }));

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -29,7 +29,9 @@ use crate::brave::client::{BraveClient, BraveError, SearchClient as _};
 use crate::clock::{Clock, SystemClock};
 use crate::envelope::{CommandOutput, Degradation, DegradedReason};
 use crate::fetch::converter::{FetchResult, RAW_FALLBACK_NOTE};
-use crate::fetch::{FetchError, FetchOptions, RedactedLogUrl, TokioDnsResolver, fetch_page};
+use crate::fetch::{
+    DnsResolver, FetchError, FetchOptions, RedactedLogUrl, TokioDnsResolver, fetch_page,
+};
 use crate::github::types::ContentsResponse;
 use crate::github::{self, GitHubClient, PerPage};
 use crate::markdown::{shift_headings, truncate_with_note};
@@ -164,6 +166,10 @@ pub struct Scout {
     /// Held on `Scout` so tests can swap in a `StaticTokenSource` before any
     /// API call spawns the production `gh auth token` subprocess.
     token_source: Arc<dyn TokenSource>,
+    /// DNS resolver consulted by the SSRF pre-check on every fetch. Held on
+    /// `Scout` so tests can swap a scripted resolver before any real DNS
+    /// lookup runs.
+    dns: Arc<dyn DnsResolver>,
 }
 
 impl Scout {
@@ -258,13 +264,7 @@ impl Scout {
         let fetch_timeout = self.config.fetch_timeout;
         let result = timeout(
             fetch_timeout,
-            fetch_page(
-                &self.fetch_http,
-                &url,
-                opts,
-                &TokioDnsResolver,
-                &self.cancel,
-            ),
+            fetch_page(&self.fetch_http, &url, opts, self.dns.clone(), &self.cancel),
         )
         .await
         .unwrap_or_else(|_| {
@@ -338,7 +338,7 @@ impl Scout {
                 brave,
                 &self.fetch_http,
                 &req,
-                &TokioDnsResolver,
+                self.dns.clone(),
                 &self.cancel,
             ),
         )
@@ -589,6 +589,7 @@ pub(crate) struct ScoutBuilder {
     clock: Arc<dyn Clock>,
     rng: Arc<dyn Rng>,
     token_source: Arc<dyn TokenSource>,
+    dns: Arc<dyn DnsResolver>,
     cancel: watch::Sender<bool>,
     config: RuntimeConfig,
     /// Pre-initialize `Scout.github` (`OnceCell`) with a test client pointed at
@@ -634,6 +635,7 @@ impl ScoutBuilder {
             clock: Arc::new(SystemClock),
             rng: Arc::new(FastrandRng),
             token_source: Arc::new(GhCliSource),
+            dns: Arc::new(TokioDnsResolver),
             cancel: watch::channel(false).0,
             config,
             #[cfg(test)]
@@ -656,6 +658,7 @@ impl ScoutBuilder {
             clock: Arc::new(SystemClock),
             rng: Arc::new(FastrandRng),
             token_source: Arc::new(GhCliSource),
+            dns: Arc::new(TokioDnsResolver),
             cancel: watch::channel(false).0,
             config: RuntimeConfig::default(),
             github_endpoint: None,
@@ -677,6 +680,12 @@ impl ScoutBuilder {
     #[cfg(test)]
     pub(crate) fn with_token_source(mut self, source: Arc<dyn TokenSource>) -> Self {
         self.token_source = source;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_dns(mut self, dns: Arc<dyn DnsResolver>) -> Self {
+        self.dns = dns;
         self
     }
 
@@ -717,6 +726,7 @@ impl ScoutBuilder {
             clock: self.clock,
             rng: self.rng,
             token_source: self.token_source,
+            dns: self.dns,
         }
     }
 }
@@ -863,6 +873,8 @@ fn format_fetch_output(result: &FetchResult) -> String {
 mod tests {
     use super::*;
     use crate::clock::FixedClock;
+    use crate::envelope::ErrorCode;
+    use crate::fetch::{FailingDnsResolver, StaticDnsResolver};
     use crate::rng::SeededRng;
     use crate::search::Lang;
     use crate::test_support::try_spawn_mock_server;
@@ -1775,6 +1787,69 @@ mod tests {
         assert!(
             Arc::ptr_eq(&scout.token_source, &injected),
             "with_token_source must install the supplied Arc into Scout.token_source"
+        );
+    }
+
+    /// [T-DNS001] `ScoutBuilder::with_dns` で渡した `Arc<dyn DnsResolver>` が
+    /// `Scout.dns` slot に届き、かつ `Scout::fetch` の SSRF 経路で実際に
+    /// consult されることを end-to-end で確認する。
+    ///
+    /// 注入した `StaticDnsResolver(10.0.0.1)` が `https://example.com` の
+    /// DNS lookup を override すれば、`ssrf_check` の private-IP 判定が
+    /// `FetchError::InternalHost` を即座に返す。default の `TokioDnsResolver`
+    /// なら `example.com` は public IP を返すため、この assert は
+    /// injection が wire できていない場合に必ず落ちる。
+    #[tokio::test]
+    async fn scout_builder_with_dns_blocks_fetch_via_injected_private_ip() {
+        let injected: Arc<dyn DnsResolver> = Arc::new(StaticDnsResolver::single("10.0.0.1"));
+        let scout = ScoutBuilder::for_test().with_dns(injected.clone()).build();
+
+        assert!(
+            Arc::ptr_eq(&scout.dns, &injected),
+            "with_dns must install the supplied Arc into Scout.dns"
+        );
+
+        let result = scout
+            .fetch(FetchParams {
+                url: Some("https://example.com/page".into()),
+                js: false,
+                raw: false,
+            })
+            .await;
+        let err = result.expect_err("injected private IP must trip SSRF check");
+        assert_eq!(
+            err.error_kind(),
+            ErrorCode::DataError,
+            "SSRF InternalHost maps to DataError (sysexits EX_DATAERR)"
+        );
+        assert!(
+            err.message().contains("internal/private"),
+            "error message must surface the SSRF cause, got: {}",
+            err.message()
+        );
+    }
+
+    /// [T-DNS002] `FailingDnsResolver` を inject すると `Scout::fetch` が
+    /// `FetchError::DnsResolution` 由来の `ScoutError` を返すことを確認する。
+    /// resolver の失敗パスが SSRF 経路に正しく伝播することを保証する。
+    #[tokio::test]
+    async fn scout_builder_with_dns_propagates_resolver_failure() {
+        let injected: Arc<dyn DnsResolver> =
+            Arc::new(FailingDnsResolver("simulated DNS failure".into()));
+        let scout = ScoutBuilder::for_test().with_dns(injected).build();
+
+        let result = scout
+            .fetch(FetchParams {
+                url: Some("https://example.com/page".into()),
+                js: false,
+                raw: false,
+            })
+            .await;
+        let err = result.expect_err("injected resolver failure must surface as error");
+        assert!(
+            err.message().contains("DNS resolution failed"),
+            "error message must surface the DNS failure cause, got: {}",
+            err.message()
         );
     }
 


### PR DESCRIPTION
Closes #134

## 概要

`DnsResolver` trait を object-safe 化し、`Pin<Box<dyn Future>>` return type で `Arc<dyn DnsResolver>` を `ScoutBuilder` 経由で inject できるように変更。ADR-0008 で確立された `Clock`/`Rng`/`TokenSource` の trait injection pattern を踏襲。

[ADR-0009](docs/decisions/0009-object-safe-dns-resolver-and-arc-injection.md) として design 判断を文書化。

## 変更内容

- `src/fetch/ssrf.rs`: `DnsResolver` trait を object-safe 化 (`Clone` bound 削除、`DnsLookupFuture` alias 追加)、test double `StaticDnsResolver`/`FailingDnsResolver` を `#[cfg(test)]` で追加
- `src/fetch.rs`: spawn site は `Arc<dyn DnsResolver>` 所有、pure-read site は `&dyn DnsResolver` 借用に統一
- `src/search/engine.rs`: `research`/`fetch_sources` で `Arc::clone(&resolver)` を per-stream-item に
- `src/tools.rs`: `Scout.dns: Arc<dyn DnsResolver>` field 追加、`ScoutBuilder::with_dns` を `#[cfg(test)] pub(crate)` で expose
- `docs/decisions/0009-*.md`: 新規 ADR
- `docs/decisions/0008-*.md`: deferred concerns から ADR-0009 へリンク

## テスト

- [x] `cargo test --offline` — 400 lib + 11 integration pass
- [x] `cargo test --offline --features js-rendering` — 405 lib + 11 integration pass
- [x] `cargo clippy --offline --all-targets` — warning なし
- [x] T-DNS001: injected resolver が private IP を返すと SSRF block で reject
- [x] T-DNS002: resolver failure が caller まで propagate