### PR TITLE
refactor(http-client): BraveClient/SlackClient に Clock/Rng 注入 seam を追加

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -1,17 +1,19 @@
 use std::env;
+use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::Client;
 use tracing::{debug, warn};
 
-use crate::clock::SystemClock;
+use crate::clock::{Clock, SystemClock};
 use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
     is_transient_network, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
-use crate::rng::FastrandRng;
+use crate::rng::{FastrandRng, Rng};
 
 use super::types::{SearchResult, WebSearchResponse};
 
@@ -79,17 +81,37 @@ pub(crate) trait SearchClient {
     ) -> Result<Vec<SearchResult>, BraveError>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct BraveClient {
     http: Client,
     api_key: Redacted,
     base_url: String,
     max_retries: u32,
+    /// Wall-clock source for `secs_until_ratelimit_reset` / Retry-After
+    /// arithmetic. Set at construction and read on every retry; defaults to
+    /// `SystemClock`. Mirrors `GitHubClient`'s injection seam.
+    clock: Arc<dyn Clock>,
+    /// Backoff jitter source handed to `retry_with_rate_limit` per attempt.
+    /// Set at construction; defaults to `FastrandRng`.
+    rng: Arc<dyn Rng>,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `send_request` always
     /// runs `validate_https`; only `with_base_url` opts in.
     #[cfg(test)]
     skip_https_check: bool,
+}
+
+// Manual Debug because `clock` and `rng` are `dyn Trait` without Debug
+// bounds. `api_key` is intentionally not exposed so accidental `{client:?}`
+// in logs cannot leak the Brave secret.
+impl fmt::Debug for BraveClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BraveClient")
+            .field("base_url", &self.base_url)
+            .field("max_retries", &self.max_retries)
+            .field("api_key", &"<redacted>")
+            .finish_non_exhaustive()
+    }
 }
 
 impl BraveClient {
@@ -115,6 +137,8 @@ impl BraveClient {
             api_key,
             base_url: API_BASE.to_owned(),
             max_retries,
+            clock: Arc::new(SystemClock),
+            rng: Arc::new(FastrandRng),
             #[cfg(test)]
             skip_https_check: false,
         })
@@ -127,8 +151,20 @@ impl BraveClient {
             api_key: Redacted::new("test-key").expect("static literal is non-empty"),
             base_url: base_url.to_owned(),
             max_retries: DEFAULT_MAX_RETRIES,
+            clock: Arc::new(SystemClock),
+            rng: Arc::new(FastrandRng),
             skip_https_check: true,
         }
+    }
+
+    pub(crate) fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    pub(crate) fn with_rng(mut self, rng: Arc<dyn Rng>) -> Self {
+        self.rng = rng;
+        self
     }
 
     /// Test-only override of the production HTTPS gate. See [`validate_https`].
@@ -163,7 +199,7 @@ impl BraveClient {
             .send()
             .await?;
 
-        let response = classify_response(response).await?;
+        let response = classify_response(response, self.clock.as_ref()).await?;
         let bytes = response.bytes().await?;
         let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
 
@@ -191,10 +227,13 @@ fn build_url(
     Ok(reqwest::Url::parse_with_params(base_url, &params)?)
 }
 
-async fn classify_response(response: reqwest::Response) -> Result<reqwest::Response, BraveError> {
+async fn classify_response(
+    response: reqwest::Response,
+    clock: &dyn Clock,
+) -> Result<reqwest::Response, BraveError> {
     let status = response.status();
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        let retry_after = parse_retry_after(response.headers(), &SystemClock);
+        let retry_after = parse_retry_after(response.headers(), clock);
         warn!(retry_after_secs = retry_after, "Brave API rate limited");
         return Err(BraveError::RateLimited { retry_after });
     }
@@ -249,7 +288,7 @@ impl SearchClient for BraveClient {
                 _ => None,
             },
             || BraveError::RateLimited { retry_after: None },
-            &FastrandRng,
+            self.rng.as_ref(),
         )
         .await?;
         Ok(response.into_results())
@@ -564,6 +603,35 @@ mod http_tests {
         assert!(
             !client.skip_https_check,
             "production constructor must not skip HTTPS check"
+        );
+    }
+
+    /// [T-BC-CLK001] `BraveClient::with_clock` installs the supplied Arc into
+    /// `BraveClient.clock`. Mirrors `T-SB001` for ScoutBuilder. Guards against
+    /// silent drop of the injected clock in a future refactor.
+    #[test]
+    fn with_clock_installs_supplied_arc() {
+        use crate::clock::FixedClock;
+        let injected: Arc<dyn Clock> = Arc::new(FixedClock(42));
+        let client = BraveClient::with_base_url(Client::new(), "http://test.local")
+            .with_clock(injected.clone());
+        assert!(
+            Arc::ptr_eq(&client.clock, &injected),
+            "with_clock must install the supplied Arc into BraveClient.clock"
+        );
+    }
+
+    /// [T-BC-RNG001] `BraveClient::with_rng` installs the supplied Arc into
+    /// `BraveClient.rng`.
+    #[test]
+    fn with_rng_installs_supplied_arc() {
+        use crate::rng::SeededRng;
+        let injected: Arc<dyn Rng> = Arc::new(SeededRng::new(7));
+        let client = BraveClient::with_base_url(Client::new(), "http://test.local")
+            .with_rng(injected.clone());
+        assert!(
+            Arc::ptr_eq(&client.rng, &injected),
+            "with_rng must install the supplied Arc into BraveClient.rng"
         );
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
+use std::sync::Arc;
 
 use futures::stream::{self, StreamExt};
 use reqwest::Client;
@@ -7,7 +8,7 @@ use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use tracing::{debug, info, warn};
 
-use crate::clock::SystemClock;
+use crate::clock::{Clock, SystemClock};
 use crate::fetch::converter::escape_yaml;
 use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
@@ -15,7 +16,7 @@ use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
     is_schema_decode_fail, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
-use crate::rng::FastrandRng;
+use crate::rng::{FastrandRng, Rng};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SlackError {
@@ -163,6 +164,13 @@ pub(crate) struct SlackClient {
     token: Redacted,
     base_url: String,
     max_retries: u32,
+    /// Wall-clock source for `parse_retry_after`. Set at construction and
+    /// read on every Slack 429; defaults to `SystemClock`. Mirrors
+    /// `GitHubClient`'s injection seam.
+    clock: Arc<dyn Clock>,
+    /// Backoff jitter source handed to `retry_with_rate_limit` per attempt.
+    /// Set at construction; defaults to `FastrandRng`.
+    rng: Arc<dyn Rng>,
     /// Test-only escape hatch for wiremock servers on `http://127.0.0.1`.
     /// Production constructors leave this `false` so `api_get_once` always
     /// runs `validate_https`; only `with_base_url` opts in.
@@ -192,6 +200,8 @@ impl SlackClient {
             token,
             base_url: API_BASE.to_owned(),
             max_retries,
+            clock: Arc::new(SystemClock),
+            rng: Arc::new(FastrandRng),
             #[cfg(test)]
             skip_https_check: false,
         }
@@ -210,8 +220,20 @@ impl SlackClient {
             token: Redacted::new("xoxp-test").expect("static literal is non-empty"),
             base_url: base_url.to_owned(),
             max_retries: DEFAULT_MAX_RETRIES,
+            clock: Arc::new(SystemClock),
+            rng: Arc::new(FastrandRng),
             skip_https_check: true,
         }
+    }
+
+    pub(crate) fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    pub(crate) fn with_rng(mut self, rng: Arc<dyn Rng>) -> Self {
+        self.rng = rng;
+        self
     }
 
     /// Test-only override of the production HTTPS gate. See [`validate_https`].
@@ -240,7 +262,7 @@ impl SlackClient {
                 _ => None,
             },
             || SlackError::RateLimited { retry_after: None },
-            &FastrandRng,
+            self.rng.as_ref(),
         )
         .await
     }
@@ -268,7 +290,7 @@ impl SlackClient {
             .await
             .map_err(|e| SlackError::Network(e.to_string()))?;
 
-        let retry_after = parse_retry_after(resp.headers(), &SystemClock);
+        let retry_after = parse_retry_after(resp.headers(), self.clock.as_ref());
 
         if resp.status() == 429 {
             warn!(retry_after_secs = retry_after, "Slack API rate limited");
@@ -1083,6 +1105,41 @@ parent body
             let resolved = resolve_messages(&messages, &users);
 
             assert_eq!(resolved[0].author, "UXXX");
+        }
+    }
+
+    mod injection_tests {
+        use super::*;
+        use reqwest::Client;
+
+        /// [T-SK-CLK001] `SlackClient::with_clock` installs the supplied Arc
+        /// into `SlackClient.clock`. Mirrors `T-SB001` for ScoutBuilder.
+        /// Guards against silent drop of the injected clock in a future
+        /// refactor of `api_get_once`.
+        #[test]
+        fn with_clock_installs_supplied_arc() {
+            use crate::clock::FixedClock;
+            let injected: Arc<dyn Clock> = Arc::new(FixedClock(42));
+            let client = SlackClient::with_base_url(Client::new(), "http://test.local")
+                .with_clock(injected.clone());
+            assert!(
+                Arc::ptr_eq(&client.clock, &injected),
+                "with_clock must install the supplied Arc into SlackClient.clock"
+            );
+        }
+
+        /// [T-SK-RNG001] `SlackClient::with_rng` installs the supplied Arc
+        /// into `SlackClient.rng`.
+        #[test]
+        fn with_rng_installs_supplied_arc() {
+            use crate::rng::SeededRng;
+            let injected: Arc<dyn Rng> = Arc::new(SeededRng::new(7));
+            let client = SlackClient::with_base_url(Client::new(), "http://test.local")
+                .with_rng(injected.clone());
+            assert!(
+                Arc::ptr_eq(&client.rng, &injected),
+                "with_rng must install the supplied Arc into SlackClient.rng"
+            );
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -315,7 +315,9 @@ impl Scout {
 
     async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<CommandOutput, ScoutError> {
         info!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), "fetch (slack)");
-        let client = SlackClient::from_env(self.http.clone(), self.config.max_retries)?;
+        let client = SlackClient::from_env(self.http.clone(), self.config.max_retries)?
+            .with_clock(self.clock.clone())
+            .with_rng(self.rng.clone());
         let slack_timeout = self.config.slack_timeout;
         let output = timeout(slack_timeout, client.fetch_message(&slack_url))
             .await
@@ -748,10 +750,13 @@ impl ScoutBuilder {
                     .with_rng(self.rng.clone()),
             );
         }
+        let brave = self
+            .brave
+            .map(|c| c.with_clock(self.clock.clone()).with_rng(self.rng.clone()));
         Scout {
             http: self.http,
             fetch_http: self.fetch_http,
-            brave: self.brave,
+            brave,
             github,
             cancel: self.cancel,
             config: self.config,


### PR DESCRIPTION
## 概要

GitHubClient は `clock: Arc<dyn Clock>` / `rng: Arc<dyn Rng>` フィールドと `with_clock` / `with_rng` setter を持ち、retry-after 算術と backoff jitter を `FixedClock` / `SeededRng` でテスト時に pin できる。一方 BraveClient と SlackClient は call site で `&SystemClock` / `&FastrandRng` を hardcode しており、同じ seam を持っていなかった。

本 PR で両 client に同じ pattern を適用し、ScoutBuilder / fetch_slack の production 経路から Scout の clock/rng を forward する。

Closes #153

## 変更内容

### BraveClient 側 (src/brave/client.rs)

- `clock` / `rng` フィールド + `with_clock` / `with_rng` setter を追加
- `from_env_with` / `with_base_url` の両コンストラクタで `SystemClock` / `FastrandRng` を default 初期化
- `classify_response` (free function) の signature に `clock: &dyn Clock` を追加し、`send_request` から `self.clock.as_ref()` を渡す
- `SearchClient::search` 内の `&FastrandRng` を `self.rng.as_ref()` に置換
- `dyn Clock` / `dyn Rng` が Debug を実装しないため `#[derive(Debug)]` を外し、`api_key` を `<redacted>` で固定値表示する手書き `Debug` 実装を追加
- T-BC-CLK001 / T-BC-RNG001: Arc::ptr_eq で setter の installation を検証する seam テストを追加

### SlackClient 側 (src/slack.rs)

- 同じパターン: `clock` / `rng` フィールド + setter + default 初期化
- `api_get` の `&FastrandRng` を `self.rng.as_ref()` に
- `api_get_once` の `&SystemClock` を `self.clock.as_ref()` に
- T-SK-CLK001 / T-SK-RNG001: 同様の Arc::ptr_eq seam テスト

### Scout 配線 (src/tools.rs)

- `ScoutBuilder::build` で `self.brave.map(|c| c.with_clock(self.clock.clone()).with_rng(self.rng.clone()))` を通して BraveClient に注入
- `Scout::fetch_slack` で `SlackClient::from_env(...).with_clock(self.clock.clone()).with_rng(self.rng.clone())` を chain して SlackClient に注入

## テスト計画

- [x] `cargo test` 422/422 pass (新 seam テスト 4 件追加: T-BC-CLK001/RNG001, T-SK-CLK001/RNG001)
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `/polish` — quality 2 件 (Debug api_key 意図明示、seam test 追加) を適用、reuse 2 件 informational のため drop、CodeRabbit 0、Codex/Gemini 一部 stub のため skip

## 解消する findings

audit 2026-05-20:

- TST-001 (medium) — slack api_get_once の hardcoded `&SystemClock`
- TST-002 (medium) — slack api_get の hardcoded `&FastrandRng`
- TST-003 (medium) — brave classify_response の hardcoded `&SystemClock`
- TST-004 (medium) — brave SearchClient::search の hardcoded `&FastrandRng`
- TST-014 (high, needs_review) — brave send_request の clock seam の不在
- REU-002 (medium) — brave clock 注入の pattern gap
- REU-003 (medium) — slack clock 注入の pattern gap
- REU-004 (medium) — slack rng 注入の pattern gap

RC-001 (高優先 RC) を完全解消。

## 関連 idiom

GitHubClient (src/github.rs:85-154) の clock/rng injection seam と同じ pattern。T-GH017 (tools.rs:1903 の `scout_builder_clock_reaches_github_client_via_seam`) が end-to-end の wiremock テストパターンを示している。本 PR では Arc::ptr_eq による minimum-proof seam テストに留め、wiremock 越しの end-to-end retry-after arithmetic テストは将来必要になれば追加する。