### PR TITLE
refactor(logging): retry/timeout/fallback イベントを LANG.md taxonomy に整合

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -149,7 +149,7 @@ pub(crate) async fn fetch_page(
         {
             match fetch_with_cdp(&final_url, Arc::clone(&resolver), cancel).await {
                 Ok(js_html) => {
-                    debug!("JS rendering succeeded via CDP");
+                    info!("JS rendering succeeded via CDP");
                     html = js_html;
                 }
                 Err(e) if opts.js => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,12 @@ pub async fn run() -> ExitCode {
         sig = wait_for_signal() => {
             tracing::info!(signal = %sig, "interrupted, draining for graceful close");
             let _ = cancel.send(true);
-            let _ = timeout(SHUTDOWN_DRAIN_TIMEOUT, &mut cmd_fut).await;
+            if timeout(SHUTDOWN_DRAIN_TIMEOUT, &mut cmd_fut).await.is_err() {
+                tracing::warn!(
+                    timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+                    "drain timed out; in-flight command was dropped before completion"
+                );
+            }
             Outcome::Interrupted(sig)
         }
     };

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,4 +1,5 @@
 use std::error::Error as _;
+use std::fmt;
 use std::future::Future;
 use std::io;
 use std::time::{Duration, UNIX_EPOCH};
@@ -6,7 +7,7 @@ use std::time::{Duration, UNIX_EPOCH};
 use reqwest::Error;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
 use tokio::time::sleep;
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::clock::Clock;
 use crate::rng::Rng;
@@ -76,6 +77,7 @@ async fn retry_with<T, E, F, Fut>(
 where
     F: Fn() -> Fut,
     Fut: Future<Output = Result<T, E>>,
+    E: fmt::Display,
 {
     let mut last_err = None;
     for attempt in 0..=max_retries {
@@ -84,9 +86,13 @@ where
             Err(e) if is_retriable(&e) => {
                 if attempt < max_retries {
                     let delay = delay_for(&e, attempt);
-                    debug!(
+                    // warn (not debug) because retries are recoverable anomalies;
+                    // the error field surfaces the underlying failure without
+                    // requiring RUST_LOG=debug.
+                    warn!(
                         attempt = attempt + 1,
                         delay_ms = u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                        error = %e,
                         "retrying after transient error"
                     );
                     sleep(delay).await;
@@ -155,6 +161,7 @@ pub(crate) async fn retry_with_rate_limit<T, E, F, Fut>(
 where
     F: Fn() -> Fut,
     Fut: Future<Output = Result<T, E>>,
+    E: fmt::Display,
 {
     retry_with(
         operation,

--- a/src/token_source.rs
+++ b/src/token_source.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use tokio::process::Command;
 use tokio::time::timeout;
-use tracing::info;
+use tracing::warn;
 
 use crate::redacted::Redacted;
 
@@ -65,19 +65,21 @@ where
     )
     .await
     .inspect_err(|_| {
-        info!(
-            "gh auth token timed out after {}s",
+        warn!(
+            "gh auth token timed out after {}s; falling back to unauthenticated",
             TOKEN_RESOLVE_TIMEOUT.as_secs()
         )
     })
     .ok()?
-    .inspect_err(|e| info!("gh auth token command failed: {e}"))
+    .inspect_err(
+        |e| warn!(error = %e, "gh auth token command failed; falling back to unauthenticated"),
+    )
     .ok()?;
 
     if !output.status.success() {
-        info!(
+        warn!(
             stderr = %String::from_utf8_lossy(&output.stderr).trim(),
-            "gh auth token failed"
+            "gh auth token failed; falling back to unauthenticated"
         );
         return None;
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -268,6 +268,11 @@ impl Scout {
         )
         .await
         .unwrap_or_else(|_| {
+            warn!(
+                url = %RedactedLogUrl(&url),
+                timeout_secs = fetch_timeout.as_secs(),
+                "fetch timed out"
+            );
             Err(FetchError::Timeout(format!(
                 "fetch timed out after {}s",
                 fetch_timeout.as_secs()
@@ -300,6 +305,12 @@ impl Scout {
         let output = timeout(slack_timeout, client.fetch_message(&slack_url))
             .await
             .unwrap_or_else(|_| {
+                warn!(
+                    workspace = %slack_url.workspace(),
+                    channel = %slack_url.channel(),
+                    timeout_secs = slack_timeout.as_secs(),
+                    "slack fetch timed out"
+                );
                 Err(SlackError::Timeout(format!(
                     "slack fetch timed out after {}s",
                     slack_timeout.as_secs()
@@ -359,6 +370,12 @@ impl Scout {
             }
             Ok(Err(e)) => return Err(e.into()),
             Err(_) => {
+                warn!(
+                    query = %query,
+                    depth = params.depth,
+                    timeout_secs = research_timeout.as_secs(),
+                    "research timed out"
+                );
                 return Err(ScoutError::timeout(format!(
                     "research timed out after {}s",
                     research_timeout.as_secs()


### PR DESCRIPTION
## 概要

scout の retry / timeout / 外部サブプロセス fallback が `debug!` / `info!` で記録されており、LANG.md の `warn!` 定義 (Recoverable anomaly: retry, fallback taken) と一致していなかった。default の info レベルでは retry storm も timeout も無音だったため、運用者が異常を default ログから検知できなかった。

audit 2026-05-20 で OPS-001/002/004/006/007/008/010/011 + SIL-005 として検出。RC-004 (log taxonomy 不在) の主要 5 sites を本 PR で解消。

## 変更内容

### retry.rs の変更

- `debug!` → `warn!` に格上げ + `error = %e` 構造化フィールド追加
- `retry_with` / `retry_with_rate_limit` に `E: fmt::Display` bound 追加 (全 caller BraveError/GitHubError/SlackError/MockErr は既に Display 実装済)

### token_source.rs の変更

- `gh auth token` の timeout / command error / non-zero exit の 3 site を `info!` → `warn!` に格上げ
- 全 site に「; falling back to unauthenticated」suffix を追加して fallback 経路を明示
- command-failure site に `error = %e` 構造化フィールド追加

### lib.rs の変更

- `SHUTDOWN_DRAIN_TIMEOUT` 満了時に `warn!(timeout_secs = ...)` を追加 (従来は `let _` で破棄、clean drain と forced drop が区別不能)

### tools.rs の変更

- fetch / slack / research の各 timeout 経路に、`*Timeout` error variant にマップする前段で `warn!` を追加
- field set は domain 固有 (fetch: url、slack: workspace+channel、research: query+depth)

### fetch.rs の変更

- JS rendering 成功 (CDP fallback) の `debug!` を `info!` に格上げ
- CDP fallback 比率を default レベルで観測可能に

Closes #154

## テスト計画

- [x] `cargo test` 418/418 pass
- [x] `cargo check --features js-rendering` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo clippy --all-targets --features js-rendering --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `/polish` — quality 3 件 (comment 圧縮 + field 命名統一を適用、token_source suffix 重複は operator 視認性のため drop)、他 reviewer 0 件

## 解消する findings

audit 2026-05-20:

- OPS-001 (high) — retry log debug → warn
- OPS-002 (high) — retry log に error field 追加
- OPS-004 (medium) — gh auth token info → warn
- OPS-006 (medium) — research timeout 経路の前置 warn
- OPS-007 (medium) — fetch timeout 経路の前置 warn
- OPS-008 (medium) — slack timeout 経路の前置 warn
- OPS-010 (medium) — SHUTDOWN_DRAIN_TIMEOUT 満了 log
- OPS-011 (medium) — JS rendering 成功 info-level
- SIL-005 (medium) — gh auth token 警告 level (OPS-004 と同義)

## スコープ外 (別 issue で扱う)

- OPS-003 — Brave search の info-level dispatch event (level 変更だけでなく per-request frequency の設計判断が必要)
- OPS-005 — `RuntimeConfig::from_env` の SCOUT_* override 適用 surface (default との比較ロジックが必要)