### PR TITLE
test(ssrf): CGN 範囲 (100.64.0.0/10) の fence-post 両端を assert

### DIFF
--- a/src/fetch/ssrf.rs
+++ b/src/fetch/ssrf.rs
@@ -245,6 +245,25 @@ mod tests {
             );
         }
     }
+
+    /// [T-FS012] validate_url_allows_cgn_boundary_neighbors
+    ///
+    /// CGN block is 100.64.0.0/10 (100.64.0.0–100.127.255.255). T-FS003 covers
+    /// the inside of the range; this test guards the fence-post on both ends so
+    /// a one-octet shift in `is_cgn` cannot pass silently. The neighbors are
+    /// public IPs and must be allowed by `validate_url_sync` (DNS-free pre-check).
+    #[test]
+    fn validate_url_allows_cgn_boundary_neighbors() {
+        for url in [
+            "http://100.63.255.255/", // one below CGN start (100.64.0.0)
+            "http://100.128.0.0/",    // one above CGN end (100.127.255.255)
+        ] {
+            assert!(
+                validate_url_sync(url).is_ok(),
+                "should allow public IP outside CGN: {url}"
+            );
+        }
+    }
 }
 
 /// Resolver test double returning a fixed IP list.


### PR DESCRIPTION
## 概要

T-FS003 (`validate_url_rejects_internal_hosts`) は CGN 範囲 100.64.0.0/10 の **内側** (`100.64.0.1`, `100.127.255.254`) を block 検証しているが、範囲の **外側** で allow されるべき IP のテストが無かった。`is_cgn` の比較を `(63..=127)` や `(64..=128)` に書き換える one-octet mutation が起きても T-FS003 は通過するため、`is_cgn` の境界が silently 緩む / 狭まる経路に検知装置が無い。

T-FS012 (`validate_url_allows_cgn_boundary_neighbors`) を追加し、CGN 範囲のすぐ外側の `100.63.255.255` (下側) と `100.128.0.0` (上側) が public IP として `validate_url_sync` で allow されることを assert。

Closes #157

## テスト計画

- [x] `cargo test validate_url_allows_cgn_boundary_neighbors` — pass
- [x] `cargo test` 418/418 pass
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `/polish` (simplify + Codex + CodeRabbit + Gemini) — quality 1 件 (`is_cgn` literal の二重メンテ回避) 適用、他はクリーン

## 解消する findings

audit 2026-05-20:

- COV-002 (high, test/edge-missing) — `100.63.255.255` 未網羅
- COV-003 (high, test/edge-missing) — `100.128.0.0` 未網羅

## 参照

- RFC 6598 (CGN 100.64.0.0/10)
- audit snapshot: `~/.claude/workspace/history/audit-2026-05-20-034649.json`