### PR TITLE
fix(fetch): CDP cleanup 失敗を warn ログで surface する

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -517,8 +517,19 @@ async fn fetch_with_cdp(
     };
 
     // Drive the CDP graceful close first so chromium runs its own teardown
-    // sequence (flush IPC, write profile state, etc).
-    let _ = timeout(Duration::from_secs(5), browser.close()).await;
+    // sequence (flush IPC, write profile state, etc). Surface both arms:
+    // an `Err` from close() means CDP refused the teardown, an `Elapsed`
+    // means chromium hung past the budget; either way `reap_pgroup` below
+    // will SIGTERM/SIGKILL but operators need to see why the graceful path
+    // failed (issue #152).
+    match timeout(Duration::from_secs(5), browser.close()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => warn!(error = ?e, "CDP browser.close() returned error"),
+        Err(_) => warn!(
+            timeout_secs = 5,
+            "CDP browser.close() exceeded timeout; falling back to reap_pgroup"
+        ),
+    }
     handler_task.abort();
     match handler_task.await {
         Ok(()) => {}
@@ -641,7 +652,20 @@ async fn reap_pgroup(pgid: Pid, child: &mut TokioChild) {
             warn!(error = %e, pgid = %pgid, "killpg SIGKILL failed");
         }
     }
-    let _ = timeout(Duration::from_secs(2), child.wait()).await;
+    // Reap so the kernel can release the parent slot. `Ok(Err)` means waitpid
+    // itself failed (rare; e.g. ECHILD if a prior wait already reaped); `Err`
+    // means the 2s budget elapsed before chromium exited, which is the zombie
+    // path scout must surface so SHUTDOWN_DRAIN_TIMEOUT calibration stays
+    // honest (issue #152).
+    match timeout(Duration::from_secs(2), child.wait()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => warn!(error = %e, pgid = %pgid, "chromium child.wait() failed during reap"),
+        Err(_) => warn!(
+            timeout_secs = 2,
+            pgid = %pgid,
+            "chromium child did not exit within timeout after SIGKILL"
+        ),
+    }
 }
 
 /// Borrows browser so the caller retains ownership for cleanup on timeout.


### PR DESCRIPTION
## 概要

- `src/fetch.rs:521` の `browser.close()` と `src/fetch.rs:644` の `child.wait()` 結果が `let _` で破棄されていたのを `match` で受けるよう変更
- inner `Err` (CDP teardown 拒否 / waitpid 失敗) と outer `Elapsed` (chromium が予算超え) を区別して構造化 warn を出力
- SHUTDOWN_DRAIN_TIMEOUT (#121) のキャリブレーションを正確にするため、orphan/zombie 経路を運用者に surface

Closes #152

## テスト計画

- [x] `cargo check --features js-rendering` clean
- [x] `cargo clippy --all-targets --features js-rendering --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` 417/417 pass (default features; cleanup paths are behind `js-rendering` feature)
- [ ] 手動: `--js` 経路を chromium 異常終了シナリオで動かして warn が出るかは future work (CDP cleanup 失敗の simulate は wiremock では難しい)

## 解消する findings

audit 2026-05-20:

- SIL-001 (critical) — `let _ = browser.close()`
- SIL-002 (high) — `let _ = child.wait()`
- RC-003 (high) — cleanup 経路のエラー surfacing 規約欠如のうち、上記 2 箇所

RC-003 のうち SIL-004 (`let _ = cancel.send(true)`) は別途 dismiss 済 (tokio watch::Sender の 0-receiver は shutdown 経路で期待される正常パターン)。