### PR TITLE
feat(logging): Brave search を info-level dispatch + complete event で bracket

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -188,11 +188,12 @@ impl BraveClient {
             validate_https(&self.base_url, || BraveError::InsecureBaseUrl)?;
         }
         let url = build_url(&self.base_url, query, search_lang)?;
+        let query_len = query.len();
 
         // Bracket the call with info events so operators can attribute
         // latency from the default log level. `query_len` (not `query`)
         // keeps the user term out of logs.
-        info!(query_len = query.len(), "Brave search dispatching");
+        info!(query_len, "Brave search dispatching");
         let started = Instant::now();
 
         let response = self
@@ -210,7 +211,7 @@ impl BraveClient {
         let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
 
         info!(
-            query_len = query.len(),
+            query_len,
             result_count = parsed.web.as_ref().map_or(0, |w| w.results.len()),
             elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
             "Brave search complete"

--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -1,10 +1,10 @@
 use std::env;
 use std::fmt;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use reqwest::Client;
-use tracing::{debug, warn};
+use tracing::{info, warn};
 
 use crate::clock::{Clock, SystemClock};
 use crate::redacted::{Redacted, validate_https};
@@ -189,6 +189,12 @@ impl BraveClient {
         }
         let url = build_url(&self.base_url, query, search_lang)?;
 
+        // Bracket the call with info events so operators can attribute
+        // latency from the default log level. `query_len` (not `query`)
+        // keeps the user term out of logs.
+        info!(query_len = query.len(), "Brave search dispatching");
+        let started = Instant::now();
+
         let response = self
             .http
             .get(url)
@@ -203,9 +209,10 @@ impl BraveClient {
         let bytes = response.bytes().await?;
         let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
 
-        debug!(
+        info!(
             query_len = query.len(),
             result_count = parsed.web.as_ref().map_or(0, |w| w.results.len()),
+            elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
             "Brave search complete"
         );
         Ok(parsed)
@@ -319,6 +326,46 @@ mod http_tests {
                 ]
             }
         })
+    }
+
+    /// [T-BC-LOG001] (issue #166 / OPS-003)
+    /// Setup: wiremock returns a 1-result Brave payload.
+    /// Action: `client.search("foo", None)` is invoked under `traced_test`.
+    /// Expected: an INFO-level `Brave search dispatching` event fires before
+    /// dispatch, and an INFO-level `Brave search complete` event fires after,
+    /// carrying `result_count` and `elapsed_ms` structured fields. Operators
+    /// at the default `info` log level can attribute latency without enabling
+    /// `RUST_LOG=debug`.
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn search_emits_info_dispatch_and_complete_events() {
+        let Some(server) = try_spawn_mock_server("brave::http").await else {
+            return;
+        };
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(ok_body()))
+            .mount(&server)
+            .await;
+
+        let client = BraveClient::with_base_url(Client::new(), &server.uri());
+        client.search("foo", None).await.unwrap();
+
+        assert!(
+            logs_contain("Brave search dispatching"),
+            "expected INFO dispatch event before the HTTP call"
+        );
+        assert!(
+            logs_contain("Brave search complete"),
+            "expected INFO completion event after the HTTP call"
+        );
+        assert!(
+            logs_contain("result_count=1"),
+            "completion event should carry result_count"
+        );
+        assert!(
+            logs_contain("elapsed_ms"),
+            "completion event should carry elapsed_ms for latency attribution"
+        );
     }
 
     /// [T-001] BraveClient sends query unmodified with q parameter


### PR DESCRIPTION
## 概要

`brave/client.rs::send_request` の trace は parse 後の `debug!` 1 行のみで、default `info` レベルでは「いつ送ったか / いつ返ってきたか / どれだけかかったか」が見えなかった。Brave 経路が遅延・失敗した時にオペレーターは latency 帰属ができず、`RUST_LOG=debug` で再現を強いられる。

dispatch/complete を info で bracket する:

- `info!("Brave search dispatching")` — HTTP send 直前
- `info!("Brave search complete")` — parse 後。`debug!` から昇格し、`elapsed_ms` field を追加 (default ログレベルで latency 帰属できる)

`elapsed_ms` の計測は `std::time::Instant` (monotonic)。既存の `Clock` injection seam は `Retry-After` arithmetic 用の wall-clock であり elapsed measurement には不適切。

`query_len` のみ field 化、`query` 本体は redacted のまま (PII/検索意図のログ流出を防ぐ)。

Closes #166

## テスト計画

- [x] `cargo test --lib` 412/412 pass
- [x] `cargo clippy --all-targets` clean
- [x] T-BC-LOG001 — `tracing_test::traced_test` で dispatch / complete 両方 INFO 発火、`result_count` と `elapsed_ms` 構造化 field を持つことを assert
- [x] advisor 1 round — `research --depth N` で `BraveClient::search` を複数回呼ぶか検証 → `search/engine.rs:53` で 1 回のみ。info 昇格は noise にならない

## 解消する finding

audit 2026-05-20:

- OPS-003 (medium) — Brave dispatch 時点の info-level event 不在
- RC-004 (log taxonomy) 残務

## 設計判断

- **`#[tracing::instrument]` span は採用しない** — single function で完結する 2 event は span にせず flat な info! 2 個で十分。span は entry/exit 自動化のための機能だが、elapsed を明示的に渡したいので manual measurement の方が直接的
- **`query` 本体は出さない** — `query_len` のみで cardinality 分析には足りる。検索文字列の露出 risk と diff 視認性のトレード負け
- **Slack の同等改善は別 issue** — `slack.rs::api_get_once` も `info!` 経由の trace は無いが、Brave 経路と分離して扱う方が PR scope が明確

## 関連 IDR

`.claude/workspace/planning/2026-05-20/idr-01.md` に詳細記録あり (PR 内では参照のみ)。