### PR TITLE
feat(fetch): redirect cap exceeded で calibration 用 warn を発火 (issue #145)

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -850,11 +850,15 @@ async fn download(
         return Ok((current_url, html));
     }
 
+    // CALIBRATION (issue #145 / #148 follow-up): structured fields below let
+    // callers sample empirical retry-success rate via `RUST_LOG=scout=warn`.
+    // Flip from DataError(65) to TempFailure(75) once rate > 10%.
+    let chain_length = max_redirects + 1;
     warn!(
-        redirect_chain_length = max_redirects + 1,
+        redirect_chain_length = chain_length,
         max_redirects,
         final_url = %RedactedLogUrl(current_url.as_str()),
-        "redirect cap exceeded (per ADR-0011 priority 2 classified as DataError; pending calibration via empirical retry-success data, see issue #145 follow-up)"
+        "redirect cap exceeded"
     );
     Err(FetchError::TooManyRedirects(max_redirects))
 }
@@ -1251,7 +1255,7 @@ mod download_tests {
         let result = download(
             &client,
             &validated(&format!("{}/redir", server.uri())),
-            0,
+            0, // max_redirects = 0
             &public_resolver(),
         )
         .await;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -850,6 +850,12 @@ async fn download(
         return Ok((current_url, html));
     }
 
+    warn!(
+        redirect_chain_length = max_redirects + 1,
+        max_redirects,
+        final_url = %RedactedLogUrl(current_url.as_str()),
+        "redirect cap exceeded (per ADR-0011 priority 2 classified as DataError; pending calibration via empirical retry-success data, see issue #145 follow-up)"
+    );
     Err(FetchError::TooManyRedirects(max_redirects))
 }
 
@@ -1221,6 +1227,39 @@ mod download_tests {
             matches!(result, Err(FetchError::TooManyRedirects(0))),
             "should error on too many redirects, got: {result:?}"
         );
+    }
+
+    /// [T-F056] redirect_cap_exceeded_emits_calibration_warn — `redirect cap
+    /// exceeded` warn must carry structured fields (`redirect_chain_length`,
+    /// `max_redirects`, `final_url`) so caller logs can sample retry-success
+    /// rate for the DataError vs TempFailure flip decision (issue #145).
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn redirect_cap_exceeded_emits_calibration_warn() {
+        let Some(server) = try_spawn_mock_server("fetch::download").await else {
+            return;
+        };
+        Mock::given(method("GET"))
+            .and(path("/redir"))
+            .respond_with(
+                ResponseTemplate::new(302).insert_header("location", "https://example.com/next"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = no_redirect_client();
+        let result = download(
+            &client,
+            &validated(&format!("{}/redir", server.uri())),
+            0,
+            &public_resolver(),
+        )
+        .await;
+        assert!(matches!(result, Err(FetchError::TooManyRedirects(0))));
+        assert!(logs_contain("redirect cap exceeded"));
+        assert!(logs_contain("redirect_chain_length"));
+        assert!(logs_contain("max_redirects"));
+        assert!(logs_contain("final_url"));
     }
 
     /// [T-F016] redirect_missing_location_header_returns_error


### PR DESCRIPTION
Closes #145.

## 概要

`src/fetch.rs:download` の `FetchError::TooManyRedirects` 直前に structured warn を発火し、caller 環境で `RUST_LOG=scout=warn` 経由で empirical retry-success rate を sample できる足場を実装。

ADR-0011 priority 2 (DataError) → priority 4 (TempFailure) への flip 判定は別 issue #148 に分割。本 PR は **観測フェーズのみ**。

## 変更内容

- `src/fetch.rs:download` cap exceeded path に `warn!("redirect cap exceeded", redirect_chain_length, max_redirects, final_url)` を追加 (URL は `RedactedLogUrl` でマスク)。
- ADR 参照と calibration rationale は `// CALIBRATION (issue #145 / #148 follow-up)` コメントに集約。
- `T-F056 redirect_cap_exceeded_emits_calibration_warn` で 4 つの structured field 存在を `tracing_test::logs_contain` で pin。

## レビュー

`/polish` 実行:

- simplify (3 sub-agents): reuse 0、quality 2 medium fixed (warn message から ADR narrative を comment へ / `chain_length` 命名)、efficiency 2 low (cold path のため skip)
- coderabbit committed: 0 findings
- gemini cross-family: 0 findings (Critical/Major)
- codex: usage limit (May 24 まで)

## テスト

- [x] `cargo test --all-features` (411 lib + 11 cli passed、T-F056 含む)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] cold path のみ追加、behavior 不変

## Follow-up

- issue #148: N ≥ 30 件 sample 後の retry success rate 判定 → DataError(65) 維持 or TempFailure(75) flip