### PR TITLE
feat(config): SCOUT_* override 適用を info-level event で surface

### DIFF
--- a/src/tools/config.rs
+++ b/src/tools/config.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::time::Duration;
 
+use tracing::info;
+
 use crate::retry::DEFAULT_MAX_RETRIES;
 
 use super::errors::ScoutError;
@@ -56,7 +58,7 @@ impl RuntimeConfig {
     where
         F: Fn(&str) -> Result<String, env::VarError>,
     {
-        Ok(Self {
+        let config = Self {
             fetch_timeout: parse_timeout(&get_var, ENV_FETCH_TIMEOUT, DEFAULT_FETCH_TIMEOUT_SECS)?,
             research_timeout: parse_timeout(
                 &get_var,
@@ -65,7 +67,40 @@ impl RuntimeConfig {
             )?,
             slack_timeout: parse_timeout(&get_var, ENV_SLACK_TIMEOUT, DEFAULT_SLACK_TIMEOUT_SECS)?,
             max_retries: parse_max_retries(&get_var)?,
-        })
+        };
+        config.surface_overrides();
+        Ok(config)
+    }
+
+    /// Emit one `info!` per `SCOUT_*` field whose value differs from the
+    /// hard-coded default. Lets an operator inspect "which tuning is active"
+    /// at the default log level without scanning the env for `SCOUT_*`.
+    /// Silent when every field is on its default (no-op events are noise).
+    fn surface_overrides(&self) {
+        if self.fetch_timeout.as_secs() != DEFAULT_FETCH_TIMEOUT_SECS {
+            info!(
+                fetch_timeout_secs = self.fetch_timeout.as_secs(),
+                "{ENV_FETCH_TIMEOUT} override applied"
+            );
+        }
+        if self.research_timeout.as_secs() != DEFAULT_RESEARCH_TIMEOUT_SECS {
+            info!(
+                research_timeout_secs = self.research_timeout.as_secs(),
+                "{ENV_RESEARCH_TIMEOUT} override applied"
+            );
+        }
+        if self.slack_timeout.as_secs() != DEFAULT_SLACK_TIMEOUT_SECS {
+            info!(
+                slack_timeout_secs = self.slack_timeout.as_secs(),
+                "{ENV_SLACK_TIMEOUT} override applied"
+            );
+        }
+        if self.max_retries != DEFAULT_MAX_RETRIES {
+            info!(
+                max_retries = self.max_retries,
+                "{ENV_MAX_RETRIES} override applied"
+            );
+        }
     }
 }
 
@@ -264,6 +299,44 @@ mod tests {
         let err =
             RuntimeConfig::from_env_with(single_env("SCOUT_SLACK_TIMEOUT_SECS", "-5")).unwrap_err();
         assert_eq!(err.error_kind(), ErrorCode::UsageError);
+    }
+
+    /// [T-CFG-LOG001] (issue #167 / OPS-005)
+    /// Setup: env reader returns a non-default `SCOUT_FETCH_TIMEOUT_SECS`.
+    /// Action: `RuntimeConfig::from_env_with(...)` runs under `traced_test`.
+    /// Expected: an INFO event `SCOUT_FETCH_TIMEOUT_SECS override applied`
+    /// fires with the structured `fetch_timeout_secs` field. The remaining
+    /// `SCOUT_*` events stay silent because their fields are still on default.
+    #[tracing_test::traced_test]
+    #[test]
+    fn fetch_timeout_override_surfaces_info_event() {
+        let _ =
+            RuntimeConfig::from_env_with(single_env("SCOUT_FETCH_TIMEOUT_SECS", "120")).unwrap();
+        assert!(
+            logs_contain("SCOUT_FETCH_TIMEOUT_SECS override applied"),
+            "expected INFO event for the overridden field"
+        );
+        assert!(
+            logs_contain("fetch_timeout_secs=120"),
+            "expected structured field carrying the active value"
+        );
+        assert!(
+            !logs_contain("SCOUT_RESEARCH_TIMEOUT_SECS override applied"),
+            "unset fields must stay silent"
+        );
+    }
+
+    /// [T-CFG-LOG002] All fields on default → no override events fire.
+    /// Silent path; protects against a future regression that emits noise
+    /// when nothing was overridden.
+    #[tracing_test::traced_test]
+    #[test]
+    fn default_run_emits_no_override_events() {
+        let _ = RuntimeConfig::from_env_with(empty_env).unwrap();
+        assert!(
+            !logs_contain("override applied"),
+            "no-op runs must not emit override events"
+        );
     }
 
     /// [T-CFG020] Default impl は from_env_with(empty) と同値


### PR DESCRIPTION
## 概要

`RuntimeConfig::from_env_with` は `SCOUT_*` env を読み取って override を適用するが、適用結果を log しなかった。default `info` ログレベルで「どの tuning が active か」を operator が確認する手段が無い (env を再 dump しないと不明)。

`RuntimeConfig::surface_overrides` を新設、各 field が default 値と異なる場合のみ `info!` 1 行を発火する。全 field が default のとき完全 silent — no-op event は daily noise なので発火しない。

- `SCOUT_FETCH_TIMEOUT_SECS override applied` (`fetch_timeout_secs=…`)
- `SCOUT_RESEARCH_TIMEOUT_SECS override applied` (`research_timeout_secs=…`)
- `SCOUT_SLACK_TIMEOUT_SECS override applied` (`slack_timeout_secs=…`)
- `SCOUT_MAX_RETRIES override applied` (`max_retries=…`)

集約 1-event 案 (`info!(?overrides, "tuning applied")`) も検討したが、個別 event の方が `field=value` structured pair で grep / log 集計が直接的なので採用。

Closes #167

## テスト計画

- [x] `cargo test --lib` 413/413 pass
- [x] `cargo clippy --all-targets` clean
- [x] T-CFG-LOG001 — `tracing_test::traced_test` で override 時に INFO + structured field 発火、unset field は silent
- [x] T-CFG-LOG002 — default のみのとき event 発火しない (no-op 通知抑止 regression guard)
- [x] `/polish` — 4 reviewer + critic-audit triage、confirmed 0/2 (false positive 100%、disputed=codebase convention)

## 解消する finding

audit 2026-05-20:

- OPS-005 (medium) — SCOUT_* override 適用を log で surface する手段なし
- RC-004 (log taxonomy) 残務 (最終ピース)

## 設計判断

- **個別 event** (集約 1-event 不採用) — `field=value` structured pair が grep / 集計で扱いやすい
- **silent default 必須** — 全 CLI 呼び出しごとの no-op event は daily noise
- **redaction 不要** — timeout 秒数 / retry 回数は機密性無し、値を直接 field 化
- **`from_env_with` 内 side-effect** — 厳密には parser を純化したいが、process 起動時 1 回のみ呼ばれる & test が override path に確実に乗るため acceptable

## 関連 IDR

`.claude/workspace/planning/2026-05-20/idr-02.md` に詳細記録あり (PR 内では参照のみ)。