### PR TITLE
test(github): PerPage::new の境界値保持を assert

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -511,11 +511,11 @@ mod http_tests {
         assert!(matches!(result, Err(GitHubError::RateLimited { .. })));
     }
 
-    /// [T-GH011a] PerPage::new accepts boundary values 1 and 100
+    /// [T-GH011a] PerPage::new preserves boundary values 1 and 100 through Display.
     #[test]
-    fn per_page_new_accepts_boundary_values() {
-        let _low = super::PerPage::new(1);
-        let _high = super::PerPage::new(100);
+    fn per_page_new_preserves_boundary_values() {
+        assert_eq!(super::PerPage::new(1).to_string(), "1");
+        assert_eq!(super::PerPage::new(100).to_string(), "100");
     }
 
     /// [T-GH011b] PerPage::new panics on 0 (ADR-0004 Rule 2; 0 is


### PR DESCRIPTION
## 概要

`per_page_new_preserves_boundary_values` テスト (`src/github.rs:514-518`) は `PerPage::new(1)` / `PerPage::new(100)` を呼ぶだけで assertion 無しだった。実装が `PerPage(50)` を常に返すよう壊れても通過する no-assert tautology。

`Display` impl 経由 (PerPage の唯一の public read 経路) で内部値を assert するよう変更。同時にテスト名を `accepts_boundary_values` → `preserves_boundary_values` に rename して、assertion 内容 (round-trip 保持) と整合させた。

Closes #156

## テスト計画

- [x] `cargo test per_page_new_preserves` — pass
- [x] `cargo test` 417/417 pass
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `/polish` (simplify + Codex + CodeRabbit + Gemini) 完了。実体 0 件、可読性 3 件のうち 2 件適用 (コメント・命名)、1 件 drop

## 解消する findings

audit 2026-05-20: COV-001 (high, test/no-assert)

## 関連 pattern

`src/signals.rs:92,99` の `InterruptSignal::Sigint.to_string() == "SIGINT"` と同じ pattern。`PartialEq` を持たない newtype の Display 経由 assertion はクレート内既存スタイル。