### PR TITLE
監査由来で ADR-0010 (envelope contract) 起票と ADR-0004 拡張

### DIFF
--- a/docs/audit/2026-05-19-undocumented-decisions.md
+++ b/docs/audit/2026-05-19-undocumented-decisions.md
@@ -1,0 +1,220 @@
+# Undocumented Decisions Audit: 2026-05-19
+
+`/audit-undocumented` 4th run. 過去 audit (`2026-05-13-undocumented-decisions.md` Part 1+2, `2026-05-13-adr-drift.md`, `2026-05-14-adr-drift.md`) でカバー済みの decision を除外し、**新規大型ファイル**と**大幅増加ファイル**に scope を絞った。Part 1/Part 2 で抽出済 + ADR-0001〜0009 に統合済の decision は重複検出を避けた。
+
+## Summary
+
+| Metric                                   | Value |
+| ---------------------------------------- | ----- |
+| Large files (>400 lines) detected        | 12    |
+| Large files scanned (post-triage)        | 5     |
+| Large files skipped (Part 1/2 covered)   | 7 (tools.rs, fetch.rs, slack.rs, github/format.rs, github/encoding.rs, github/helpers.rs, search/engine.rs) |
+| Documents scanned                        | 4 (README.md, README.ja.md, Cargo.toml, deny.toml) |
+| Decision candidates (post-exclusion)     | 32    |
+| ADR-covered (excluded by reviewer in-flight) | reviewer-rust prompt で ADR-0003/0004/0005/0006/0007/0008/0009 範囲を事前除外指示 (件数は reviewer 内で吸収、未集計) |
+| ADR promotion candidates (initial)       | 4 (A, B, C, D)  |
+| Post-challenge: keep                     | 1 (A → new ADR-0010) |
+| Post-challenge: downgrade                | 1 (C → ADR-0004 extension) |
+| Post-challenge: drop                     | 2 (B, D → inline comment) |
+| ADR drift findings                       | 1 (ADR-0003 8→9 variants) |
+| Bug fix follow-ups                       | 3 (`TooLarge` hint, `TooManyRedirects` classification, 401 fallthrough) |
+
+### Scope decision
+
+- 7 files skipped per user triage (Part 1/2 differential too small to warrant re-scan):
+  - `tools.rs` (1898, +488): Part 1 で 10 candidates 抽出済、ADR-0001 で構造判断 covered
+  - `fetch.rs` (1807, +351): Part 1 で 14 candidates 抽出済、SSRF/CDP/js-rendering は ADR-0001
+  - `slack.rs` (1063, +93), `github/format.rs` (860, ±0): Part 2 covered
+  - `github/encoding.rs` (470), `github/helpers.rs` (506), `search/engine.rs` (450): Part 2 covered
+
+- 5 files scanned (focus = post-Part2 PR 追加部分 + 新規大型):
+  - **envelope.rs** (531, new): JSON envelope = ADR-0065 territory with no scout-local ADR yet
+  - **tools/errors.rs** (890, +279): PR #94 で ErrorCode 5→9 variant 拡張後
+  - **retry.rs** (484, new): ADR-0006/0008 partial
+  - **brave/client.rs** (566, new): ADR-0005/0007 partial
+  - **github.rs** (766, +236): ADR-0004 covers 3 Rules
+
+## Large File Decisions
+
+### src/envelope.rs (531 lines)
+
+| # | Line | Decision | Documented? | Incomplete-contract? | Impact | Reversibility | Existing ADR? |
+| - | ---- | -------- | ----------- | -------------------- | ------ | ------------- | -------------- |
+| E-01 | 51-77 | `Degradation` を `(Vec<String>, Vec<DegradedReason>)` 2-Vec 1:1 pairing で表現 (tuple Vec/HashMap 不採用) | Partial | Yes | M | medium | ADR-0003 (DegradedReason 範囲) |
+| E-02 | 86-123 | `CommandOutput::degraded` を `bool` field として stored、derived ではない | Partial | Yes | M | medium | None |
+| **E-03** | **200-205** | **`ErrorCode::is_retryable() = matches!(self, TempFailure \| Timeout)` policy。`Internal` (exit 70) と `Unknown` (exit 104) を non-retryable 固定** | **Partial** | **Yes** | **H** | **low** | **partial ADR-0003** |
+| **E-04** | **226-236** | **`ErrorPayload` field omit mix: `code`/`message`/`retryable` は常時、`next_step`/`candidates` は `skip_serializing_if`** | **No** | **Yes** | **H** | **low** | **ADR-0065 (schema 範囲のみ)** |
+| **E-05** | **210-217** | **`SuccessEnvelope` asymmetry: `notes` は常に `[]` 出力、`degraded_reasons` は `skip_serializing_if`** | **Partial** | **Yes** | **H** | **low** | **ADR-0065 (notes)、ADR-0003 (degraded_reasons additive) — 統一 rule なし** |
+| E-06 | 32-44 | `DegradedReason::label()` で 5 variants を `"resource"` collapse、4 variants は固有 label。doc では "the three `*FetchFailed` variants" と書くが実際は 4 | Partial | Yes | M | medium | ADR-0003 partial (8 variants と書くが実装 9 variants — **drift**) |
+| E-07 | 142-158 | `#[cfg(test)]` test-only accessors (production は consume API のみ) | Yes | No | L | high | None (documented で十分) |
+| E-08 | 13-14, 168-169 | `serde(rename_all = "SCREAMING_SNAKE_CASE")` を 2 enum で重複 | No | Yes | L | high | ADR-0065 (case convention) |
+
+### src/tools/errors.rs (890 lines, +279 since Part 2)
+
+| # | Line | Decision | Documented? | Incomplete-contract? | Impact | Reversibility | Existing ADR? |
+| - | ---- | -------- | ----------- | -------------------- | ------ | ------------- | -------------- |
+| TE-01 | 299 | Slack `Api` transient code allowlist 3 strings (`internal_error`/`service_unavailable`/`fatal_error`) — closed enumeration、spec citation 無し (`pending_spec_check`) | Partial | Yes | M | high | partial ADR-0003 |
+| TE-02 | 303 | `SlackError::Api` 未認識 string を user_error (exit 64) に default。HTTP-based `Unknown(104)` escape (line 222, 345) と asymmetric | Partial | Yes | M | high | partial ADR-0003 |
+| TE-03 | 251 | `FetchError::Status(401\|403)` collapsed arm + single hint。GitHub の `Forbidden` (scope hint) と `Api{401}` (auth hint) split (line 178-182) と asymmetric | No | No | L | high | None |
+| TE-04 | 267 | `FetchError::DnsResolution` が bespoke inline hint で ADR-0006 transient helpers (`transient_with_network_hint` 等) を bypass | No | No | L | high | ADR-0006 (helper set 定義) |
+| TE-05 | 245 | `FetchError::TooLarge` hint が "10MB" hardcoded、`MAX_RESPONSE_BYTES = 10_000_000` 定数と乖離 (single source of truth 違反) | No | Yes | M | high | None |
+| TE-06 | 246 | `FetchError::TooManyRedirects → DataError` (exit 65, 非retry)。redirect loop は server-side 状況、TempFailure 検討余地 (`pending_calibration`) | No | Yes | M | medium | None |
+
+### src/retry.rs (484 lines)
+
+| # | Line | Decision | Documented? | Incomplete-contract? | Impact | Reversibility | Existing ADR? |
+| - | ---- | -------- | ----------- | -------------------- | ------ | ------------- | -------------- |
+| RT-01 | 14 | `INITIAL_BACKOFF_MS = 1000` (500/2000 でなく 1000 の根拠 無し) | No | Yes | M | high | None |
+| **RT-02** | **15** | **`MAX_RETRY_AFTER_SECS = 300` (5min) cap、RFC 9110 §10.2.4 と GitHub/Brave/Slack docs は client-side cap 値を規定しない** | **Partial** | **Yes** | **H** | **high** | **partial ADR-0006** |
+| RT-03 | 109 | `parse_retry_after` 過去日時を `saturating_sub` で 0 clamp → "retry now"。clock skew 下で tight loop 化リスク | Partial | Yes | M | medium | None (ADR-0008 は Clock injection seam のみ) |
+| RT-04 | 22-26 | Equal jitter (`half + rand[0, half)`) vs Full jitter (`rand[0, base)` AWS 推奨)。選択根拠 無し | Partial | Yes | L | high | None |
+| RT-05 | 22, 26 | `jittered_backoff` に base 上限 cap 無し。`RETRIES_CAP = 10` (`tools/config.rs:23`) cross-module invariant が implicit | No | Yes | M | high | None |
+| RT-06 | 111, 116 | unparseable `Retry-After` を `warn!` (default visible) level で log。policy 選択 (debug/error と比較) は不文 | No | No | L | high | None |
+
+### src/brave/client.rs (566 lines)
+
+| # | Line | Decision | Documented? | Incomplete-contract? | Impact | Reversibility | Existing ADR? |
+| - | ---- | -------- | ----------- | -------------------- | ------ | ------------- | -------------- |
+| BC-01 | 19 | `REQUEST_TIMEOUT = 20s` per-request budget。retry × 20s wall clock 累積関係 unstated | No | Yes | M | high | None |
+| BC-02 | 20, 228-230 | `BODY_SNIPPET_BYTES = 200` error body truncation。multi-byte 境界 silent cut | No | Yes | L | high | None |
+| **BC-03** | **179-189** | **`build_url` が `q` と optional `search_lang` のみ送信、Brave API の `count`/`offset`/`safesearch`/`freshness`/`country` 等は全 omit (Brave defaults 受け入れ)** | **No** | **Yes** | **H** | **medium** | **None (`pending_spec_check`)** |
+| BC-04 | 256-263 | `is_retriable` whitelist が `RateLimited`/`Server`/transient `Network` のみ。408 (Request Timeout), 425 (Too Early) を terminal 扱い | Partial | Yes | M | high | ADR-0006 (mechanism のみ) |
+| BC-05 | 198-201 | HTTP 401 と 403 を `BraveError::Unauthorized` に collapsed。RFC 7235 上は 401=credentials missing/invalid, 403=credentials understood but refused | Partial | Yes | M | medium | None (`pending_spec_check`) |
+| BC-06 | 74-80 | `pub(crate) trait SearchClient` の contract が未記述 (result ordering, max length, URL normalization, dedup, lang filter semantics) | No | Yes | M | low | ADR-0005 (Brave backend 範囲のみ) |
+
+### src/github.rs (766 lines, +236 since Part 2)
+
+| # | Line | Decision | Documented? | Incomplete-contract? | Impact | Reversibility | Existing ADR? |
+| - | ---- | -------- | ----------- | -------------------- | ------ | ------------- | -------------- |
+| GH-01 | 82-84 + `token_source.rs:51` | Auth chain order rationale unstated (なぜ `GITHUB_TOKEN > GH_TOKEN > gh CLI`) | Partial | Yes | M | medium | None |
+| GH-02 | 205-262 | 401 が dedicated arm 無しで `Api{401}` に fall through、`Unauthorized` variant + auth-rotation hint 不在 | No | Yes | M | low | None |
+| GH-03 | 400-406 | `secs_until_ratelimit_reset` が `Some(0)` (即 retry) を返す stale 場合の semantics。`None` (jitter fallback) ではない | Partial | Yes | M | high | partial ADR-0008 (Clock injection seam のみ) |
+| **GH-04** | **316-350** | **`get_issues`/`get_pulls`/`get_releases` が `?page=` 送らず `Link` header も parse しない。100件で silent truncation** | **No** | **Yes** | **H** | **medium** | **None (ADR-0004 Rule 2 は per_page cap、これは per-call cap)** |
+| **GH-05** | **323, 335** | **List endpoint で `state=open&sort=updated&direction=desc` 固定、closed/created/asc 不可** | **No** | **Partial** | **M** | **medium** | **None** |
+| GH-06 | 379-387 | `extract_error_message` 200-char truncation (no ellipsis、`.chars()` cut grapheme cluster) | No | No | L | high | None |
+
+## Prose Document Decisions
+
+### README.md (新規行)
+
+| # | Line | Decision Verb | Decision | ADR Coverage |
+| - | ---- | ------------- | -------- | ------------ |
+| P-A | 158 | always / never | `data = {query, sources, fetched_pages, failed_urls}`、`All array fields are []` (never null) when empty | partial ADR-0065 (schema 範囲) |
+| P-B | 173 | always | Page metadata YAML frontmatter block is `always present`; individual fields conditional | None (ADR-0001 範囲外、fetch markdown contract) |
+| P-C | 228 | (statement) | "SSRF defense is designed for local CLI use" + embedding service には additional measures 必要 | ADR-0001 (threat model statement に該当) |
+| P-D | 314 | never | `data.fetched_pages` / `data.failed_urls` (research only)、both default to `[]` (never null) when empty | partial ADR-0065 (P-A と同様) |
+
+### README.ja.md / Cargo.toml / deny.toml
+
+新規 decision 無し。Part 1 で抽出済 (P-02 sysexits、P-03/04 lints、P-05/06/07 deny) + deny.toml の license policy comment は Part 1 follow-up で追加済み (line 7-8)。
+
+## External ADR Dependencies
+
+新規 external ADR ref: なし (ADR-0065 は既知の deliberately active carve out)。
+
+ADR-0065 への code refs (`src/envelope.rs`, `src/lib.rs`, `src/tools/errors.rs`, `tests/cli_integration.rs`) は引き続き ADR-0002 §"More Information" の supersede note の対象。**本 audit の最大の発見**として、scout-local ADR-0010 (envelope contract) を起票することで ADR-0065 の JSON schema portion を scout に移植する道筋ができる。
+
+## ADR Promotion Candidates (post-challenge)
+
+`critic-design` agent が 4 initial promotion candidates を Part 1+2 で得た heuristic (「個人 OSS の ADR は (1) 型/lint で守れない不変条件 (2) 公開 API 互換性コミットメント のみ価値」) で挑戦:
+
+| # | Source | Candidate | Initial | Challenge | Final | Action |
+| - | ------ | --------- | ------- | --------- | ----- | ------ |
+| **A** | envelope.rs E-03 + E-04 + E-05 + README P-A/P-D | scout-local JSON envelope contract (is_retryable mapping + omit policy + `[]`-never-`null`) | promote | **keep** | **ADR-0010** | 新規 ADR 起票、ADR-0065 JSON schema portion を supersede。ADR-0002 §"More Information" の伏線 "until a scout-local ADR is promoted" を成就 |
+| B | brave/client.rs BC-03 | Brave search request defaults (count/safesearch/freshness omit) | promote | **drop** | inline-comment | `build_url` body 上に `// Intentionally omit count/safesearch/freshness/country/ui_lang — accept Brave defaults.` 1 行追加 |
+| **C** | github.rs GH-04 + GH-05 | GitHub list endpoint silent 100-cap + 固定 filter/sort | promote | **downgrade** | **ADR-0004 extension** | ADR-0004 に Rule 4 (pagination 不在 / silent 100-cap) + Rule 5 (固定 `state=open&sort=updated&direction=desc`) 追加 |
+| D | retry.rs RT-02 | `MAX_RETRY_AFTER_SECS = 300` cap 値 | promote | **drop** | inline-comment | `retry.rs:15` 上に `// 5-min cap matches interactive CLI patience; tuning via SCOUT_MAX_RETRY_AFTER_SECS is future work.` 追加 |
+
+### Summary
+
+| Verdict | Count |
+| ------- | ----- |
+| keep | 1 (A → ADR-0010 新規) |
+| downgrade | 1 (C → ADR-0004 拡張) |
+| drop | 2 (B, D → inline comment) |
+
+### 最終 ADR 候補
+
+| # | ADR タイトル案 | 統合元 | 規模 |
+| - | -------------- | ------ | ---- |
+| 1 | `0010-scout-local-json-envelope-contract.md` (新規) | envelope.rs E-03/E-04/E-05 + README P-A/P-D | 中規模 (omit policy + retryable mapping + `[]`-never-`null` 公開契約。ADR-0065 supersede 部分含む) |
+| 2 | ADR-0004 amendment | github.rs GH-04 + GH-05 | 小規模 (Rule 4/Rule 5 + Reassessment Trigger row + Confirmation row 追加) |
+
+### Critic-design からの insight
+
+> 個人 OSS で ADR が価値を持つのは **(1) 型/lint で守れない不変条件** と **(2) 公開 API 互換性コミットメント** の 2 領域。本回の 4 candidate を heuristic に当てると、A のみ両方を満たす (omit policy/`[]`-never-`null` は型で守れず、README 公開契約)。C は (2) のみ満たすが、ADR-0004 が既存の正しい家。B (Brave defaults 受け入れ) は contract 不在の decision-by-omission、D (300s cap) は実装 tuning であり interface promise ではない。Impact: H ラベルは ADR-worthy の代理指標として弱く、heuristic 4 が真の filter。
+
+## ADR Drift (情報のみ、別 audit 系統)
+
+| # | Source | Drift | Recommended action |
+| - | ------ | ----- | ------------------ |
+| D-01 | envelope.rs E-06 + ADR-0003 | ADR-0003 が `DegradedReason` を "8 variants" と書くが実装は **9 variants**。rustdoc も "Only the three `*FetchFailed` variants" と書くが実際 4 variants が固有 label | ADR-0003 line 57 Note を "9 variants (post-implementation)" に更新 + envelope.rs:36 doc を "the four variants that flow through that helper" に修正 |
+
+## Bug fix follow-ups (情報のみ、ADR ではない)
+
+| # | Source | Bug | Recommended fix |
+| - | ------ | --- | --------------- |
+| BG-01 | tools/errors.rs TE-05 | `FetchError::TooLarge` hint "10MB" hardcoded、`MAX_RESPONSE_BYTES` 定数と乖離 | `format!("URL response exceeds {} bytes; fetch a smaller resource", MAX_RESPONSE_BYTES)` または `MAX_RESPONSE_BYTES_HUMAN` 公開定数 |
+| BG-02 | tools/errors.rs TE-06 | `FetchError::TooManyRedirects → DataError(65)` 非retry。CDN A/B test 等で transient 可能性 | `pending_calibration`: 実データで transient vs permanent を測定後、TempFailure (75) に flip 検討 |
+| ~~BG-03~~ | ~~github.rs GH-02~~ | ~~401 が `Api{401}` fall through、`Unauthorized` variant + token-rotation hint 不在~~ | **取り下げ (false premise)**: 2026-05-19 follow-up 着手時に発見、既に T-ER030 (`src/tools/errors.rs:644`) で `Api { code: 401, .. }` arm + auth hint mapping (issue #101 fix) が実装済。reviewer-rust が "no UX hint" を誤判定。型安全性のための `Unauthorized` variant 化は YAGNI、現状の `Api { code: 401, .. }` match で機能している |
+
+## Inline comment downgrades (情報のみ、軽微)
+
+incomplete-contract=Yes だが impact=M または reversibility=high の findings は ADR ではなく inline comment で対応推奨。promotion 候補ではないが、refactor 時の reader 体験向上のため記録:
+
+- E-01 / E-02: `Degradation` 2-Vec representation + `degraded` stored bool の rationale comment
+- TE-01 / TE-02: Slack code list の "closed-world vs Unknown escape asymmetry" 注記
+- TE-03 / TE-04: `FetchError` arm asymmetry (401/403 collapse, DnsResolution helper bypass) の 1 行説明
+- RT-01 / RT-03 / RT-04 / RT-05: retry magic constants と implicit cross-module invariant 注記
+- BC-01 / BC-04: Brave timeout と is_retriable 4xx boundary の RFC ref
+- BC-06: `SearchClient` trait contract rustdoc (ordering, max length, dedup invariant)
+- GH-01: auth chain order の rationale (`GITHUB_TOKEN` が `GH_TOKEN` を超える理由)
+- GH-03: `secs_until_ratelimit_reset` stale 時 `Some(0)` vs `None` の policy 注記
+
+## Follow-up
+
+### ADR 起票 (post-challenge 1 件)
+
+- [ ] `docs/decisions/0010-scout-local-json-envelope-contract.md`
+  - `ErrorCode::is_retryable()` mapping (`TempFailure | Timeout` のみ true、`Internal`/`Unknown` non-retryable 固定)
+  - `ErrorPayload` / `SuccessEnvelope` の field omit policy (always-out vs `skip_serializing_if`)
+  - README L158/L314 で公開済の `[]`-never-`null` array invariant
+  - ADR-0065 JSON schema portion を supersede
+
+### ADR 拡張 (post-challenge 1 件)
+
+- [ ] `docs/decisions/0004-github-client-behavioral-limits.md`
+  - Rule 4: list endpoint pagination 不在 (silent 100-cap、`Link` header parse 無し)
+  - Rule 5: 固定 filter/sort (`state=open&sort=updated&direction=desc`、knob 無し)
+  - Reassessment Trigger: "Caller requests closed-state issues or non-update-sort access"
+  - Confirmation: `--help` で `repo-overview` の silent 100-cap を文書化
+
+### Inline comment 追加 (drop だが trace 用 2 件)
+
+- [ ] `src/brave/client.rs:179-189` `build_url` body 上に omitted params の意図 comment
+- [ ] `src/retry.rs:15` `MAX_RETRY_AFTER_SECS` 上に CLI patience 理由 + env override future note
+
+### ADR drift fix (1 件)
+
+- [ ] ADR-0003 line 57 Note: `DegradedReason` 8 → 9 variants 更新
+- [ ] `src/envelope.rs:36` rustdoc: "the three" → "the four" variants
+
+### Bug fix follow-ups (3 件 → 別 PR / Issue)
+
+- [ ] `FetchError::TooLarge` hint を `MAX_RESPONSE_BYTES` 定数から format
+- [ ] `FetchError::TooManyRedirects` classification 再検討 (`pending_calibration`)
+- [ ] `GitHubError::Unauthorized` variant + 401 dedicated arm + auth-rotation hint
+
+## Skill Design Feedback
+
+### Triage step が有効
+
+>800 line files 4 件 (tools.rs, fetch.rs, slack.rs, github/format.rs) を user triage で skip。差分対比 (Part 1 の line count から増加分) を提示して skip 推奨 → ユーザ即決 → reviewer-rust 5 invocations に集約。Part 1 が 9 of 12 files を scan して 31 candidates だったのに対し、本回は 5 of 12 で 32 candidates と同等密度を達成。
+
+### Reviewer-rust の existing ADR cross-reference 精度向上
+
+Part 2 で指摘した "外部仕様の主張は引用源を明示" "documented? 判定前にファイル全体 scan" を reviewer prompt に明示的に含めた結果、`pending_spec_check` ラベルが reviewer 側で付与され、本回 critic-design が "B drop (`pending_spec_check` で ADR より bug fix)" に倒すのを助けた。
+
+### Heuristic 4 の filter 力
+
+「個人 OSS の ADR が価値を持つのは (1) 型/lint で守れない不変条件 (2) 公開 API 互換性コミットメント のみ」の heuristic を challenge 段階で明示的に渡したことで、Impact: H ラベル単独では ADR 化されない (B/D drop) ことが定量化された。Part 1+2 の累積実践知が本回 final candidate を 4 → 1 promote + 1 downgrade に絞り込むのに寄与した。

--- a/docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md
+++ b/docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md
@@ -92,7 +92,7 @@ scout 独自の意味づけ (例: 10 = network, 20 = parse, 30 = auth)。
 
 This ADR supersedes the **sysexits portion** of `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (dotclaude meta ADR). The exit-code mapping table (64/65/66/74/75) was originally defined there as part of the agent-friendly CLI policy (ADR-0060 → ADR-0065 chain). It is now scout-local under this ADR. PR #94 で ADR-0065 9-code policy 採用に伴って追加された `70 EX_SOFTWARE` / `104 PJ extension` / `124 GNU coreutils` も本 ADR の scout-local 管理対象に含まれる (詳細は本 ADR 末尾の Note 2026-05-14 を参照)。
 
-The **JSON output schema portion** of ADR-0065 (`error.code` field, `--json` mode, error envelope structure) is **not** included in this ADR and remains active in ADR-0065 until a scout-local ADR is promoted to capture it. Until then, code that maps `ErrorCode` → exit code is governed by this ADR; code that maps domain errors → `ErrorCode` JSON tags is governed by ADR-0065.
+The **JSON output schema portion** of ADR-0065 (`error.code` field, `--json` mode, error envelope structure) is **not** included in this ADR. As of 2026-05-19, the JSON schema portion is captured by **ADR-0010 (scout-local)** which supersedes ADR-0065 for the `error.code` JSON tag, `ErrorEnvelope` / `SuccessEnvelope` / `ErrorPayload` structure, field omit policy, and `data` array `[]`-never-`null` invariant. Code that maps `ErrorCode` → exit code is governed by this ADR; code that maps domain errors → `ErrorCode` JSON tags and the envelope serialization rules are governed by ADR-0010.
 
 ### 採用 code 詳細
 

--- a/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
+++ b/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
@@ -56,6 +56,8 @@ Chosen option: Option A, because public CLI contract として一貫した class
 >
 > **Note (2026-05-13, follow-up implementation)**: 残り scope を additive route で実装完了。実装した variants は callsite から逆算した 8 種類 (`IssuesFetchFailed`, `PullsFetchFailed`, `ReleasesFetchFailed`, `ReadmeFetchFailed`, `ReadmeBlobFetchFailed`, `ReadmeDecodeFailed`, `UrlFetchFailed`, `ReadabilityFallback`)。当初挙げた `ReadmeMissing` は `resolve_readme` 実装が 404 を silent 扱い (notes 追加なし) としていたため variant 化せず、README 系は failure mode で 3 種に分割。JSON schema 変更は additive (`degraded_reasons` field を `skip_serializing_if = "Vec::is_empty"` で追加) なので Cargo `version = "1.0.0"` → `"1.1.0"` の minor bump。既存 caller (`notes` の `Vec<String>` 構造を見る) は無影響。
 >
+> **Note (2026-05-19, post-ADR-0005 update)**: ADR-0005 (Brave Search switch, 2026-05-15) に伴い `BraveSearchFailed` variant 追加で **計 9 variants**。`unwrap_or_degraded` 経由で meaningful label を持つのは `*FetchFailed` の 3 つに加えて `BraveSearchFailed` の合計 4 variants。命名規約 (`*FetchFailed`) の例外として `BraveSearchFailed` は Brave API endpoint 機能名 (search) に倣う。発見元 audit: `docs/audit/2026-05-19-undocumented-decisions.md` E-06。
+>
 > **README 404 silent の意図的選択**: 「README が存在しない repo」は scout として degraded ではない (overview は他フィールドだけで成立)。404 を silent にすることで `degraded` flag を「abnormal なときだけ立てる」契約に保つ。代わりに JSON consumer は `data.readme` が null か否かで「README の有無」を直接判別可能 (404 と fetch error の区別は `degraded_reasons` の `ReadmeFetchFailed` の有無で行う)。403 等の non-404 4xx は `ReadmeFetchFailed` で集約しており、status code 別の細分は当面 scope 外。
 
 ### Consequences
@@ -98,7 +100,7 @@ Chosen option: Option A, because public CLI contract として一貫した class
 
 * 各 `ErrorCode` バリアントの construction site で本 ADR の mapping table を参照
 * `unwrap_or_note` を `unwrap_or_degraded` に rename 済み (`src/tools/errors.rs` `unwrap_or_degraded`)。`DegradedReason` を受け取り、`Degradation::push` 経由で `(notes[i], reasons[i])` の pair invariant を保ったまま統一的に蓄積する形に refactor 済み
-* `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (実装後 8 variants、上記 Note 2026-05-13 follow-up implementation を参照)
+* `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (実装後 9 variants、上記 Note 2026-05-19 post-ADR-0005 update を参照)
 * ADR-0065 §Classification Priority の 5 段ルール (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN 退避) を各 `From<...>` 実装の match arm 順序と `// Priority N` コメントで明示する。`*Error::Api { code }` の 4xx は priority 2 (DataError) に集約する。Priority 5 (INTERNAL) 以下は 3 つの sibling constructor に分離する: `internal_bug()` は scout-side invariant violation (例: deserialize 想定外 schema) を `ErrorCode::Internal` (exit 70 EX_SOFTWARE) で表し、`io_error()` は scout の不変条件外にある external tool / IO failure (例: headless browser CDP error) を `ErrorCode::IoError` (exit 74 EX_IOERR) で表し、`unknown()` は priority 1-5 のどれにも該当しない unclassifiable failure を `ErrorCode::Unknown` (exit 104 PJ extension) で退避する。3 つの分離により caller script / agent は scout 側 bug (70) と外部要因 (74) と分類欠落 (104) を programmatic 判別できる
 
 ### Reassessment Triggers

--- a/docs/decisions/0004-github-client-behavioral-limits.md
+++ b/docs/decisions/0004-github-client-behavioral-limits.md
@@ -62,19 +62,45 @@ GitHub docs は 403 で header を必ず付けるとは保証していないた�
 * filename-only match の旧 behavior は廃止
 * `src/*.rs` のような glob が intuitive に動作
 
+### Rule 4: List endpoints surface only the first page (no pagination)
+
+`get_issues` / `get_pulls` / `get_releases` (`src/github.rs:316,328,340`):
+
+* `?page=` を送らず、`Link` header (`rel="next"` / `rel="last"`) を parse しない
+* `per_page` (1..=100、Rule 2 で type-enforced) で 1 call = 最大 100 件
+* `per_page` を超える結果は silent truncation (Rule 2 の per-page cap とは別 layer、per-call cap)
+* `repo_overview` の "at a glance" outcome に最適化 (`scout repo-overview` の usage 例で `PerPage::new(5)` 等の small constant が default)
+* "全件" semantics は scope 外。caller が closed issues / 完全 PR 履歴 を必要とする場合は GitHub web UI / `gh` CLI へ誘導
+
+### Rule 5: List endpoints use fixed filter / sort
+
+`get_issues` / `get_pulls` の query string は固定:
+
+* `state=open` (closed / all は不可)
+* `sort=updated` (created / comments は不可)
+* `direction=desc` (asc は不可)
+
+`get_releases` は filter / sort 引数を持たない (GitHub 側 default = published_at desc)。
+
+`repo_overview` の "latest activity" outcome に対する optimal default。flexibility が必要になった時点で signature 変更 (Reassessment Trigger 参照)。
+
 ### Consequences
 
 * Good, because invalid per_page 値が compile-time panic として検出される (silent data truncation 不可能)
 * Good, because rate limit retry が header 不在でも確実に発動
 * Good, because glob semantics が intuitive、`src/*.rs` 等が動作
+* Good, because list endpoint の固定 filter / sort と pagination 不在は `repo_overview` outcome に最適化された intentional limit、`gh` CLI 代替への誘導が明確
 * Bad, because behavior 変更で既存 caller (per_page > 100、per_page == 0、filename-only glob 依存) が break する可能性 (semver bump 検討)
 * Bad, because header 不在を retry に倒す decision は false-positive retry を増やす (secondary rate limit が稀に出る場合)
+* Bad, because Rule 4 で >100 件の真の "全件" を期待する caller が silent truncation を被る (Rule 2 と同じ class、layer が異なる)
 
 ### Confirmation
 
 * `src/github.rs:153` 周辺で 403 + header 不在の unit test (mock response)、`RateLimited` に分類されることを確認
 * `src/github.rs` の `PerPage::new` boundary test: `per_page=1` / `per_page=100` accept (T-GH011a)、`per_page=0` / `per_page=101` で panic 検証 (T-GH011b/c、`#[should_panic]`)
 * `src/github/helpers.rs:161` で `filter_tree_entries(entries, None, Some("src/*.rs"))` が `src/foo.rs` を含むことの test
+* `src/github.rs:316,328,340` の list endpoint URL に `?page=` が含まれないこと、固定 query string (`state=open&sort=updated&direction=desc`) が caller の引数で変更されないことの compile-time enforcement (関数 signature が `per_page: PerPage` のみ受け取る)
+* `scout repo-overview --help` で list endpoint が "first N items" の semantics であることを README / `--help` で文書化
 
 ## Pros and Cons of the Options
 
@@ -106,11 +132,16 @@ GitHub docs は 403 で header を必ず付けるとは保証していないた�
 | GitHub API が per_page max を緩和                                  | Rule 2 cap 値を更新                   |
 | GitHub API が 403 で常に rate-limit header を保証                  | Rule 1 fallback を Forbidden に変更検討 |
 | filter_tree_entries の filename-only behavior を期待する caller 多発 | Rule 3 に option パラメータ追加検討   |
+| Caller が closed issues / 全件 PR 履歴 / 非 updated-sort を要求    | Rule 4 で pagination (Link header walk) 追加 + Rule 5 で filter / sort knob を別 method として導入 |
+| `repo_overview` 用途以外の list call site が増加                   | Rule 4/5 で knob を struct param 化 (現状は `repo_overview` 専用 default として最適化) |
 
 ### 参照
 
-* `docs/audit/2026-05-13-undocumented-decisions-part2.md` (本 ADR の根拠 audit、Candidate #14, #15, #16)
-* `src/github.rs:153-165` (403 header fallback の現実装)
-* `src/github.rs:239,252,265` (per_page silent clamp の現実装)
-* `src/github/helpers.rs:161-177` (filter_tree_entries glob scope の現実装)
+* `docs/audit/2026-05-13-undocumented-decisions-part2.md` (Rule 1-3 の根拠 audit、Candidate #14, #15, #16)
+* `docs/audit/2026-05-19-undocumented-decisions.md` (Rule 4-5 の根拠 audit、Candidate GH-04, GH-05)
+* `src/github.rs:153-165` (403 header fallback の現実装、Rule 1)
+* `src/github.rs:289-298` (`PerPage::new` validation、Rule 2)
+* `src/github/helpers.rs:161-177` (filter_tree_entries glob scope の現実装、Rule 3)
+* `src/github.rs:316,328,340` (list endpoint の pagination 不在 + 固定 filter/sort、Rule 4-5)
 * GitHub Rate Limit docs: https://docs.github.com/en/rest/rate-limit
+* GitHub Pagination docs: https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api

--- a/docs/decisions/0010-scout-local-json-envelope-contract.md
+++ b/docs/decisions/0010-scout-local-json-envelope-contract.md
@@ -1,0 +1,179 @@
+---
+status: "accepted"
+date: 2026-05-19
+decision-makers: thkt (project owner)
+---
+
+# Scout-local JSON envelope contract
+
+## Context and Problem Statement
+
+scout の `--json` 出力は 2 layer の policy で governed:
+
+- exit codes: ADR-0002 (scout-local, sysexits.h convention 8 non-zero codes)
+- `error.code` JSON tag、envelope schema 構造: `~/.claude/docs/decisions/0065-...` (dotclaude meta, external)
+
+ADR-0002 §"More Information" は "until a scout-local ADR is promoted to capture it" と書き、JSON schema portion の scout-local 化を 2026-05-13 時点で伏線として残していた。
+
+2026-05-19 audit (`docs/audit/2026-05-19-undocumented-decisions.md` Candidate A) で `src/envelope.rs` + README L158/L314 に **scout-local の field-level rule** が 4 つ存在することが判明した:
+
+1. `ErrorCode::is_retryable()` mapping (`envelope.rs:201-206`): `TempFailure | Timeout` のみ true、`Internal`/`Unknown` は false 固定。
+2. `ErrorPayload` field omit policy (`envelope.rs:228-236`): `code`/`message`/`retryable` は常時出力、`next_step`/`candidates` は `skip_serializing_if`。
+3. `SuccessEnvelope` array field 出力 asymmetry (`envelope.rs:211-218`): `notes: Vec<String>` は常時 `[]`、`degraded_reasons` は `skip_serializing_if`。
+4. `data` 配下 array field の `[]`-never-`null` invariant: README L158 と L314 で公開契約として宣言済。
+
+これらは ADR-0065 で governed されない (schema structure 自体は ADR-0065、field-level の omit policy / retryable mapping / `[]`-vs-`null` commitment は scout 判断)。型 / lint / serde derive で 機械 enforce できず、test は個別 case を pin できても **新規 field 追加時の rule** を未来の reviewer に伝える媒体が無い。
+
+## Decision Drivers
+
+- ADR-0002 §"More Information" の supersede 伏線を実装で成就する。
+- AI agent caller (`--json` の主要 consumer) は parser を `if "next_step" in payload` / `data.array.length === 0` 等の pattern で書く。field 存在性 / `[]`-vs-`null` の予測可能性が破綻すると silent regression が起きる。
+- scout-local の field rule (omit policy, retryable mapping) は型 / lint / serde derive で機械 enforce できない。例: 将来 `Vec<String>` を `Option<Vec<String>>` に変える PR が field rule を silent に反転させる可能性がある。
+- README L158 / L314 は既に "All array fields are `[]` (never null) when empty" を public contract として宣言済。コードは公開契約に追従する責務がある。
+
+## Considered Options
+
+- (Chosen) Option A: 新規 scout-local ADR-0010 起票、ADR-0065 JSON schema portion を supersede。
+- Option B: ADR-0002 / ADR-0003 への section 追加で済ませる。
+- Option C: inline comment + test で field-level rule を pin (ADR 化なし)。
+
+## Decision Outcome
+
+Chosen: Option A — 新規 ADR-0010、ADR-0065 JSON schema portion を supersede。
+
+### Rule 1: `ErrorCode::is_retryable()` = `TempFailure | Timeout` 固定
+
+`src/envelope.rs:201-206` の `is_retryable` は `matches!(self, TempFailure | Timeout)` のみ true を返す。各 variant の retryable 判定:
+
+| ErrorCode | Retryable | Rationale |
+| --------- | --------- | --------- |
+| `UsageError` (64) | false | caller 入力 fix が必要 (token rotation 等) |
+| `DataError` (65) | false | URL / data の差し替え必要 |
+| `NotFound` (66) | false | resource 不在、retry で解決しない |
+| `Internal` (70) | **false** | scout-side invariant violation、bug fix が必要。retry は scout のバグを mask する |
+| `IoError` (74) | false | external tool / IO failure、root cause fix が必要 |
+| `TempFailure` (75) | **true** | server-side transient (5xx, rate limit) |
+| `Timeout` (124) | **true** | transport timeout、retry で解決可能 |
+| `Unknown` (104) | **false** | classification 漏れ。`true` だと未知 cause で blind retry になり caller を巻き込む |
+
+`Unknown=false` を採用した理由: `Unknown` の rate 上昇は classification 設計の verification signal として機能する。`true` を返すと caller が blind retry し、signal が消える。
+
+### Rule 2: `ErrorPayload` field omit policy
+
+`src/envelope.rs:228-236` の serialization 規約:
+
+| Field | Serialization | Why |
+| ----- | ------------- | --- |
+| `code` | always | parser の枝分かれ根拠 (`code === "RATE_LIMIT"`) |
+| `message` | always | human-readable explanation、empty string 含む |
+| `retryable` | always | parser の retry 判定根拠 (`retryable === true`) |
+| `next_step` | `skip_serializing_if = "Option::is_none"` | optional hint、`null` を avoid (parser の `if "next_step" in payload`) |
+| `candidates` | `skip_serializing_if = "Vec::is_empty"` | optional alternatives、`[]` も省略 |
+
+`code` / `message` / `retryable` の always emit と `next_step` / `candidates` の skip-if-empty は **意図的な分岐**:
+
+- always emit field = parser の primary 判断に使う signal
+- skip-if-empty field = secondary hint、parser が `if "X" in payload` で feature-detect
+
+新規 field 追加時の判断 rule: parser の primary 判断に使う field は always emit、secondary hint は skip-if-empty。
+
+### Rule 3: `SuccessEnvelope` array field omit asymmetry
+
+`src/envelope.rs:211-218` の `notes: Vec<String>` は常時 `[]` 出力 (`skip_serializing_if` なし)、`degraded_reasons: Vec<DegradedReason>` は `skip_serializing_if = "Vec::is_empty"`。
+
+| Field | Serialization | Rule basis |
+| ----- | ------------- | ---------- |
+| `notes` | always (`[]` when empty) | ADR-0065 で defined 済の original field、parser は `.notes.length` を常に読める前提 |
+| `degraded_reasons` | skip-if-empty | ADR-0003 で post-hoc 追加された additive field、parser は `if "degraded_reasons" in payload` で feature-detect |
+
+新規 additive field 追加時の rule:
+
+- ADR-0065 で defined 済の original field を変更 → always emit を維持
+- scout-local で post-hoc 追加 → `skip_serializing_if` で additive、既存 caller を壊さない
+
+### Rule 4: `data` 配下 array field の `[]`-never-`null` invariant
+
+`data` 配下の array field (`data.sources`, `data.fetched_pages`, `data.failed_urls` 等) は empty 時 `null` ではなく `[]` を返す。
+
+公開契約 (README L158, L314):
+
+> JSON envelope: `data = {query, sources, fetched_pages, failed_urls}`. All array fields are `[]` (never `null`) when empty.
+>
+> `data.fetched_pages` and `data.failed_urls` (research only) are unchanged in shape; both default to `[]` (never `null`) when empty
+
+実装側 commitment:
+
+- `Vec<T>` を `serde(skip_serializing_if = "Vec::is_empty")` で omit しない (omit すると parser の `data.failed_urls.length` が破綻)
+- `Option<Vec<T>>` を使わない (`null` 出力を生む)
+- 新規 array field 追加時、empty `[]` 出力を test で pin する
+
+### Consequences
+
+- Good, because AI agent parser が `data.array.length === 0` / `if "next_step" in payload` 等の pattern を確実に書ける。silent regression は test と本 ADR Rule で防止。
+- Good, because `Unknown=false` retryable mapping により classification 漏れが silent retry で隠蔽されず、設計の verification signal が保たれる。
+- Good, because ADR-0002 §"More Information" の supersede 伏線が成就、JSON schema portion が scout-local 化される。
+- Good, because 新規 field 追加 PR の reviewer が omit policy rule (Rule 2/3) を本 ADR の table で確認できる。
+- Bad, because ADR-0065 supersede による code-side ref (`src/envelope.rs`, `src/lib.rs`, `src/tools/errors.rs`, `tests/cli_integration.rs`) の `per ADR-0065` → `per ADR-0010` 移行 PR が follow-up として必要 (ADR-0002 supersede 時と同様の作業)。
+- Bad, because Rule 4 で `Option<Vec<T>>` を禁じることで "field 不在" を意味的に表現できなくなり、`data.foo: null` が必要な case で workaround (`Option<NonEmptyVec<T>>` 等) が必要になる。
+
+### Confirmation
+
+- `src/envelope.rs:201-206` の `is_retryable` 実装は Rule 1 と機械的に一致 (`matches!(self, TempFailure | Timeout)`)。
+- `src/envelope.rs:228-236` の `ErrorPayload` derive は Rule 2 と機械的に一致 (`code`/`message`/`retryable` 無修飾、`next_step` に `Option::is_none`、`candidates` に `Vec::is_empty`)。
+- `src/envelope.rs:211-218` の `SuccessEnvelope` derive は Rule 3 と機械的に一致 (`notes` 無修飾、`degraded_reasons` に `Vec::is_empty`)。
+- 既存 unit test (T-EN001..T-EN015) が omit / always-emit を個別 case で pin。
+- `tests/cli_integration.rs` の `--json` end-to-end が `data.failed_urls = []` 等の `[]` 出力を検証。
+
+## Pros and Cons of the Options
+
+### Option A: 新規 ADR-0010 + ADR-0065 supersede (採用)
+
+- Good, because ADR-0002 §"More Information" の伏線 ("until a scout-local ADR is promoted") を成就する。
+- Good, because 4 つの field-level rule を一本化、reviewer の判断 rule が一箇所に集約。
+- Good, because ADR-0065 (dotclaude meta) と scout-local の責務境界が clarify される。
+- Bad, because supersede 後の code ref 移行作業が follow-up PR で発生。
+
+### Option B: ADR-0002 / ADR-0003 への section 追加
+
+- Good, because 既存 ADR を再利用、新規番号消費なし。
+- Bad, because ADR-0002 (exit code) と ADR-0003 (error classification mapping) は責務が違う。JSON envelope の field-level rule は third concern、混入で各 ADR の Decision section が肥大化。
+- Bad, because supersede note を ADR-0002 と ADR-0003 の両方に書く必要が生じ、責務分散。
+
+### Option C: inline comment + test で pin (ADR 化なし)
+
+- Good, because doc 追加コストゼロ。
+- Bad, because comment は個別 site にしか書けず、新規 field 追加時の "omit policy はどちらか" の判断 rule が見えない。
+- Bad, because test は個別 case を pin できるが、未来追加 field の rule (always emit vs skip-if-empty) は test で表現できない (型/lint 同様、enforce 不能)。
+
+## More Information
+
+### Supersedes (ADR-0065 carve out)
+
+本 ADR は `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (dotclaude meta) の **JSON output schema portion** を scout-local 化する:
+
+- `error.code` JSON tag (Rule 1 retryable mapping を含む)
+- `ErrorEnvelope` / `SuccessEnvelope` / `ErrorPayload` 構造 (Rule 2-3 field omit policy を含む)
+- `data` 配下 array field の `[]`-never-`null` invariant (Rule 4)
+
+ADR-0065 の **sysexits portion** (8 non-zero exit codes 64/65/66/70/74/75/104/124) は依然 ADR-0002 (scout-local) で governed (2026-05-13 supersede 済)。
+
+code-side migration (`per ADR-0065` → `per ADR-0010` ref 更新) は follow-up PR で実施する。
+
+### Reassessment Triggers
+
+| Trigger | アクション |
+| ------- | ---------- |
+| 新規 `ErrorCode` variant が追加され、その retryable 判定が `TempFailure | Timeout` mapping に収まらない | Rule 1 table 拡張、`is_retryable()` の `match` arm 追加 |
+| 新規 field 追加で omit policy の判断が必要 | Rule 2/3 table に新規 row 追加、`always emit` / `skip-if-empty` の判断軸を記録 |
+| `data` 配下に新規 array field 追加 | Rule 4 に従い `[]`-never-`null` test を追加 |
+| `Unknown` rate が caller logs で持続的に上昇 | classification design を audit、`Unknown` をさらに分類できないか検討 (新規 ErrorCode variant 化) |
+| `data.foo: null` の表現が真に必要な case が発生 | Rule 4 に `Option<NonEmptyVec<T>>` 等の例外 pattern を追加 |
+
+### 参照
+
+- `docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md` §"More Information" (本 ADR の supersede 伏線元)
+- `docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md` (error mapping は本 ADR Rule 1 `is_retryable` の前提)
+- `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (本 ADR が JSON schema portion を supersede する meta ADR)
+- `docs/audit/2026-05-19-undocumented-decisions.md` (本 ADR の根拠 audit、Candidate A = envelope E-03/E-04/E-05 + README P-A/P-D)
+- `src/envelope.rs:201-236` (実装 site)
+- `README.md` L158, L314 (公開契約の declared form)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,8 @@ This directory contains important decisions about the project's architecture.
 | [0006](0006-centralize-retry-after-delay-in-retry-helper.md) | Centralize retry-after delay in retry helper | accepted | 2026-05-16 |
 | [0007](0007-unify-brave-client-init-via-factory-and-result-based-https-check.md) | Unify Brave client init via factory and Result-based https check | accepted | 2026-05-17 |
 | [0008](0008-trait-injection-and-scoutbuilder-for-test-seam.md) | Test seam architecture via `Arc<dyn Trait>` fields and `ScoutBuilder` | accepted | 2026-05-19 |
+| [0009](0009-object-safe-dns-resolver-and-arc-injection.md) | Object-safe `DnsResolver` and `Arc<dyn DnsResolver>` injection | accepted | 2026-05-19 |
+| [0010](0010-scout-local-json-envelope-contract.md) | Scout-local JSON envelope contract | accepted | 2026-05-19 |
 
 ## By Status
 
@@ -27,6 +29,8 @@ This directory contains important decisions about the project's architecture.
 - **0006**: Centralize retry-after delay in retry helper
 - **0007**: Unify Brave client init via factory and Result-based https check
 - **0008**: Test seam architecture via `Arc<dyn Trait>` fields and `ScoutBuilder`
+- **0009**: Object-safe `DnsResolver` and `Arc<dyn DnsResolver>` injection
+- **0010**: Scout-local JSON envelope contract
 
 ## About MADR Format
 

--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -181,6 +181,9 @@ fn build_url(
     query: &str,
     search_lang: Option<&str>,
 ) -> Result<reqwest::Url, BraveError> {
+    // Intentionally omit count/offset/safesearch/freshness/country/ui_lang —
+    // accept Brave defaults (safesearch=moderate, count=20). Adding params is
+    // additive; introduce them only when a caller surfaces a concrete need.
     let mut params = vec![("q", query)];
     if let Some(lang) = search_lang {
         params.push(("search_lang", lang));

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -26,9 +26,10 @@ pub(crate) enum DegradedReason {
 
 impl DegradedReason {
     /// Human-readable label used by [`crate::tools::errors::unwrap_or_degraded`]
-    /// to build the `"Could not fetch {label} ({e})"` message. Only the three
-    /// `*FetchFailed` variants that flow through that helper get a meaningful
-    /// label; other variants build bespoke messages at their callsite.
+    /// to build the `"Could not fetch {label} ({e})"` message. The four
+    /// fetch-style variants (three `*FetchFailed` plus `BraveSearchFailed`)
+    /// that flow through that helper get a meaningful label; other variants
+    /// build bespoke messages at their callsite.
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::IssuesFetchFailed => "issues",

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -12,6 +12,9 @@ use crate::clock::Clock;
 use crate::rng::Rng;
 
 const INITIAL_BACKOFF_MS: u64 = 1000;
+/// 5-min cap matches interactive CLI patience (a user waiting at a terminal
+/// stops trusting the tool past this point). Server hints beyond the cap
+/// fail fast rather than block.
 const MAX_RETRY_AFTER_SECS: u64 = 300;
 
 /// Default retry count used by every backend client when no override is

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -241,8 +241,15 @@ impl From<FetchError> for ScoutError {
             FetchError::UnsupportedContentType(_) => Self::data_error(e.to_string())
                 .with_next_step("URL must serve HTML or text content"),
             FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
-            FetchError::TooLarge => Self::data_error(e.to_string())
-                .with_next_step("URL response exceeds 10MB; fetch a smaller resource"),
+            FetchError::TooLarge => {
+                Self::data_error(e.to_string()).with_next_step("fetch a smaller resource")
+            }
+            // Classified as DataError (terminal) per priority 2: redirect chain
+            // shape is treated as caller-fixable URL config. CDN A/B test glitches
+            // or eventual-consistency redirects could be transient; pending
+            // empirical retry-success data, keep the terminal classification —
+            // flipping to TempFailure(75) requires measuring real-world retry
+            // success rate first.
             FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
                 .with_next_step("URL has too many redirects; check for a redirect loop"),
             // Status arms order specific HTTP codes before the 4xx / _ fallback;


### PR DESCRIPTION
## 何を / なぜ

2026-05-19 の `/audit-undocumented` で抽出した 32 findings から、critic-design challenge で keep 判定された 1 件と downgrade 判定された 1 件を ADR 化し、付随する drift fix と refactor を実施。AI エージェントが scout の JSON 出力に依存する際、scout-local の field-level rule (omit policy / retryable mapping / `[]`-never-`null`) を ADR で固定することで silent regression を防ぐ。

## 変更内容

- **ADR-0010 起票** (`docs/decisions/0010-...md`): scout-local JSON envelope contract。`ErrorCode::is_retryable()` mapping、`ErrorPayload` omit policy、`SuccessEnvelope` array field invariant の 4 Rule。ADR-0065 (dotclaude meta) の JSON schema portion を supersede。
- **ADR-0004 拡張**: Rule 4 (list endpoint pagination 不在 / silent 100-cap)、Rule 5 (固定 `state=open&sort=updated&direction=desc`) を追加。`repo_overview` 用途の intentional limit を contract 化。
- **ADR-0003 drift fix**: `DegradedReason` を 8 → 9 variants へ更新 (ADR-0005 以降の `BraveSearchFailed` 追加分の drift)。`envelope.rs:30` rustdoc も "the four fetch-style variants" に修正。
- **refactor(errors)**: `brave/client.rs build_url` に omit 意図 comment、`retry.rs MAX_RETRY_AFTER_SECS` に 5-min cap 根拠 doc comment、`tools/errors.rs TooLarge` hint を `"fetch a smaller resource"` に短縮 (Display が既に byte 数を出すため重複削除)、`TooManyRedirects` に classification 維持の `pending_calibration` comment。
- **監査レポート** (`docs/audit/2026-05-19-undocumented-decisions.md`): 32 findings の per-file table、critic-design challenge 結果、follow-up menu を記録。

## スコープ

- **含まない**: ADR-0010 supersede に伴う `per ADR-0065` → `per ADR-0010` の code-side ref 移行は別 PR (ADR-0002 supersede 時と同じ shape)。Brave search request defaults の機能拡張、retry-after cap の env override 化、`pending_calibration` の TooManyRedirects 分類 flip も対象外。

## 設計判断

- **ADR-0010 を新規起票 (B/D drop の 2 候補と異なる扱い)**: critic-design heuristic「個人 OSS の ADR が価値を持つのは (1) 型/lint で守れない不変条件 (2) 公開 API 互換性コミットメント のみ」で A (envelope contract) のみ両方を満たす。B (Brave default omit) は decision-by-omission で contract 不在、D (300s cap value) は実装 tuning で interface promise ではない、両方 inline comment に downgrade。
- **ADR-0004 amendment (C は keep ではなく downgrade)**: GitHub list endpoint behavior は ADR-0004 の既存 3 Rule と同軸 (silent behavior on GitHub endpoints that AI agents depend on) なので、parallel な新規 ADR ではなく既存 ADR への Rule 4/5 追加を選択。
- **`TooLarge` hint の trim**: 当初 `MAX_RESPONSE_BYTES` を `pub(crate)` 化して hint で format したが、`FetchError::TooLarge` の Display impl が既に `(>10000000 bytes)` を出力するため重複表示が発生。`/polish` の simplify-quality review で発見、hint を `"fetch a smaller resource"` に短縮 + `pub(crate)` revert。

## 検証手順

1. `cargo test --lib --offline` で 405 passing。
2. `cargo test --test cli_integration --offline` で 11 passing。
3. `cargo clippy --lib --all-features --offline -- -D warnings` で clean。
4. `docs/decisions/0010-scout-local-json-envelope-contract.md` を読み、Rule 1-4 が `src/envelope.rs:201-236` の derive と整合することを目視確認。
5. `docs/decisions/0004-github-client-behavioral-limits.md` の Rule 4/5 が `src/github.rs:316,328,340` の URL 構築と整合することを目視確認。
6. `docs/audit/2026-05-19-undocumented-decisions.md` の post-challenge ranking と follow-up menu を確認。

## 関連

- Audit basis: `docs/audit/2026-05-19-undocumented-decisions.md`
- Supersedes (partial): dotclaude meta `~/.claude/docs/decisions/0065-...` の JSON schema portion
- 前回 audit chain: `docs/audit/2026-05-13-undocumented-decisions.md` (Part 1+2), `2026-05-13/14-adr-drift.md`
