### PR TITLE
feat(resource): stdin / Slack replies / users.info に並行・量・時間の上限を導入

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 
-use futures::future::join_all;
+use futures::stream::{self, StreamExt};
 use reqwest::Client;
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
@@ -172,6 +172,19 @@ pub(crate) struct SlackClient {
 
 const API_BASE: &str = "https://slack.com/api";
 
+/// Cap for `conversations.replies` page size. Slack's default is undocumented
+/// and threads can grow into the thousands on incident channels; making the
+/// limit explicit bounds the JSON payload that `api_get_once` buffers in
+/// memory (issue #155 / CHX-005).
+const SLACK_REPLIES_LIMIT: &str = "200";
+
+/// Concurrent in-flight `users.info` requests during `prefetch_users`.
+/// Slack Tier-4 allows ~50 req/min; capping at 5 keeps the burst well below
+/// that even for threads with hundreds of unique participants, instead of
+/// firing every request simultaneously and tripping the per-minute cap
+/// (issue #155 / OPS-009 / CHX-001).
+const SLACK_USERS_CONCURRENCY: usize = 5;
+
 impl SlackClient {
     pub fn new(http: Client, token: Redacted, max_retries: u32) -> Self {
         Self {
@@ -330,17 +343,21 @@ impl SlackClient {
         }
     }
 
-    /// Slack `users.info` per-ID fetch via `join_all`.
-    ///
-    /// No concurrency cap because Slack Tier-4 allows 50+ req/min and a single
-    /// thread rarely has more than ~20 unique users. Sustained violation would
-    /// require a thread with hundreds of participants. If that becomes a real
-    /// case, switch to `buffer_unordered` with an explicit cap.
+    /// Slack `users.info` per-ID fetch capped at `SLACK_USERS_CONCURRENCY`
+    /// concurrent requests via `buffer_unordered`. The cap bounds the burst
+    /// rate so a thread with hundreds of participants cannot fire that many
+    /// simultaneous requests and trip Slack's per-minute rate limit. Matches
+    /// the same idiom used in `search/engine.rs::fetch_sources`.
     async fn prefetch_users(&self, ids: &HashSet<String>) -> HashMap<String, String> {
-        let ids: Vec<String> = ids.iter().cloned().collect();
-        let futs = ids.iter().map(|id| self.fetch_user_name(id));
-        let results = join_all(futs).await;
-        ids.into_iter().zip(results).collect()
+        let id_list: Vec<String> = ids.iter().cloned().collect();
+        stream::iter(id_list)
+            .map(|id| async move {
+                let name = self.fetch_user_name(&id).await;
+                (id, name)
+            })
+            .buffer_unordered(SLACK_USERS_CONCURRENCY)
+            .collect()
+            .await
     }
 
     async fn fetch_thread(&self, slack_url: &SlackUrl) -> Result<FetchedThread, SlackError> {
@@ -349,7 +366,11 @@ impl SlackClient {
             let body: MessagesBody = self
                 .api_get(
                     "conversations.replies",
-                    &[("channel", ch), ("ts", thread_ts)],
+                    &[
+                        ("channel", ch),
+                        ("ts", thread_ts),
+                        ("limit", SLACK_REPLIES_LIMIT),
+                    ],
                 )
                 .await?;
             return Ok(FetchedThread {
@@ -377,7 +398,11 @@ impl SlackClient {
             let thread: MessagesBody = self
                 .api_get(
                     "conversations.replies",
-                    &[("channel", ch), ("ts", &slack_url.ts)],
+                    &[
+                        ("channel", ch),
+                        ("ts", &slack_url.ts),
+                        ("limit", SLACK_REPLIES_LIMIT),
+                    ],
                 )
                 .await?;
             Ok(FetchedThread {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -41,17 +41,32 @@ use crate::slack::{SlackClient, SlackError, SlackUrl, parse_slack_url};
 use crate::token_source::{GhCliSource, TokenSource};
 
 const MAX_STDIN_BYTES: u64 = 1_048_576;
+/// Upper bound for waiting on piped input. Without this, a stalled or
+/// half-closed pipe (upstream writer hung mid-stream) would block scout
+/// indefinitely with no log output (issue #155 / CHX-006).
+const STDIN_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 async fn read_stdin(needs_stdin: bool) -> Result<Option<String>, ScoutError> {
     if !needs_stdin {
         return Ok(None);
     }
     let mut buf = String::new();
-    tokio_stdin()
-        .take(MAX_STDIN_BYTES)
-        .read_to_string(&mut buf)
-        .await
-        .map_err(|e| ScoutError::user_error(format!("Failed to read stdin: {e}")))?;
+    timeout(
+        STDIN_READ_TIMEOUT,
+        tokio_stdin().take(MAX_STDIN_BYTES).read_to_string(&mut buf),
+    )
+    .await
+    .map_err(|_| {
+        warn!(
+            timeout_secs = STDIN_READ_TIMEOUT.as_secs(),
+            "stdin read timed out"
+        );
+        ScoutError::user_error(format!(
+            "stdin read timed out after {}s; upstream writer may be stalled",
+            STDIN_READ_TIMEOUT.as_secs()
+        ))
+    })?
+    .map_err(|e| ScoutError::user_error(format!("Failed to read stdin: {e}")))?;
     let trimmed = buf.trim();
     Ok(if trimmed.is_empty() {
         None


### PR DESCRIPTION
## 概要

scout の I/O 取得点で 3 つの resource budget が欠落していたのを補う:

1. **stdin read timeout** — `read_stdin` を `tokio::time::timeout(STDIN_READ_TIMEOUT=30s, ...)` でラップ。stalled pipe (upstream の writer が hang) に対して scout が無限待機しないようにする。満了時は warn ログ + UsageError。
2. **`conversations.replies` の `limit=200`** — Slack の default page size は仕様上不定。明示することで `api_get_once` が deserialize 前に buffer する JSON サイズを bounded にする。
3. **`prefetch_users` 並行上限** — Slack `users.info` を `buffer_unordered(SLACK_USERS_CONCURRENCY=5)` で capping。`search/engine.rs::fetch_sources` と同じ idiom。Tier-4 (~50 req/min) に対し 5 concurrent は余裕の範囲。100+ 参加者のスレッドでも rate limit cascade を回避できる。

Closes #155

## テスト計画

- [x] `cargo test` 418/418 pass
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `/polish` — reuse 1 件 (buffer_unordered パターン採用) 適用、quality 2 件は drop または REU-001 で消滅、他クリーン

## 解消する findings

audit 2026-05-20:

- OPS-009 (high) — prefetch_users 並行上限なし
- CHX-001 (high, needs_review→confirmed) — OPS-009 と同じ事象
- CHX-005 (medium) — conversations.replies に limit なし
- CHX-006 (medium) — stdin read に timeout なし

## スコープ外 (別 issue を起票)

audit の CHX-008 (Brave body size cap) / CHX-009 (Slack body size cap) は `.bytes()` / `.json()` を chunked streaming に書き換える必要があり、本 PR とは別の refactor になる。severity は low なので別途切り出して follow-up とする。

## 関連 idiom

`prefetch_users` の書き換えは `search/engine.rs:72-96` の `stream::iter(...).map(|...|...).buffer_unordered(N).collect().await` と同じ pattern。