### PR TITLE
feat(http-client): Brave/Slack API response body に 1 MiB cap を導入

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -11,7 +11,8 @@ use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
-    is_transient_network, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
+    MAX_API_RESPONSE_BYTES, is_transient_network, parse_retry_after, retry_after_within_cap,
+    retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
 
@@ -38,6 +39,9 @@ pub(crate) enum BraveError {
     #[error("Failed to parse Brave API response: {0}")]
     ParseJson(#[from] serde_json::Error),
 
+    #[error("Brave API response too large (>{} bytes)", MAX_API_RESPONSE_BYTES)]
+    ResponseTooLarge,
+
     #[error("Invalid Brave API URL: {0}")]
     ParseUrl(#[from] url::ParseError),
 
@@ -56,13 +60,15 @@ impl BraveError {
     /// may legitimately surface as a degraded result instead of propagating.
     ///
     /// Configuration errors (`ApiKeyNotSet`, `Unauthorized`, `ParseUrl`,
-    /// `InsecureBaseUrl`), the scout-side invariant `ParseJson`, and 4xx `Api`
-    /// codes stay propagated — they require user action or signal a scout bug.
+    /// `InsecureBaseUrl`), the scout-side invariants `ParseJson` and
+    /// `ResponseTooLarge`, and 4xx `Api` codes stay propagated — they require
+    /// user action or signal a scout/upstream invariant violation.
     pub(crate) fn is_degradable(&self) -> bool {
         match self {
             Self::ApiKeyNotSet
             | Self::Unauthorized
             | Self::ParseJson(_)
+            | Self::ResponseTooLarge
             | Self::ParseUrl(_)
             | Self::InsecureBaseUrl => false,
             Self::Api { code, .. } if (400..500).contains(code) => false,
@@ -200,7 +206,7 @@ impl BraveClient {
             .await?;
 
         let response = classify_response(response, self.clock.as_ref()).await?;
-        let bytes = response.bytes().await?;
+        let bytes = read_body_capped(response).await?;
         let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
 
         debug!(
@@ -225,6 +231,34 @@ fn build_url(
         params.push(("search_lang", lang));
     }
     Ok(reqwest::Url::parse_with_params(base_url, &params)?)
+}
+
+/// Drain the response body into a Vec while enforcing `MAX_API_RESPONSE_BYTES`.
+/// Mirrors the `fetch.rs` pattern so a misbehaving Brave deployment cannot
+/// force scout to allocate unbounded memory (issue #165 / CHX-008).
+async fn read_body_capped(response: reqwest::Response) -> Result<Vec<u8>, BraveError> {
+    let content_length = response.content_length();
+    if let Some(len) = content_length
+        && usize::try_from(len).unwrap_or(usize::MAX) > MAX_API_RESPONSE_BYTES
+    {
+        return Err(BraveError::ResponseTooLarge);
+    }
+    let capacity = content_length
+        .map(|len| {
+            usize::try_from(len)
+                .unwrap_or(usize::MAX)
+                .min(MAX_API_RESPONSE_BYTES)
+        })
+        .unwrap_or(8192);
+    let mut body = Vec::with_capacity(capacity);
+    let mut stream = response;
+    while let Some(chunk) = stream.chunk().await? {
+        body.extend_from_slice(&chunk);
+        if body.len() > MAX_API_RESPONSE_BYTES {
+            return Err(BraveError::ResponseTooLarge);
+        }
+    }
+    Ok(body)
 }
 
 async fn classify_response(
@@ -300,6 +334,10 @@ fn is_retriable(e: &BraveError) -> bool {
         BraveError::RateLimited { retry_after } => retry_after_within_cap(*retry_after),
         BraveError::Server(_) => true,
         BraveError::Network(e) => is_transient_network(e),
+        // Oversized body is an upstream invariant violation (issue #165 /
+        // CHX-008), not transient. Explicit arm so a future variant
+        // addition cannot silently fall through to retriable=true.
+        BraveError::ResponseTooLarge => false,
         _ => false,
     }
 }
@@ -515,6 +553,34 @@ mod http_tests {
         assert!(
             matches!(result, Err(BraveError::Server(503))),
             "expected ServerError(503), got: {result:?}"
+        );
+    }
+
+    /// [T-BC-CAP001] (issue #165 / CHX-008)
+    /// Setup: wiremock returns a 2xx whose body exceeds `MAX_API_RESPONSE_BYTES`
+    /// (1 MiB), simulating an upstream Brave deployment returning unbounded
+    /// JSON.
+    /// Action: `client.search("foo", None)` is invoked.
+    /// Expected: returns `BraveError::ResponseTooLarge`; no retry (mock call
+    /// count = 1) because the variant is not retriable.
+    #[tokio::test]
+    async fn search_oversized_body_returns_too_large() {
+        let Some(server) = try_spawn_mock_server("brave::http").await else {
+            return;
+        };
+        // 1 MiB + 1 byte trips the cap regardless of pre-check vs chunk path.
+        let body = vec![b'x'; (1024 * 1024) + 1];
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = BraveClient::with_base_url(Client::new(), &server.uri());
+        let result = client.search("foo", None).await;
+        assert!(
+            matches!(result, Err(BraveError::ResponseTooLarge)),
+            "expected ResponseTooLarge, got: {result:?}"
         );
     }
 

--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -11,8 +11,8 @@ use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
-    MAX_API_RESPONSE_BYTES, is_transient_network, parse_retry_after, retry_after_within_cap,
-    retry_with_rate_limit,
+    MAX_API_RESPONSE_BYTES, is_transient_network, parse_retry_after, read_body_capped,
+    retry_after_within_cap, retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
 
@@ -206,7 +206,8 @@ impl BraveClient {
             .await?;
 
         let response = classify_response(response, self.clock.as_ref()).await?;
-        let bytes = read_body_capped(response).await?;
+        let bytes =
+            read_body_capped(response, || BraveError::ResponseTooLarge, BraveError::from).await?;
         let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
 
         debug!(
@@ -231,34 +232,6 @@ fn build_url(
         params.push(("search_lang", lang));
     }
     Ok(reqwest::Url::parse_with_params(base_url, &params)?)
-}
-
-/// Drain the response body into a Vec while enforcing `MAX_API_RESPONSE_BYTES`.
-/// Mirrors the `fetch.rs` pattern so a misbehaving Brave deployment cannot
-/// force scout to allocate unbounded memory (issue #165 / CHX-008).
-async fn read_body_capped(response: reqwest::Response) -> Result<Vec<u8>, BraveError> {
-    let content_length = response.content_length();
-    if let Some(len) = content_length
-        && usize::try_from(len).unwrap_or(usize::MAX) > MAX_API_RESPONSE_BYTES
-    {
-        return Err(BraveError::ResponseTooLarge);
-    }
-    let capacity = content_length
-        .map(|len| {
-            usize::try_from(len)
-                .unwrap_or(usize::MAX)
-                .min(MAX_API_RESPONSE_BYTES)
-        })
-        .unwrap_or(8192);
-    let mut body = Vec::with_capacity(capacity);
-    let mut stream = response;
-    while let Some(chunk) = stream.chunk().await? {
-        body.extend_from_slice(&chunk);
-        if body.len() > MAX_API_RESPONSE_BYTES {
-            return Err(BraveError::ResponseTooLarge);
-        }
-    }
-    Ok(body)
 }
 
 async fn classify_response(
@@ -335,8 +308,7 @@ fn is_retriable(e: &BraveError) -> bool {
         BraveError::Server(_) => true,
         BraveError::Network(e) => is_transient_network(e),
         // Oversized body is an upstream invariant violation (issue #165 /
-        // CHX-008), not transient. Explicit arm so a future variant
-        // addition cannot silently fall through to retriable=true.
+        // CHX-008), not transient — retry cannot shrink the response.
         BraveError::ResponseTooLarge => false,
         _ => false,
     }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -33,6 +33,40 @@ pub(crate) const DEFAULT_MAX_RETRIES: u32 = 2;
 /// not human pages.
 pub(crate) const MAX_API_RESPONSE_BYTES: usize = 1024 * 1024;
 
+/// Drain `response` into a `Vec<u8>` while enforcing `MAX_API_RESPONSE_BYTES`.
+/// Content-Length is pre-checked before any allocation; the chunk loop also
+/// rejects bodies that exceed the cap when the header is absent or lies.
+/// `fetch.rs` keeps its own copy because it interleaves charset and redirect
+/// handling around the same loop.
+pub(crate) async fn read_body_capped<E>(
+    response: reqwest::Response,
+    too_large: impl Fn() -> E,
+    network: impl Fn(reqwest::Error) -> E,
+) -> Result<Vec<u8>, E> {
+    let content_length = response.content_length();
+    if let Some(len) = content_length
+        && usize::try_from(len).unwrap_or(usize::MAX) > MAX_API_RESPONSE_BYTES
+    {
+        return Err(too_large());
+    }
+    let capacity = content_length
+        .map(|len| {
+            usize::try_from(len)
+                .unwrap_or(usize::MAX)
+                .min(MAX_API_RESPONSE_BYTES)
+        })
+        .unwrap_or(8192);
+    let mut body = Vec::with_capacity(capacity);
+    let mut stream = response;
+    while let Some(chunk) = stream.chunk().await.map_err(&network)? {
+        body.extend_from_slice(&chunk);
+        if body.len() > MAX_API_RESPONSE_BYTES {
+            return Err(too_large());
+        }
+    }
+    Ok(body)
+}
+
 pub(crate) fn jittered_backoff(attempt: u32, rng: &dyn Rng) -> u64 {
     let base = INITIAL_BACKOFF_MS.saturating_mul(2u64.saturating_pow(attempt));
     let half = base / 2;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -23,6 +23,16 @@ const MAX_RETRY_AFTER_SECS: u64 = 300;
 /// so `2` yields the 3-attempt budget that backends are tuned against.
 pub(crate) const DEFAULT_MAX_RETRIES: u32 = 2;
 
+/// Upper bound on JSON response body bytes accepted from Brave and Slack
+/// (issue #165 / CHX-008 / CHX-009). 1 MiB comfortably covers a
+/// `web/search` payload at Brave's `count=20` default and a Slack thread
+/// at `SLACK_REPLIES_LIMIT=200`; an oversized response cannot consume
+/// unbounded memory while the JSON parser allocates. `fetch.rs` keeps a
+/// separate `MAX_RESPONSE_BYTES = 10 MB` for HTML — the JSON cap is an
+/// order of magnitude smaller because API payloads are structured data,
+/// not human pages.
+pub(crate) const MAX_API_RESPONSE_BYTES: usize = 1024 * 1024;
+
 pub(crate) fn jittered_backoff(attempt: u32, rng: &dyn Rng) -> u64 {
     let base = INITIAL_BACKOFF_MS.saturating_mul(2u64.saturating_pow(attempt));
     let half = base / 2;

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -14,7 +14,7 @@ use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
-    is_schema_decode_fail, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
+    MAX_API_RESPONSE_BYTES, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
 
@@ -297,15 +297,12 @@ impl SlackClient {
             return Err(SlackError::RateLimited { retry_after });
         }
 
-        let body: serde_json::Value = resp.json().await.map_err(|e| {
-            // Schema fail → Decode (terminal). Transport drop → Network →
-            // retry loop. See `is_schema_decode_fail` (issue #113).
-            if is_schema_decode_fail(&e) {
-                SlackError::Decode(e.to_string())
-            } else {
-                SlackError::Network(e.to_string())
-            }
-        })?;
+        let bytes = read_body_capped(resp).await?;
+        // Schema fail → Decode (terminal). Transport drop happens before
+        // `from_slice` runs — `read_body_capped` surfaces it as Network so
+        // the retry loop sees it. See `is_schema_decode_fail` (issue #113).
+        let body: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| SlackError::Decode(e.to_string()))?;
 
         if body.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
             // ok:false with a missing `error` field is a Slack API contract
@@ -629,6 +626,45 @@ fn is_retriable(e: &SlackError) -> bool {
     }
 }
 
+/// Drain the response body into a Vec while enforcing `MAX_API_RESPONSE_BYTES`.
+/// Mid-stream drops surface as `SlackError::Network` (transient — retry loop
+/// picks them up); a cap breach surfaces as `SlackError::Decode` (terminal —
+/// Slack contract violation, retry will not recover). Mirrors the `fetch.rs`
+/// pattern so a misbehaving Slack workspace cannot force scout to allocate
+/// unbounded memory (issue #165 / CHX-009).
+async fn read_body_capped(response: reqwest::Response) -> Result<Vec<u8>, SlackError> {
+    let content_length = response.content_length();
+    if let Some(len) = content_length
+        && usize::try_from(len).unwrap_or(usize::MAX) > MAX_API_RESPONSE_BYTES
+    {
+        return Err(SlackError::Decode(format!(
+            "response too large (>{MAX_API_RESPONSE_BYTES} bytes)"
+        )));
+    }
+    let capacity = content_length
+        .map(|len| {
+            usize::try_from(len)
+                .unwrap_or(usize::MAX)
+                .min(MAX_API_RESPONSE_BYTES)
+        })
+        .unwrap_or(8192);
+    let mut body = Vec::with_capacity(capacity);
+    let mut stream = response;
+    while let Some(chunk) = stream
+        .chunk()
+        .await
+        .map_err(|e| SlackError::Network(e.to_string()))?
+    {
+        body.extend_from_slice(&chunk);
+        if body.len() > MAX_API_RESPONSE_BYTES {
+            return Err(SlackError::Decode(format!(
+                "response too large (>{MAX_API_RESPONSE_BYTES} bytes)"
+            )));
+        }
+    }
+    Ok(body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -755,6 +791,38 @@ mod tests {
                 matches!(result, Err(SlackError::Decode(_))),
                 "expected SlackError::Decode for ok:false without error field, got: {result:?}"
             );
+        }
+
+        /// [T-SK032] (issue #165 / CHX-009)
+        /// Setup: wiremock returns a 2xx whose body exceeds
+        /// `MAX_API_RESPONSE_BYTES` (1 MiB), simulating a runaway Slack
+        /// thread/channel response.
+        /// Action: `api_get_once::<DummyBody>("test.method", &[])` is invoked.
+        /// Expected: returns `SlackError::Decode` (terminal — Slack contract
+        /// violation, retry will not recover). Body message contains
+        /// "too large" to surface the cap in the user-facing error.
+        #[tokio::test]
+        async fn api_get_once_oversized_body_returns_decode() {
+            let Some(server) = try_spawn_mock_server("slack::http").await else {
+                return;
+            };
+            let body = vec![b'x'; (1024 * 1024) + 1];
+            Mock::given(method("GET"))
+                .and(path("/test.method"))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let client = SlackClient::with_base_url(Client::new(), &server.uri());
+            let result: Result<DummyBody, _> = client.api_get_once("test.method", &[]).await;
+            match result {
+                Err(SlackError::Decode(msg)) => assert!(
+                    msg.contains("too large"),
+                    "expected size-cap message, got: {msg}"
+                ),
+                other => panic!("expected SlackError::Decode for oversized body, got: {other:?}"),
+            }
         }
 
         /// [T-SK030] Mid-stream body drop on 2xx routes through SlackError::Network

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -14,7 +14,8 @@ use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
-    MAX_API_RESPONSE_BYTES, parse_retry_after, retry_after_within_cap, retry_with_rate_limit,
+    MAX_API_RESPONSE_BYTES, parse_retry_after, read_body_capped, retry_after_within_cap,
+    retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
 
@@ -297,10 +298,18 @@ impl SlackClient {
             return Err(SlackError::RateLimited { retry_after });
         }
 
-        let bytes = read_body_capped(resp).await?;
-        // Schema fail → Decode (terminal). Transport drop happens before
-        // `from_slice` runs — `read_body_capped` surfaces it as Network so
-        // the retry loop sees it. See `is_schema_decode_fail` (issue #113).
+        let bytes = read_body_capped(
+            resp,
+            || {
+                SlackError::Decode(format!(
+                    "response too large (>{MAX_API_RESPONSE_BYTES} bytes)"
+                ))
+            },
+            |e| SlackError::Network(e.to_string()),
+        )
+        .await?;
+        // Schema fail → Decode (terminal); transport drop already mapped to
+        // Network by the closure above (issue #113).
         let body: serde_json::Value =
             serde_json::from_slice(&bytes).map_err(|e| SlackError::Decode(e.to_string()))?;
 
@@ -624,45 +633,6 @@ fn is_retriable(e: &SlackError) -> bool {
         SlackError::Network(_) | SlackError::Timeout(_) => true,
         _ => false,
     }
-}
-
-/// Drain the response body into a Vec while enforcing `MAX_API_RESPONSE_BYTES`.
-/// Mid-stream drops surface as `SlackError::Network` (transient — retry loop
-/// picks them up); a cap breach surfaces as `SlackError::Decode` (terminal —
-/// Slack contract violation, retry will not recover). Mirrors the `fetch.rs`
-/// pattern so a misbehaving Slack workspace cannot force scout to allocate
-/// unbounded memory (issue #165 / CHX-009).
-async fn read_body_capped(response: reqwest::Response) -> Result<Vec<u8>, SlackError> {
-    let content_length = response.content_length();
-    if let Some(len) = content_length
-        && usize::try_from(len).unwrap_or(usize::MAX) > MAX_API_RESPONSE_BYTES
-    {
-        return Err(SlackError::Decode(format!(
-            "response too large (>{MAX_API_RESPONSE_BYTES} bytes)"
-        )));
-    }
-    let capacity = content_length
-        .map(|len| {
-            usize::try_from(len)
-                .unwrap_or(usize::MAX)
-                .min(MAX_API_RESPONSE_BYTES)
-        })
-        .unwrap_or(8192);
-    let mut body = Vec::with_capacity(capacity);
-    let mut stream = response;
-    while let Some(chunk) = stream
-        .chunk()
-        .await
-        .map_err(|e| SlackError::Network(e.to_string()))?
-    {
-        body.extend_from_slice(&chunk);
-        if body.len() > MAX_API_RESPONSE_BYTES {
-            return Err(SlackError::Decode(format!(
-                "response too large (>{MAX_API_RESPONSE_BYTES} bytes)"
-            )));
-        }
-    }
-    Ok(body)
 }
 
 #[cfg(test)]

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -348,8 +348,13 @@ impl From<BraveError> for ScoutError {
                 transient_with_retry_hint(&e)
             }
             // Priority 5: INTERNAL — schema drift is a scout-side invariant;
-            // peer to `GitHubError::Decode` / `SlackError::Decode`.
-            BraveError::ParseJson(_) => Self::internal_bug(e.to_string()),
+            // peer to `GitHubError::Decode` / `SlackError::Decode`. Oversized
+            // body is an upstream invariant violation (Brave returning >1 MiB
+            // on `web/search`), classified the same as schema drift because
+            // it signals the API surface drifted and retry will not recover.
+            BraveError::ParseJson(_) | BraveError::ResponseTooLarge => {
+                Self::internal_bug(e.to_string())
+            }
             // Unknown — Api codes that did not match 4xx or 5xx
             BraveError::Api { .. } => Self::unknown(e.to_string()),
         }


### PR DESCRIPTION
## 概要

Brave (`web/search`) と Slack (`api_get_once`) は応答 body を `response.bytes()` / `resp.json()` で直接 buffering しており、不正に大きいレスポンスを受け取った際に scout がメモリを unbounded に消費する経路があった。`fetch.rs` 既存の `MAX_RESPONSE_BYTES` (10 MB, HTML 用) と同 posture を API client 側にも適用する。

- `retry.rs::MAX_API_RESPONSE_BYTES = 1 MiB` — Brave `count=20` の `web/search` payload と Slack `SLACK_REPLIES_LIMIT=200` を余裕でカバー。HTML より一桁小さくしているのは API payload が structured data だから。
- `retry.rs::read_body_capped<E>(resp, too_large, network)` — generic helper。Content-Length pre-check (allocation 前) + chunk loop 内 cap 再チェック。各 call site が typed mapper を渡して error taxonomy を保つ。
- Brave: 新規 `BraveError::ResponseTooLarge` variant。`is_retriable=false` (explicit arm) / `is_degradable=false` (scout-side invariant、`ParseJson` 同等)。`tools/errors.rs` で Internal(70) に分類。
- Slack: 既存 `Decode` variant に集約 (Slack contract violation = schema drift と同 posture)。mid-stream drop は `Network` に流れて retry loop が拾う (T-SK030 維持)。

Closes #165

## テスト計画

- [x] `cargo test --lib` 413/413 pass
- [x] `cargo clippy --all-targets` clean
- [x] T-BC-CAP001 (Brave: 1 MiB+1 body → `ResponseTooLarge`, no retry)
- [x] T-SK032 (Slack: 1 MiB+1 body → `Decode("too large")`, no retry)
- [x] T-SK030 (mid-stream drop → `Network`, retriable) 維持
- [x] `/polish` — critic-audit triage で 5 件中 1 件 (DRY 抽出) のみ confirmed → helper を `retry.rs` に統合

## 解消する finding

audit 2026-05-20:

- CHX-008 (low) — Brave response body unbounded
- CHX-009 (low) — Slack response body unbounded
- RC-005 残務 (resource budget convention 不在の最終ピース)

## 設計判断

- **fetch.rs は別 helper を維持** — chunk loop に charset / redirect 処理が interleave しており extraction で shape が崩れる。3 箇所重複は将来別 PR で扱う。
- **Slack を typed variant 化しない** — `Decode` は Slack contract violation の catch-all (schema fail、`ok:false` without `error`、cap breach はいずれも同質)。typed variant 化は call site 1 つだけだと over-engineering。