### PR TITLE
refactor(test_support): no_redirect_client() の重複定義を統合

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1031,14 +1031,9 @@ mod content_type_tests {
 #[cfg(test)]
 mod download_tests {
     use super::*;
-    use crate::test_support::try_spawn_mock_server;
-    use reqwest::redirect::Policy;
+    use crate::test_support::{no_redirect_client, try_spawn_mock_server};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
-
-    fn no_redirect_client() -> Client {
-        Client::builder().redirect(Policy::none()).build().unwrap()
-    }
 
     fn validated(url: &str) -> ValidatedUrl {
         ValidatedUrl::for_test(url)
@@ -1320,14 +1315,9 @@ mod download_tests {
 #[cfg(test)]
 mod fetch_page_tests {
     use super::*;
-    use crate::test_support::try_spawn_mock_server;
-    use reqwest::redirect::Policy;
+    use crate::test_support::{no_redirect_client, try_spawn_mock_server};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
-
-    fn no_redirect_client() -> Client {
-        Client::builder().redirect(Policy::none()).build().unwrap()
-    }
 
     fn real_resolver() -> Arc<dyn DnsResolver> {
         Arc::new(TokioDnsResolver)

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,7 +5,16 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::{self, JoinHandle};
 
+use reqwest::Client;
+use reqwest::redirect::Policy;
 use wiremock::MockServer;
+
+/// Build a reqwest `Client` with redirects disabled. No connect or read
+/// timeouts are set; wrap calls in `tokio::time::timeout` if a bounded test
+/// is needed.
+pub(crate) fn no_redirect_client() -> Client {
+    Client::builder().redirect(Policy::none()).build().unwrap()
+}
 
 static NETWORK_SKIP_COUNT: AtomicUsize = AtomicUsize::new(0);
 


### PR DESCRIPTION
## 概要

`src/fetch.rs` 内の 2 つの `#[cfg(test)] mod` で `no_redirect_client()` が完全同一定義で重複していた:

- `download_tests` (L1039 of pre-change)
- `fetch_page_tests` (L1328 of pre-change)

両定義を `src/test_support.rs` の `pub(crate) fn no_redirect_client()` に集約し、各 module から `use crate::test_support::{no_redirect_client, try_spawn_mock_server};` で import する形に変更。両 module から不要になった `use reqwest::redirect::Policy;` も除去。

doc コメントには「timeouts を設定していないため bounded test が必要なら `tokio::time::timeout` で wrap せよ」という注意書きを添えた (本番 `build_default_clients()` は `CONNECT_TIMEOUT`/`HTTP_TIMEOUT` を持つので運用 posture と異なる)。

Closes #158

## テスト計画

- [x] `cargo test` 418/418 pass
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `/polish` — REU-001 (`pub`→`pub(crate)`), REU-002 (timeout 注記追加), QUAL-001 (doc trim) を適用、QUAL-002 (`///` → `//`) は既存スタイル統一済のため drop

## 解消する findings

audit 2026-05-20: DUP-001 (high, duplication/test-helpers)

RC-007 (`test_support.rs` の scope が server-spawn 限定) の縮小版。残る DUP-002 (`real_resolver`)、DUP-005 (Brave JSON fixture) は別 issue で扱う。