### PR TITLE
docs(readme): SCOUT_* チューニング変数 と repo-tree/repo-read の使用例追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -78,6 +78,17 @@ export SLACK_TOKEN="..."            # 任意: Slackパーマリンクを `fetch`
 
 `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` の順で認証されます。
 
+### チューニング
+
+ビルトインのタイムアウトとリトライ予算を上書きできます。不正な値はリクエストを送る前に終了コード64（使い方エラー）で失敗します。
+
+| 環境変数                      | デフォルト | 範囲   | 効果                                                                       |
+| ----------------------------- | ---------- | ------ | -------------------------------------------------------------------------- |
+| `SCOUT_FETCH_TIMEOUT_SECS`    | 95         | 1〜600 | `fetch` のURLごとの実時間予算                                              |
+| `SCOUT_RESEARCH_TIMEOUT_SECS` | 45         | 1〜600 | `research` の実時間予算                                                    |
+| `SCOUT_SLACK_TIMEOUT_SECS`    | 60         | 1〜600 | Slackパーマリンク `fetch` の実時間予算                                     |
+| `SCOUT_MAX_RETRIES`           | 2          | 0〜10  | 一時的なAPIエラー時のリトライ回数（初回試行に加算、`0` でリトライ無効）    |
+
 ### オプション: JSレンダリング（SPA対応）
 
 `fetch` はJS依存ページ（React、Next.js、Vue、Nuxt）を自動検出し、ヘッドレスChrome（CDP）でレンダリングします。Chrome/Chromiumのローカルインストールと `js-rendering` featureが必要です。
@@ -177,6 +188,11 @@ scout repo-tree denoland/deno --path cli/ --pattern "*.rs"
   ...
 ```
 
+```sh
+# タグ・ブランチ・コミットSHAを指定
+scout repo-tree denoland/deno --ref v2.0.0 --path cli/
+```
+
 | フラグ       | 説明                              |
 | ------------ | --------------------------------- |
 | `--ref`      | ブランチ、タグ、またはコミットSHA |
@@ -187,6 +203,11 @@ scout repo-tree denoland/deno --path cli/ --pattern "*.rs"
 
 ```sh
 scout repo-read facebook/react src/ReactElement.js --lines 1-50
+```
+
+```sh
+# UTF-8以外のファイルをエンコーディング指定で読む
+scout repo-read owner/repo legacy.txt --encoding shift_jis
 ```
 
 | フラグ        | 説明                                                                                                                                                                                                           |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ export SLACK_TOKEN="..."            # Optional: required for `fetch` on Slack pe
 
 `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` are all supported, in that order.
 
+### Tuning
+
+Override the built-in timeouts and retry budget. Invalid values fail with exit 64 (usage error) before any request is made.
+
+| Env var                       | Default | Range | Effect                                                                                |
+| ----------------------------- | ------- | ----- | ------------------------------------------------------------------------------------- |
+| `SCOUT_FETCH_TIMEOUT_SECS`    | 95      | 1–600 | Per-URL wall-clock budget for `fetch`                                                 |
+| `SCOUT_RESEARCH_TIMEOUT_SECS` | 45      | 1–600 | Wall-clock budget for `research`                                                      |
+| `SCOUT_SLACK_TIMEOUT_SECS`    | 60      | 1–600 | Wall-clock budget for Slack permalink `fetch`                                         |
+| `SCOUT_MAX_RETRIES`           | 2       | 0–10  | Retries on transient API failures, on top of the initial attempt (`0` disables retry) |
+
 ### Optional: JS rendering (for SPAs)
 
 `fetch` auto-detects JS-dependent pages (React, Next.js, Vue, Nuxt) and falls back to headless Chrome via CDP. Requires Chrome or Chromium installed locally and the `js-rendering` feature:
@@ -187,6 +198,11 @@ scout repo-tree denoland/deno --path cli/ --pattern "*.rs"
   ...
 ```
 
+```sh
+# Pin to a tag, branch, or commit SHA
+scout repo-tree denoland/deno --ref v2.0.0 --path cli/
+```
+
 | Flag         | Description                |
 | ------------ | -------------------------- |
 | `--ref`      | Branch, tag, or commit SHA |
@@ -197,6 +213,11 @@ scout repo-tree denoland/deno --path cli/ --pattern "*.rs"
 
 ```sh
 scout repo-read facebook/react src/ReactElement.js --lines 1-50
+```
+
+```sh
+# Read a non-UTF-8 file by explicit encoding
+scout repo-read owner/repo legacy.txt --encoding shift_jis
 ```
 
 | Flag          | Description                                                                                                                                                                                                                                      |


### PR DESCRIPTION
## 概要

`scout --help` (`src/lib.rs:60-87`) と README の drift を埋める doc 同期 PR。実装変更なし。

## 検出された drift (Explore 結果)

| # | 種別 | 場所 | 内容 |
|---|------|------|------|
| 1 | **CRITICAL** | README.md / README.ja.md | `SCOUT_FETCH_TIMEOUT_SECS` / `SCOUT_RESEARCH_TIMEOUT_SECS` / `SCOUT_SLACK_TIMEOUT_SECS` / `SCOUT_MAX_RETRIES` が `--help` には記載されているのに README には 0 mentions |
| 2 | LOW | repo-tree | `--ref` flag は table 記載のみで使用例なし |
| 3 | LOW | repo-read | `--encoding` flag は table 記載のみで使用例なし |

`A. README に書いてあるが実装に存在しない` カテゴリは 0 件 (実装側の rename / removal は README に反映済)。

## 変更内容

- 両 README の `Environment` セクション直後に `Tuning` セクションを追加 (4 変数 × デフォルト/範囲/効果の table)
- repo-tree セクションに `--ref v2.0.0 --path cli/` の最小例を追加
- repo-read セクションに `--encoding shift_jis` の最小例を追加
- 英日対称な構造で +21 行ずつ

## なぜ Tuning が critical 扱いか

`src/lib.rs:350-371` の test T-H001 (`root_help_lists_scout_tuning_env_vars`) が「`scout --help` にこれら 4 変数が現れること」を必須 assert しており、`--help` 経由での発見性は意図的に保証されている。一方 README は未記載で、AI agent が README しか読まない場合に存在を発見できない状態だった (memory rule: user-visible outputs avoid internal refs と並ぶ「user-visible outputs に必要な情報が落ちない」観点)。

## 検証

- [x] `cargo test --lib`: 406 passed (T-H001 含む)
- [x] `cargo check` 通過
- behavior 変更なし、test 追加 / 更新は不要