### PR TITLE
docs(errors): TooManyRedirects の DataError 分類を first-principles で確定 (issue #148)

### DIFF
--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -244,12 +244,14 @@ impl From<FetchError> for ScoutError {
             FetchError::TooLarge => {
                 Self::data_error(e.to_string()).with_next_step("fetch a smaller resource")
             }
-            // Classified as DataError (terminal) per priority 2: redirect chain
-            // shape is treated as caller-fixable URL config. CDN A/B test glitches
-            // or eventual-consistency redirects could be transient; pending
-            // empirical retry-success data, keep the terminal classification —
-            // flipping to TempFailure(75) requires measuring real-world retry
-            // success rate first.
+            // Classified as DataError (terminal) per priority 2. cap=5 absorbs
+            // canonical chains (HTTPS upgrade → trailing slash → final URL);
+            // breach dominantly indicates a server-side redirect loop or caller
+            // URL config mistake, both caller-fixable. Retry success rate is
+            // unobservable from inside scout (single-shot CLI with no
+            // caller-side telemetry seam), so the empirical calibration scoped
+            // in issue #148 cannot be run — terminal classification confirmed
+            // by first principles, not deferred.
             FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
                 .with_next_step("URL has too many redirects; check for a redirect loop"),
             // Status arms order specific HTTP codes before the 4xx / _ fallback;


### PR DESCRIPTION
## 概要

- issue #148 で予定していた empirical retry-success rate calibration は scout architecture では実行不能と判明 (single-shot CLI、caller-side telemetry seam なし)
- `src/tools/errors.rs:247-254` の inline comment を "pending empirical data" から first-principles 確定文に書き換え
- behavior 変更なし (comment-only update)

## 判断の根拠

- `MAX_REDIRECTS = 5` は canonical redirect chain (HTTPS upgrade → trailing slash → final URL) を吸収する想定で設定
- cap=5 breach は dominantly server-side redirect loop または caller URL config mistake (both caller-fixable) → ADR-0011 priority 2 (DataError) の精神に合致
- 理論的に CDN A/B test glitch 等の transient ケースは存在するが、scout 内で観測不能、caller fix > automated retry の方向性が outcome (一次ソース取得) に整合

## empirical calibration を諦めた理由

- issue #148 の前提条件 `N ≥ 30 sample` は single-user CLI では年単位の時間軸
- retry success rate は scout が `TooManyRedirects` を返した後に caller が retry した結果を観測する必要があり、scout 単体では measure 不能 (`src/retry.rs` の retry loop は HTTP-level reqwest::Error が対象、redirect cap 抵触は対象外)
- "pending data" 状態を放置するより、scout architecture を前提に first-principles で確定する方が読み手 (AI agent contributor) にとって明快

## Test plan

- [x] `cargo check` 通過
- [x] `cargo clippy --all-targets -- -D warnings` 通過
- comment-only change、behavior tests は変更不要

Closes #148