### PR TITLE
v2.1.0 をリリース

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64",
  "chardetng 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scout"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.95"
 description = "CLI tool for web search (Brave Search), page fetching, and GitHub repository exploration"


### PR DESCRIPTION
## 背景と目的

scout `2.0.0` → `2.1.0` の MINOR リリース。v2.0.0 以降にマージした観測性 (Brave 検索 / SCOUT_* override の info-level logging) と耐性 (response body cap / リソース並行度 bound / Clock・Rng DI) 強化を tag 付きで配布するため version を bump する。Releases ページと Homebrew tap (`thkt/homebrew-tap`) への反映が tag push で自動的に走る。

## 変更内容

- `Cargo.toml` / `Cargo.lock` の `scout` version を `2.0.0` → `2.1.0`

## スコープ

- **対象外**: 機能・ロジック・依存パッケージの変更なし。bump 専用

## リリース内容 (v2.0.0 以降)

- #171 feat(config): surface SCOUT_* tuning overrides via info-level events
- #170 feat(logging): bracket Brave search with info-level dispatch + complete events
- #169 feat(http-client): cap Brave/Slack API response bodies at 1 MiB
- #168 refactor(http-client): inject Clock/Rng into BraveClient and SlackClient
- #164 feat(resource): bound stdin / Slack replies / users.info concurrency
- #163 refactor(logging): align retry/timeout/fallback events with LANG.md taxonomy
- #162 refactor(test_support): consolidate no_redirect_client into shared helper
- #161 test(ssrf): assert CGN fence-post neighbors are allowed
- #160 test(github): assert PerPage::new preserves boundary values
- #159 fix(fetch): surface CDP cleanup failures via warn log

## 動作確認手順

1. この PR をマージ
2. main で `git tag -a v2.1.0 -m "..."` → `git push origin v2.1.0`
3. `.github/workflows/release.yml` が 4 ターゲットを build → GitHub Release 作成 → `thkt/homebrew-tap` の Formula 自動更新まで通る
4. `brew upgrade scout` でローカルが `2.1.0` になる / `scout --version` が `scout 2.1.0`