### PR TITLE
refactor(errors): 各 backend に classify() を追加して variant 分類を co-locate

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -7,6 +7,7 @@ use reqwest::Client;
 use tracing::{info, warn};
 
 use crate::clock::{Clock, SystemClock};
+use crate::envelope::ErrorCode;
 use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
@@ -15,6 +16,7 @@ use crate::retry::{
     retry_after_within_cap, retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
+use crate::tools::Classification;
 
 use super::types::{SearchResult, WebSearchResponse};
 
@@ -75,6 +77,44 @@ impl BraveError {
             Self::RateLimited { .. } | Self::Server(_) | Self::Network(_) | Self::Api { .. } => {
                 true
             }
+        }
+    }
+
+    /// Map each variant to its ADR-0011 priority-table [`Classification`].
+    ///
+    /// Arm order is load-bearing: `Api { code: 4xx }` precedes the bare
+    /// `Api { .. }` fallback so a reorder cannot silently demote a 4xx
+    /// response from DataError to Unknown.
+    pub(crate) fn classify(&self) -> Classification {
+        match self {
+            // Priority 1: USAGE_ERROR / config
+            Self::ApiKeyNotSet => Classification::new(ErrorCode::UsageError)
+                .with_hint("Set BRAVE_SEARCH_API_KEY environment variable"),
+            Self::Unauthorized => Classification::new(ErrorCode::UsageError).with_hint(
+                "Verify BRAVE_SEARCH_API_KEY at https://api-dashboard.search.brave.com/",
+            ),
+            // Priority 2: DATA_ERROR (4xx body, URL parse failure, or insecure base URL)
+            Self::ParseUrl(_) | Self::InsecureBaseUrl => Classification::new(ErrorCode::DataError),
+            Self::Api { code, .. } if (400..500).contains(code) => {
+                Classification::new(ErrorCode::DataError)
+            }
+            // Priority 4: TIMEOUT
+            Self::Network(re) if re.is_timeout() => Classification::timeout_retry(),
+            // Priority 4: TEMP_FAILURE
+            Self::RateLimited { .. } => Classification::transient_retry(),
+            Self::Server(_) => Classification::transient_retry(),
+            Self::Network(_) => Classification::transient_network(),
+            Self::Api { code, .. } if (500..=599).contains(code) => {
+                Classification::transient_retry()
+            }
+            // Priority 5: INTERNAL — schema drift is a scout-side invariant;
+            // peer to `GitHubError::Decode` / `SlackError::Decode`. Oversized
+            // body is an upstream invariant violation (Brave returning >1 MiB
+            // on `web/search`), classified the same as schema drift because
+            // it signals the API surface drifted and retry will not recover.
+            Self::ParseJson(_) | Self::ResponseTooLarge => Classification::new(ErrorCode::Internal),
+            // Unknown — Api codes that did not match 4xx or 5xx
+            Self::Api { .. } => Classification::new(ErrorCode::Unknown),
         }
     }
 }
@@ -719,5 +759,100 @@ mod http_tests {
             Arc::ptr_eq(&client.rng, &injected),
             "with_rng must install the supplied Arc into BraveClient.rng"
         );
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+
+    /// [T-BRC001] ApiKeyNotSet classifies as UsageError with BRAVE_SEARCH_API_KEY hint.
+    #[test]
+    fn api_key_not_set_is_usage_error_with_key_hint() {
+        let c = BraveError::ApiKeyNotSet.classify();
+        assert_eq!(c.kind, ErrorCode::UsageError);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("BRAVE_SEARCH_API_KEY")),
+            "expected BRAVE_SEARCH_API_KEY hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-BRC002] Unauthorized classifies as UsageError with a Brave dashboard hint.
+    #[test]
+    fn unauthorized_is_usage_error_with_dashboard_hint() {
+        let c = BraveError::Unauthorized.classify();
+        assert_eq!(c.kind, ErrorCode::UsageError);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("api-dashboard.search.brave.com")),
+            "expected Brave dashboard hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-BRC003] Priority-2 DataError variants classify as DataError.
+    #[test]
+    fn data_error_variants_classify_as_data_error() {
+        let cases: Vec<BraveError> = vec![
+            BraveError::InsecureBaseUrl,
+            BraveError::Api {
+                code: 400,
+                message: "bad".into(),
+            },
+            BraveError::Api {
+                code: 422,
+                message: "unprocessable".into(),
+            },
+        ];
+        for case in &cases {
+            assert_eq!(case.classify().kind, ErrorCode::DataError, "{case:?}");
+        }
+    }
+
+    /// [T-BRC004] Server (5xx) and RateLimited classify as TempFailure.
+    #[test]
+    fn server_and_rate_limited_are_temp_failure() {
+        let cases: Vec<BraveError> = vec![
+            BraveError::Server(503),
+            BraveError::RateLimited { retry_after: None },
+            BraveError::Api {
+                code: 502,
+                message: "bad gateway".into(),
+            },
+        ];
+        for case in &cases {
+            assert_eq!(case.classify().kind, ErrorCode::TempFailure, "{case:?}");
+        }
+    }
+
+    /// [T-BRC005] Schema drift variants classify as Internal per ADR-0011 priority 5.
+    /// `ResponseTooLarge` and `ParseJson` both signal an upstream invariant violation
+    /// that retry will not recover from.
+    #[test]
+    fn schema_drift_is_internal() {
+        let serde_err =
+            serde_json::from_str::<serde_json::Value>("{not valid").expect_err("malformed json");
+        let cases: Vec<BraveError> = vec![
+            BraveError::ResponseTooLarge,
+            BraveError::ParseJson(serde_err),
+        ];
+        for case in &cases {
+            assert_eq!(case.classify().kind, ErrorCode::Internal, "{case:?}");
+        }
+    }
+
+    /// [T-BRC006] Api codes outside 4xx/5xx classify as Unknown (escape hatch).
+    #[test]
+    fn api_non_4xx_5xx_is_unknown() {
+        let c = BraveError::Api {
+            code: 304,
+            message: "not modified".into(),
+        }
+        .classify();
+        assert_eq!(c.kind, ErrorCode::Unknown);
     }
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -20,6 +20,10 @@ use std::sync::OnceLock;
 #[cfg(feature = "js-rendering")]
 use std::time::Duration;
 
+use crate::envelope::ErrorCode;
+use crate::retry::is_transient_network;
+use crate::tools::Classification;
+
 use tokio::sync::watch;
 #[cfg(feature = "js-rendering")]
 use tokio::time::timeout;
@@ -95,6 +99,66 @@ pub(crate) enum FetchError {
 
     #[error("browser rendering failed: {0}")]
     BrowserFailed(String),
+}
+
+impl FetchError {
+    /// Map each variant to its ADR-0011 priority-table [`Classification`].
+    ///
+    /// Arm order is load-bearing: specific `Status` codes (401/403, 404,
+    /// 408/429) precede the 4xx fallback so a reorder cannot silently demote
+    /// them to DataError.
+    pub(crate) fn classify(&self) -> Classification {
+        match self {
+            // Priority 1: USAGE_ERROR
+            Self::BrowserNotFound(_) => Classification::new(ErrorCode::UsageError),
+            // Priority 2: DATA_ERROR (non-Status variants)
+            Self::InvalidScheme => Classification::new(ErrorCode::DataError)
+                .with_hint("URL must use http:// or https://"),
+            Self::InvalidUrl(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("URL must include scheme and host"),
+            Self::InternalHost => Classification::new(ErrorCode::DataError)
+                .with_hint("URL must point to an external host (private IPs are blocked)"),
+            Self::UnsupportedContentType(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("URL must serve HTML or text content"),
+            Self::RedirectMissingLocation => Classification::new(ErrorCode::DataError),
+            Self::TooLarge => {
+                Classification::new(ErrorCode::DataError).with_hint("fetch a smaller resource")
+            }
+            // Terminal DataError: cap=5 absorbs canonical chains (HTTPS upgrade →
+            // trailing slash → final URL), so a breach dominantly indicates a
+            // server-side redirect loop or caller URL mistake — both caller-fixable.
+            Self::TooManyRedirects(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("URL has too many redirects; check for a redirect loop"),
+            // Priority 1: USAGE_ERROR (specific HTTP codes before 4xx fallback)
+            Self::Status(401 | 403) => Classification::new(ErrorCode::UsageError)
+                .with_hint("URL requires authentication that scout does not support"),
+            // Priority 3: NOT_FOUND
+            Self::Status(404) => Classification::new(ErrorCode::NotFound)
+                .with_hint("Check that the URL is correct and the resource exists"),
+            // Priority 4: TEMP_FAILURE
+            Self::Status(408 | 429) => Classification::transient_retry(),
+            // Priority 2: DATA_ERROR (4xx body)
+            Self::Status(code) if (400..500).contains(code) => {
+                Classification::new(ErrorCode::DataError)
+            }
+            // Priority 4: TEMP_FAILURE (5xx and other unmatched)
+            Self::Status(_) => Classification::transient_retry(),
+            // Priority 4: TIMEOUT (transport timeout — long-backoff retry advised)
+            Self::Timeout(_) => Classification::timeout_retry(),
+            // Priority 4: TEMP_FAILURE (non-Status variants)
+            Self::DnsResolution(_) => Classification::new(ErrorCode::TempFailure)
+                .with_hint("Check the URL's domain name and your DNS resolver"),
+            // `is_transient_network` covers connect, timeout, and mid-stream
+            // body drop (issue #113), but ADR-0002 splits timeout into 124.
+            // Check `is_timeout()` first.
+            Self::Http(re) if re.is_timeout() => Classification::timeout_retry(),
+            Self::Http(re) if is_transient_network(re) => Classification::transient_network(),
+            // Priority 5 sibling: IO_ERROR — external tool failure (browser)
+            Self::BrowserFailed(_) => Classification::new(ErrorCode::IoError),
+            // Unknown — reqwest errors that do not match transient network patterns
+            Self::Http(_) => Classification::new(ErrorCode::Unknown),
+        }
+    }
 }
 
 /// ~1 sentence; pages below this almost always need JS rendering.
@@ -1860,5 +1924,118 @@ mod cdp_integration_tests {
             "rendered HTML should contain page content, got {} bytes",
             html.len()
         );
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+
+    /// [T-FEC001] BrowserNotFound classifies as UsageError.
+    #[test]
+    fn browser_not_found_is_usage_error() {
+        let c = FetchError::BrowserNotFound("not installed".into()).classify();
+        assert_eq!(c.kind, ErrorCode::UsageError);
+    }
+
+    /// [T-FEC002] Status(401) and Status(403) classify as UsageError
+    /// (priority 1 over the priority-2 4xx fallback).
+    #[test]
+    fn status_401_403_is_usage_error_not_data_error() {
+        for code in [401u16, 403] {
+            let c = FetchError::Status(code).classify();
+            assert_eq!(
+                c.kind,
+                ErrorCode::UsageError,
+                "code {code} must precede 4xx arm"
+            );
+        }
+    }
+
+    /// [T-FEC003] Status(404) classifies as NotFound
+    /// (priority 3 over the priority-2 4xx fallback).
+    #[test]
+    fn status_404_is_not_found_not_data_error() {
+        let c = FetchError::Status(404).classify();
+        assert_eq!(c.kind, ErrorCode::NotFound);
+        assert!(
+            c.next_step.as_deref().is_some_and(|h| h.contains("URL")),
+            "expected URL hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-FEC004] Status(408) and Status(429) classify as TempFailure
+    /// (priority 4 over the priority-2 4xx fallback).
+    #[test]
+    fn status_408_429_is_temp_failure_not_data_error() {
+        for code in [408u16, 429] {
+            let c = FetchError::Status(code).classify();
+            assert_eq!(c.kind, ErrorCode::TempFailure, "code {code}");
+        }
+    }
+
+    /// [T-FEC005] Other 4xx Status codes classify as DataError.
+    #[test]
+    fn status_other_4xx_is_data_error() {
+        for code in [400u16, 410, 422, 499] {
+            let c = FetchError::Status(code).classify();
+            assert_eq!(c.kind, ErrorCode::DataError, "code {code}");
+        }
+    }
+
+    /// [T-FEC006] 5xx Status codes classify as TempFailure.
+    #[test]
+    fn status_5xx_is_temp_failure() {
+        for code in [500u16, 502, 503, 599] {
+            let c = FetchError::Status(code).classify();
+            assert_eq!(c.kind, ErrorCode::TempFailure, "code {code}");
+        }
+    }
+
+    /// [T-FEC007] Priority-2 DataError variants (non-Status) classify as DataError.
+    #[test]
+    fn data_error_variants_classify_as_data_error() {
+        let cases: Vec<FetchError> = vec![
+            FetchError::InvalidScheme,
+            FetchError::InternalHost,
+            FetchError::UnsupportedContentType("image/png".into()),
+            FetchError::RedirectMissingLocation,
+            FetchError::TooLarge,
+            FetchError::TooManyRedirects(10),
+        ];
+        for case in &cases {
+            assert_eq!(
+                case.classify().kind,
+                ErrorCode::DataError,
+                "{case:?} must classify as DataError"
+            );
+        }
+    }
+
+    /// [T-FEC008] Timeout classifies as Timeout (exit 124 split from TempFailure).
+    #[test]
+    fn timeout_is_timeout_kind() {
+        let c = FetchError::Timeout("timed out".into()).classify();
+        assert_eq!(c.kind, ErrorCode::Timeout);
+    }
+
+    /// [T-FEC009] DnsResolution classifies as TempFailure with a DNS hint.
+    #[test]
+    fn dns_resolution_is_temp_failure_with_dns_hint() {
+        let c = FetchError::DnsResolution("dns failed".into()).classify();
+        assert_eq!(c.kind, ErrorCode::TempFailure);
+        assert!(
+            c.next_step.as_deref().is_some_and(|h| h.contains("DNS")),
+            "expected DNS hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-FEC010] BrowserFailed classifies as IoError (priority 5 sibling).
+    #[test]
+    fn browser_failed_is_io_error() {
+        let c = FetchError::BrowserFailed("CDP error".into()).classify();
+        assert_eq!(c.kind, ErrorCode::IoError);
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -12,6 +12,7 @@ use serde::de::DeserializeOwned;
 use tracing::{debug, info, warn};
 
 use crate::clock::{Clock, SystemClock};
+use crate::envelope::ErrorCode;
 use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
@@ -21,6 +22,7 @@ use crate::retry::{
 };
 use crate::rng::{FastrandRng, Rng};
 use crate::token_source::TokenSource;
+use crate::tools::Classification;
 
 use helpers::encode_path;
 pub(crate) use helpers::{
@@ -75,6 +77,62 @@ pub(crate) enum GitHubError {
 
     #[error("Insecure URL: HTTPS required for token-bearing request")]
     InsecureUrl,
+}
+
+impl GitHubError {
+    /// Map each variant to its ADR-0011 priority-table [`Classification`].
+    ///
+    /// Arm order is load-bearing: `Api { code: 401 }` precedes the generic 4xx
+    /// arm so a reorder cannot silently demote 401 from UsageError(64) to
+    /// DataError(65).
+    pub(crate) fn classify(&self) -> Classification {
+        match self {
+            // Priority 1: USAGE_ERROR
+            Self::Forbidden(_) => Classification::new(ErrorCode::UsageError)
+                .with_hint("Check that your GITHUB_TOKEN has the required scopes"),
+            // 401 must precede the 4xx arm below to avoid falling into DataError.
+            Self::Api { code: 401, .. } => Classification::new(ErrorCode::UsageError)
+                .with_hint("Set GITHUB_TOKEN or run `gh auth login` to authenticate"),
+            // Priority 2: DATA_ERROR
+            Self::InvalidRepo(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("Use 'owner/repo' format, e.g., 'facebook/react'"),
+            Self::InvalidRef(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("Use a branch name, tag, or commit SHA"),
+            Self::InvalidPath(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("Use a path within the repository"),
+            Self::InvalidLineRange(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("Use format like '1-80', '50-', or '100' (first N lines)"),
+            Self::InvalidPattern(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("Use a glob pattern like '*.rs' or '*.{ts,tsx}'"),
+            Self::NonUtf8(_) => Classification::new(ErrorCode::DataError)
+                .with_hint("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
+            Self::InsecureUrl => Classification::new(ErrorCode::DataError),
+            Self::Api { code, .. } if (400..500).contains(code) => {
+                Classification::new(ErrorCode::DataError)
+            }
+            // Priority 3: NOT_FOUND
+            Self::NotFound(_) => Classification::new(ErrorCode::NotFound)
+                .with_hint("Check that the repository or path exists, and that you have access"),
+            // Priority 4: TIMEOUT (request timeout via reqwest builder)
+            Self::Network(re) if re.is_timeout() => Classification::timeout_retry(),
+            // Priority 4: TEMP_FAILURE
+            Self::RateLimited { retry_after } => Classification::new(ErrorCode::TempFailure)
+                .with_hint(match retry_after {
+                    Some(secs) => format!(
+                        "Retry after {secs} seconds, or set GITHUB_TOKEN to increase rate limit"
+                    ),
+                    None => "Set GITHUB_TOKEN to increase rate limit".to_owned(),
+                }),
+            Self::Network(_) => Classification::transient_network(),
+            Self::Api { code, .. } if (500..=599).contains(code) => {
+                Classification::transient_retry()
+            }
+            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
+            Self::Decode(_) => Classification::new(ErrorCode::Internal),
+            // Unknown — Api codes that did not match 4xx or 5xx (e.g., 1xx/3xx leak)
+            Self::Api { .. } => Classification::new(ErrorCode::Unknown),
+        }
+    }
 }
 
 /// HTTP client for the GitHub REST API v3.
@@ -762,5 +820,149 @@ mod http_tests {
             ),
             "expected retry_after = 300 (reset 1300 - clock 1000), got: {result:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+
+    /// [T-GHC001] Forbidden classifies as UsageError with GITHUB_TOKEN scope hint.
+    #[test]
+    fn forbidden_is_usage_error_with_scope_hint() {
+        let c = GitHubError::Forbidden("denied".into()).classify();
+        assert_eq!(c.kind, ErrorCode::UsageError);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("GITHUB_TOKEN")),
+            "expected GITHUB_TOKEN hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-GHC002] Api { code: 401 } classifies as UsageError (priority 1 over 4xx fallback).
+    /// Regression guard: a reorder that moves the 4xx arm above 401 would flip this to
+    /// DataError(65) without `match` exhaustiveness catching it.
+    #[test]
+    fn api_401_is_usage_error_not_data_error() {
+        let c = GitHubError::Api {
+            code: 401,
+            message: "Bad credentials".into(),
+        }
+        .classify();
+        assert_eq!(c.kind, ErrorCode::UsageError, "401 must precede 4xx arm");
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("gh auth login")),
+            "expected gh auth login hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-GHC003] All priority-2 DataError variants classify as DataError.
+    #[test]
+    fn data_error_variants_classify_as_data_error() {
+        let cases: Vec<GitHubError> = vec![
+            GitHubError::InvalidRepo("bad".into()),
+            GitHubError::InvalidRef("bad".into()),
+            GitHubError::InvalidPath("bad".into()),
+            GitHubError::InvalidLineRange("bad".into()),
+            GitHubError::InvalidPattern("bad".into()),
+            GitHubError::NonUtf8("bad".into()),
+            GitHubError::InsecureUrl,
+            GitHubError::Api {
+                code: 400,
+                message: "bad request".into(),
+            },
+            GitHubError::Api {
+                code: 422,
+                message: "unprocessable".into(),
+            },
+        ];
+        for case in &cases {
+            assert_eq!(
+                case.classify().kind,
+                ErrorCode::DataError,
+                "{case:?} must classify as DataError"
+            );
+        }
+    }
+
+    /// [T-GHC004] NotFound classifies as NotFound with a "check the repo/path" hint.
+    #[test]
+    fn not_found_is_not_found_with_hint() {
+        let c = GitHubError::NotFound("/x".into()).classify();
+        assert_eq!(c.kind, ErrorCode::NotFound);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("repository or path")),
+            "expected repo/path hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-GHC005] RateLimited with retry_after embeds the seconds into next_step.
+    #[test]
+    fn rate_limited_with_retry_after_embeds_seconds() {
+        let c = GitHubError::RateLimited {
+            retry_after: Some(42),
+        }
+        .classify();
+        assert_eq!(c.kind, ErrorCode::TempFailure);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("42 seconds")),
+            "expected 42 seconds in hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-GHC006] RateLimited without retry_after still suggests GITHUB_TOKEN.
+    #[test]
+    fn rate_limited_without_retry_after_suggests_token() {
+        let c = GitHubError::RateLimited { retry_after: None }.classify();
+        assert_eq!(c.kind, ErrorCode::TempFailure);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("GITHUB_TOKEN")),
+            "expected GITHUB_TOKEN hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-GHC007] Api 5xx classifies as TempFailure (priority 4 over Unknown fallback).
+    #[test]
+    fn api_5xx_is_temp_failure() {
+        for code in [500u16, 502, 503, 599] {
+            let c = GitHubError::Api {
+                code,
+                message: "x".into(),
+            }
+            .classify();
+            assert_eq!(c.kind, ErrorCode::TempFailure, "code {code}");
+        }
+    }
+
+    /// [T-GHC008] Decode (schema drift) classifies as Internal per ADR-0011 priority 5.
+    #[test]
+    fn decode_is_internal() {
+        let c = GitHubError::Decode("schema mismatch".into()).classify();
+        assert_eq!(c.kind, ErrorCode::Internal);
+    }
+
+    /// [T-GHC009] Api codes outside 4xx/5xx (e.g., 1xx/3xx leak) land on Unknown.
+    #[test]
+    fn api_non_4xx_5xx_is_unknown() {
+        let c = GitHubError::Api {
+            code: 304,
+            message: "not modified".into(),
+        }
+        .classify();
+        assert_eq!(c.kind, ErrorCode::Unknown);
     }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -9,6 +9,7 @@ use serde::de::DeserializeOwned;
 use tracing::{debug, info, warn};
 
 use crate::clock::{Clock, SystemClock};
+use crate::envelope::ErrorCode;
 use crate::fetch::converter::escape_yaml;
 use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
@@ -18,6 +19,7 @@ use crate::retry::{
     retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
+use crate::tools::Classification;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SlackError {
@@ -41,6 +43,45 @@ pub(crate) enum SlackError {
 
     #[error("Insecure URL: HTTPS required for token-bearing request")]
     InsecureUrl,
+}
+
+impl SlackError {
+    /// Map each variant to its ADR-0011 priority-table [`Classification`].
+    ///
+    /// Slack surfaces failures as `error` strings inside `Api` instead of HTTP
+    /// status codes, so the string-table arm replaces the HTTP-status arm used
+    /// by other backends. The table's `internal_error` / `service_unavailable`
+    /// / `fatal_error` entries are load-bearing — without them those codes
+    /// would fall through to UsageError instead of the retryable TempFailure.
+    pub(crate) fn classify(&self) -> Classification {
+        match self {
+            // Priority 1: USAGE_ERROR
+            Self::TokenNotSet => Classification::new(ErrorCode::UsageError)
+                .with_hint("Export a User OAuth token to SLACK_TOKEN (xoxp-…)"),
+            // Priority 2: DATA_ERROR (insecure URL — peer to BraveError::InsecureBaseUrl)
+            Self::InsecureUrl => Classification::new(ErrorCode::DataError),
+            Self::Api { error } => match error.as_str() {
+                // Priority 3: NOT_FOUND. Underscore forms are Slack-native error
+                // codes; "message not found" (space) is scout's own string from
+                // `fetch_message` when the resolved messages list is empty.
+                "channel_not_found" | "message_not_found" | "thread_not_found"
+                | "message not found" => Classification::new(ErrorCode::NotFound),
+                // Priority 4: TEMP_FAILURE
+                "internal_error" | "service_unavailable" | "fatal_error" => {
+                    Classification::transient_retry()
+                }
+                // Priority 1: USAGE_ERROR (invalid_auth, missing_scope, etc.)
+                _ => Classification::new(ErrorCode::UsageError),
+            },
+            // Priority 4: TEMP_FAILURE
+            Self::RateLimited { .. } => Classification::transient_retry(),
+            Self::Network(_) => Classification::transient_network(),
+            // Priority 4: TIMEOUT
+            Self::Timeout(_) => Classification::timeout_retry(),
+            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
+            Self::Decode(_) => Classification::new(ErrorCode::Internal),
+        }
+    }
 }
 
 /// Parsed Slack message URL. Fields are private so the only construction path
@@ -1179,5 +1220,108 @@ parent body
                 "with_rng must install the supplied Arc into SlackClient.rng"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::*;
+
+    /// [T-SLC001] TokenNotSet classifies as UsageError with SLACK_TOKEN hint.
+    #[test]
+    fn token_not_set_is_usage_error_with_token_hint() {
+        let c = SlackError::TokenNotSet.classify();
+        assert_eq!(c.kind, ErrorCode::UsageError);
+        assert!(
+            c.next_step
+                .as_deref()
+                .is_some_and(|h| h.contains("SLACK_TOKEN")),
+            "expected SLACK_TOKEN hint, got: {:?}",
+            c.next_step
+        );
+    }
+
+    /// [T-SLC002] InsecureUrl classifies as DataError (peer to other backends' InsecureUrl).
+    #[test]
+    fn insecure_url_is_data_error() {
+        let c = SlackError::InsecureUrl.classify();
+        assert_eq!(c.kind, ErrorCode::DataError);
+    }
+
+    /// [T-SLC003] Slack-native NOT_FOUND error codes classify as NotFound.
+    /// scout's internal "message not found" (space form) must classify the same
+    /// as Slack's `message_not_found` (underscore) — both should land on
+    /// EX_NOINPUT(66) per issue #114.
+    #[test]
+    fn api_not_found_codes_classify_as_not_found() {
+        for code in [
+            "channel_not_found",
+            "message_not_found",
+            "thread_not_found",
+            "message not found",
+        ] {
+            let c = SlackError::Api {
+                error: code.to_owned(),
+            }
+            .classify();
+            assert_eq!(
+                c.kind,
+                ErrorCode::NotFound,
+                "{code} must classify as NotFound"
+            );
+        }
+    }
+
+    /// [T-SLC004] Slack TEMP_FAILURE error codes classify as TempFailure
+    /// (ADR-0003 — internal_error must not be misclassified as UsageError).
+    #[test]
+    fn api_temp_failure_codes_classify_as_temp_failure() {
+        for code in ["internal_error", "service_unavailable", "fatal_error"] {
+            let c = SlackError::Api {
+                error: code.to_owned(),
+            }
+            .classify();
+            assert_eq!(c.kind, ErrorCode::TempFailure, "{code}");
+        }
+    }
+
+    /// [T-SLC005] Other Slack API error codes (e.g., invalid_auth) classify as UsageError.
+    #[test]
+    fn api_other_codes_classify_as_usage_error() {
+        for code in ["invalid_auth", "missing_scope", "not_authed"] {
+            let c = SlackError::Api {
+                error: code.to_owned(),
+            }
+            .classify();
+            assert_eq!(c.kind, ErrorCode::UsageError, "{code}");
+        }
+    }
+
+    /// [T-SLC006] RateLimited classifies as TempFailure.
+    #[test]
+    fn rate_limited_is_temp_failure() {
+        let c = SlackError::RateLimited { retry_after: None }.classify();
+        assert_eq!(c.kind, ErrorCode::TempFailure);
+    }
+
+    /// [T-SLC007] Network classifies as TempFailure (network-class hint).
+    #[test]
+    fn network_is_temp_failure() {
+        let c = SlackError::Network("connection reset".into()).classify();
+        assert_eq!(c.kind, ErrorCode::TempFailure);
+    }
+
+    /// [T-SLC008] Timeout classifies as Timeout (exit 124 split from TempFailure).
+    #[test]
+    fn timeout_is_timeout_kind() {
+        let c = SlackError::Timeout("timed out".into()).classify();
+        assert_eq!(c.kind, ErrorCode::Timeout);
+    }
+
+    /// [T-SLC009] Decode (schema drift) classifies as Internal per ADR-0011 priority 5.
+    #[test]
+    fn decode_is_internal() {
+        let c = SlackError::Decode("schema mismatch".into()).classify();
+        assert_eq!(c.kind, ErrorCode::Internal);
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -7,6 +7,7 @@ pub use errors::ScoutError;
 pub use params::Command;
 
 pub(crate) use config::RuntimeConfig;
+pub(crate) use errors::Classification;
 
 use std::io::{IsTerminal, stdin};
 use std::sync::Arc;

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -6,29 +6,56 @@ use crate::brave::client::BraveError;
 use crate::envelope::{Degradation, DegradedReason, ErrorCode};
 use crate::fetch::FetchError;
 use crate::github;
-use crate::retry::is_transient_network;
 use crate::slack::SlackError;
 
 /// Reusable next_step hints so transient/network errors stay consistent.
 const HINT_RETRY_DELAY: &str = "Retry after a short delay";
 const HINT_CHECK_NETWORK: &str = "Check your network connection";
 
-/// Builds a transient `ScoutError` with the "retry after a short delay" hint.
-/// Used for rate-limit, 5xx, and other timing-recoverable failures.
-fn transient_with_retry_hint(e: &impl fmt::Display) -> ScoutError {
-    ScoutError::transient(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+/// Per-variant error classification produced by each backend error type's
+/// `classify()` method. Carries the `ErrorCode` and the optional `next_step`
+/// hint; `From<XxxError> for ScoutError` composes it with the variant's
+/// `Display` message into a `ScoutError`.
+///
+/// Centralising classification on the variant (instead of inside `From`) keeps
+/// the ADR-0011 priority decision next to the variant definition and lets
+/// `classify()` be unit-tested directly.
+pub(crate) struct Classification {
+    pub(crate) kind: ErrorCode,
+    pub(crate) next_step: Option<String>,
 }
 
-/// Builds a transient `ScoutError` with the "check your network" hint.
-/// Used for connect-level network failures where retry alone will not help.
-fn transient_with_network_hint(e: &impl fmt::Display) -> ScoutError {
-    ScoutError::transient(e.to_string()).with_next_step(HINT_CHECK_NETWORK)
-}
+impl Classification {
+    pub(crate) fn new(kind: ErrorCode) -> Self {
+        Self {
+            kind,
+            next_step: None,
+        }
+    }
 
-/// Builds a timeout `ScoutError` with the "retry after a short delay" hint.
-/// Used for transport-timeout failures distinct from generic transients.
-fn timeout_with_retry_hint(e: &impl fmt::Display) -> ScoutError {
-    ScoutError::timeout(e.to_string()).with_next_step(HINT_RETRY_DELAY)
+    pub(crate) fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.next_step = Some(hint.into());
+        self
+    }
+
+    /// TempFailure(75) with the "retry after a short delay" hint. Used for
+    /// 5xx, rate-limit, and other timing-recoverable failures.
+    pub(crate) fn transient_retry() -> Self {
+        Self::new(ErrorCode::TempFailure).with_hint(HINT_RETRY_DELAY)
+    }
+
+    /// TempFailure(75) with the "check your network" hint. Used for
+    /// connect-level network failures where retry alone will not help.
+    pub(crate) fn transient_network() -> Self {
+        Self::new(ErrorCode::TempFailure).with_hint(HINT_CHECK_NETWORK)
+    }
+
+    /// Timeout(124) with the "retry after a short delay" hint. Split from
+    /// TempFailure(75) per ADR-0002 so caller scripts can apply a longer
+    /// backoff than for rate-limit / 5xx failures.
+    pub(crate) fn timeout_retry() -> Self {
+        Self::new(ErrorCode::Timeout).with_hint(HINT_RETRY_DELAY)
+    }
 }
 
 #[derive(Debug)]
@@ -74,26 +101,13 @@ impl ScoutError {
 
     /// External tool / IO failure outside scout's invariants (e.g. headless
     /// browser CDP error). Maps to `ErrorCode::IoError` (exit 74 EX_IOERR).
-    /// Use [`Self::internal_bug`] for scout-side schema bugs (exit 70).
+    /// scout-side schema bugs route through `Classification::new(Internal)`
+    /// in each backend's `classify()` instead.
     pub(super) fn io_error(msg: impl Into<String>) -> Self {
         Self::new(ErrorCode::IoError, msg)
     }
 
-    /// scout-side invariant violation (e.g., unexpected API schema during
-    /// deserialize). Maps to `ErrorCode::Internal` (exit 70 EX_SOFTWARE) per
-    /// ADR-0011 priority 5.
-    pub(super) fn internal_bug(msg: impl Into<String>) -> Self {
-        Self::new(ErrorCode::Internal, msg)
-    }
-
-    /// Unclassifiable failure — the priority rules (1-5) did not match.
-    /// Maps to `ErrorCode::Unknown` (exit 104, PJ extension per ADR-0002) per
-    /// ADR-0011 §Classification Priority Table 退避 slot. A rising Unknown rate
-    /// signals the classification design needs revisiting.
-    pub(super) fn unknown(msg: impl Into<String>) -> Self {
-        Self::new(ErrorCode::Unknown, msg)
-    }
-
+    #[cfg(test)]
     pub(super) fn transient(msg: impl Into<String>) -> Self {
         Self::new(ErrorCode::TempFailure, msg)
     }
@@ -106,15 +120,24 @@ impl ScoutError {
         Self::new(ErrorCode::Timeout, msg)
     }
 
+    #[cfg(test)]
     pub(super) fn not_found(msg: impl Into<String>) -> Self {
         Self::new(ErrorCode::NotFound, msg)
     }
 
-    pub(super) fn data_error(msg: impl Into<String>) -> Self {
-        Self::new(ErrorCode::DataError, msg)
+    /// Build a `ScoutError` from a backend-emitted [`Classification`] paired
+    /// with the variant's `Display` message. Used by `From<XxxError>` impls
+    /// so the classification logic stays co-located with each error variant.
+    fn from_classification(c: Classification, msg: impl Into<String>) -> Self {
+        let mut err = Self::new(c.kind, msg);
+        err.next_step = c.next_step;
+        err
     }
 
-    /// Attach a recovery hint to this error per ADR-0002 `error.next_step`.
+    /// Test-only builder for fixtures that construct `ScoutError` directly
+    /// without going through `From<XxxError>`; production paths attach
+    /// `next_step` via [`Classification`].
+    #[cfg(test)]
     pub(super) fn with_next_step(mut self, hint: impl Into<String>) -> Self {
         self.next_step = Some(hint.into());
         self
@@ -161,203 +184,33 @@ pub(super) fn parse_repo_param(repository: &str) -> Result<(&str, &str), ScoutEr
     github::parse_repo(repository).map_err(ScoutError::from)
 }
 
-// Match arms in each `From<...>` impl below evaluate in classification-priority
-// order per ADR-0011 §Classification Priority Table:
-//   1. USAGE_ERROR  — env/config/argument misuse
-//   2. DATA_ERROR   — format violations (URL, owner/repo, encoding, 4xx body)
-//   3. NOT_FOUND    — resource absence (404, search 0 hits)
-//   4. TEMP_FAILURE — retryable (rate limit, 5xx, network); TIMEOUT(124) splits off
-//   5. INTERNAL     — scout-side invariant violation (unexpected schema); IO_ERROR(74)
-//                     is the sibling for external tool failure (browser)
-// Disjoint variants are otherwise free to be reordered; the priority comments
-// document intent so a reviewer can spot a misclassification mechanically.
+// `From<XxxError>` impls delegate to each backend's `classify()` so the
+// ADR-0011 priority decision stays exhaustiveness-checked next to the variant.
 impl From<github::GitHubError> for ScoutError {
     fn from(e: github::GitHubError) -> Self {
-        match &e {
-            // Priority 1: USAGE_ERROR
-            github::GitHubError::Forbidden(_) => Self::user_error(e.to_string())
-                .with_next_step("Check that your GITHUB_TOKEN has the required scopes"),
-            // 401 must precede the 4xx arm below to avoid falling into DataError.
-            github::GitHubError::Api { code: 401, .. } => Self::user_error(e.to_string())
-                .with_next_step("Set GITHUB_TOKEN or run `gh auth login` to authenticate"),
-            // Priority 2: DATA_ERROR
-            github::GitHubError::InvalidRepo(_) => Self::data_error(e.to_string())
-                .with_next_step("Use 'owner/repo' format, e.g., 'facebook/react'"),
-            github::GitHubError::InvalidRef(_) => Self::data_error(e.to_string())
-                .with_next_step("Use a branch name, tag, or commit SHA"),
-            github::GitHubError::InvalidPath(_) => {
-                Self::data_error(e.to_string()).with_next_step("Use a path within the repository")
-            }
-            github::GitHubError::InvalidLineRange(_) => Self::data_error(e.to_string())
-                .with_next_step("Use format like '1-80', '50-', or '100' (first N lines)"),
-            github::GitHubError::InvalidPattern(_) => Self::data_error(e.to_string())
-                .with_next_step("Use a glob pattern like '*.rs' or '*.{ts,tsx}'"),
-            github::GitHubError::NonUtf8(_) => Self::data_error(e.to_string())
-                .with_next_step("Pass --encoding to decode non-UTF-8 files (e.g., shift_jis)"),
-            github::GitHubError::InsecureUrl => Self::data_error(e.to_string()),
-            github::GitHubError::Api { code, .. } if (400..500).contains(code) => {
-                Self::data_error(e.to_string())
-            }
-            // Priority 3: NOT_FOUND
-            github::GitHubError::NotFound(_) => Self::not_found(e.to_string()).with_next_step(
-                "Check that the repository or path exists, and that you have access",
-            ),
-            // Priority 4: TIMEOUT (request timeout via reqwest builder)
-            github::GitHubError::Network(re) if re.is_timeout() => timeout_with_retry_hint(&e),
-            // Priority 4: TEMP_FAILURE
-            github::GitHubError::RateLimited { retry_after } => Self::transient(e.to_string())
-                .with_next_step(match retry_after {
-                    Some(secs) => format!(
-                        "Retry after {secs} seconds, or set GITHUB_TOKEN to increase rate limit"
-                    ),
-                    None => "Set GITHUB_TOKEN to increase rate limit".to_owned(),
-                }),
-            github::GitHubError::Network(_) => transient_with_network_hint(&e),
-            github::GitHubError::Api { code, .. } if (500..=599).contains(code) => {
-                transient_with_retry_hint(&e)
-            }
-            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
-            github::GitHubError::Decode(_) => Self::internal_bug(e.to_string()),
-            // Unknown — Api codes that did not match 4xx or 5xx (e.g., 1xx/3xx leak)
-            github::GitHubError::Api { .. } => Self::unknown(e.to_string()),
-        }
+        let msg = e.to_string();
+        Self::from_classification(e.classify(), msg)
     }
 }
 
 impl From<FetchError> for ScoutError {
     fn from(e: FetchError) -> Self {
-        match &e {
-            // Priority 1: USAGE_ERROR
-            FetchError::BrowserNotFound(_) => Self::user_error(e.to_string()),
-            // Priority 2: DATA_ERROR (non-Status variants)
-            FetchError::InvalidScheme => {
-                Self::data_error(e.to_string()).with_next_step("URL must use http:// or https://")
-            }
-            FetchError::InvalidUrl(_) => {
-                Self::data_error(e.to_string()).with_next_step("URL must include scheme and host")
-            }
-            FetchError::InternalHost => Self::data_error(e.to_string())
-                .with_next_step("URL must point to an external host (private IPs are blocked)"),
-            FetchError::UnsupportedContentType(_) => Self::data_error(e.to_string())
-                .with_next_step("URL must serve HTML or text content"),
-            FetchError::RedirectMissingLocation => Self::data_error(e.to_string()),
-            FetchError::TooLarge => {
-                Self::data_error(e.to_string()).with_next_step("fetch a smaller resource")
-            }
-            // Classified as DataError (terminal) per priority 2. cap=5 absorbs
-            // canonical chains (HTTPS upgrade → trailing slash → final URL);
-            // breach dominantly indicates a server-side redirect loop or caller
-            // URL config mistake, both caller-fixable. Retry success rate is
-            // unobservable from inside scout (single-shot CLI with no
-            // caller-side telemetry seam), so the empirical calibration scoped
-            // in issue #148 cannot be run — terminal classification confirmed
-            // by first principles, not deferred.
-            FetchError::TooManyRedirects(_) => Self::data_error(e.to_string())
-                .with_next_step("URL has too many redirects; check for a redirect loop"),
-            // Status arms order specific HTTP codes before the 4xx / _ fallback;
-            // the per-arm priority label restores ADR-0011 ranking for review.
-            // Priority 1: USAGE_ERROR
-            FetchError::Status(401 | 403) => Self::user_error(e.to_string())
-                .with_next_step("URL requires authentication that scout does not support"),
-            // Priority 3: NOT_FOUND
-            FetchError::Status(404) => Self::not_found(e.to_string())
-                .with_next_step("Check that the URL is correct and the resource exists"),
-            // Priority 4: TEMP_FAILURE
-            FetchError::Status(408 | 429) => transient_with_retry_hint(&e),
-            // Priority 2: DATA_ERROR (4xx body)
-            FetchError::Status(code) if (400..500).contains(code) => {
-                Self::data_error(e.to_string())
-            }
-            // Priority 4: TEMP_FAILURE (5xx and other unmatched)
-            FetchError::Status(_) => transient_with_retry_hint(&e),
-            // Priority 4: TIMEOUT (transport timeout — long-backoff retry advised)
-            FetchError::Timeout(_) => timeout_with_retry_hint(&e),
-            // Priority 4: TEMP_FAILURE (non-Status variants)
-            FetchError::DnsResolution(_) => Self::transient(e.to_string())
-                .with_next_step("Check the URL's domain name and your DNS resolver"),
-            // `is_transient_network` covers connect, timeout, and mid-stream
-            // body drop (issue #113), but ADR-0002 splits timeout into 124.
-            // Check `is_timeout()` first.
-            FetchError::Http(re) if re.is_timeout() => timeout_with_retry_hint(&e),
-            FetchError::Http(re) if is_transient_network(re) => transient_with_network_hint(&e),
-            // Priority 5 sibling: IO_ERROR — external tool failure (browser)
-            FetchError::BrowserFailed(_) => Self::io_error(e.to_string()),
-            // Unknown — reqwest errors that do not match transient network patterns
-            FetchError::Http(_) => Self::unknown(e.to_string()),
-        }
+        let msg = e.to_string();
+        Self::from_classification(e.classify(), msg)
     }
 }
 
 impl From<SlackError> for ScoutError {
     fn from(e: SlackError) -> Self {
-        match &e {
-            // Priority 1: USAGE_ERROR
-            SlackError::TokenNotSet => Self::user_error(e.to_string())
-                .with_next_step("Export a User OAuth token to SLACK_TOKEN (xoxp-…)"),
-            // Priority 2: DATA_ERROR (insecure URL — peer to BraveError::InsecureBaseUrl)
-            SlackError::InsecureUrl => Self::data_error(e.to_string()),
-            // Slack API surfaces failures as error code strings (not HTTP status),
-            // so per-string classification replaces the priority-2 HTTP arm.
-            SlackError::Api { error } => match error.as_str() {
-                // Priority 3: NOT_FOUND. Underscore forms are Slack-native error
-                // codes; "message not found" (space) is scout's own string from
-                // `fetch_message` when the resolved messages list is empty.
-                "channel_not_found" | "message_not_found" | "thread_not_found"
-                | "message not found" => Self::not_found(e.to_string()),
-                // Priority 4: TEMP_FAILURE
-                "internal_error" | "service_unavailable" | "fatal_error" => {
-                    transient_with_retry_hint(&e)
-                }
-                // Priority 1: USAGE_ERROR (invalid_auth, missing_scope, etc.)
-                _ => Self::user_error(e.to_string()),
-            },
-            // Priority 4: TEMP_FAILURE
-            SlackError::RateLimited { .. } => transient_with_retry_hint(&e),
-            SlackError::Network(_) => transient_with_network_hint(&e),
-            // Priority 4: TIMEOUT
-            SlackError::Timeout(_) => timeout_with_retry_hint(&e),
-            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
-            SlackError::Decode(_) => Self::internal_bug(e.to_string()),
-        }
+        let msg = e.to_string();
+        Self::from_classification(e.classify(), msg)
     }
 }
 
 impl From<BraveError> for ScoutError {
     fn from(e: BraveError) -> Self {
-        match &e {
-            // Priority 1: USAGE_ERROR / config
-            BraveError::ApiKeyNotSet => Self::user_error(e.to_string())
-                .with_next_step("Set BRAVE_SEARCH_API_KEY environment variable"),
-            BraveError::Unauthorized => Self::user_error(e.to_string()).with_next_step(
-                "Verify BRAVE_SEARCH_API_KEY at https://api-dashboard.search.brave.com/",
-            ),
-            // Priority 2: DATA_ERROR (4xx body, URL parse failure, or insecure base URL)
-            BraveError::ParseUrl(_) | BraveError::InsecureBaseUrl => {
-                Self::data_error(e.to_string())
-            }
-            BraveError::Api { code, .. } if (400..500).contains(code) => {
-                Self::data_error(e.to_string())
-            }
-            // Priority 4: TIMEOUT
-            BraveError::Network(re) if re.is_timeout() => timeout_with_retry_hint(&e),
-            // Priority 4: TEMP_FAILURE
-            BraveError::RateLimited { .. } => transient_with_retry_hint(&e),
-            BraveError::Server(_) => transient_with_retry_hint(&e),
-            BraveError::Network(_) => transient_with_network_hint(&e),
-            BraveError::Api { code, .. } if (500..=599).contains(code) => {
-                transient_with_retry_hint(&e)
-            }
-            // Priority 5: INTERNAL — schema drift is a scout-side invariant;
-            // peer to `GitHubError::Decode` / `SlackError::Decode`. Oversized
-            // body is an upstream invariant violation (Brave returning >1 MiB
-            // on `web/search`), classified the same as schema drift because
-            // it signals the API surface drifted and retry will not recover.
-            BraveError::ParseJson(_) | BraveError::ResponseTooLarge => {
-                Self::internal_bug(e.to_string())
-            }
-            // Unknown — Api codes that did not match 4xx or 5xx
-            BraveError::Api { .. } => Self::unknown(e.to_string()),
-        }
+        let msg = e.to_string();
+        Self::from_classification(e.classify(), msg)
     }
 }
 
@@ -870,6 +723,8 @@ mod tests {
     async fn fetch_error_http_connection_refused_is_transient() {
         use reqwest::Client;
         use std::net::TcpListener;
+
+        use crate::retry::is_transient_network;
 
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## 概要

- `ScoutError` の `From<XxxError>` impl (4 個、約 190 行) が ADR-0011 priority table を match arm 順で表現していた。enum 定義と分離した中央集権 (`tools/errors.rs`) で、variant 追加時に分類ロジックが見えない問題があった。
- 各 backend error に `classify(&self) -> Classification` を生やし、variant 定義と classify を同一ファイル/同一 impl block に配置。`From` impl は `e.classify()` を呼ぶ 1-line wrapper に圧縮。
- 各 backend に `mod classify_tests` を新設 (計 34 件)。priority-sensitive arm (401 vs 4xx fallback など) の reorder 退行を `From` を経由せずに事前検知。

## スコープ補足

- CI の `-D warnings` 対応で副作用的な dead-code 整理:
  - 削除: `internal_bug` / `unknown` / `data_error` constructors (旧 `From` impl 専用、production 利用なし)
  - `#[cfg(test)]` gating: `transient` / `not_found` / `with_next_step` (test fixture でのみ利用)
  - `transient_with_retry_hint` 等の module-local helper fn → `Classification::transient_retry / transient_network / timeout_retry` constants に置換
- Tightening: `Classification` の field `pub` → `pub(crate)` (intent clarity、`new()/with_hint()` を唯一の construction path に)

## issue タイトルとの差分

issue #173 のタイトルは「arm 順依存を排除」だが、本 PR は **arm 順依存を完全排除しない**。`classify()` 内でも 401 を 4xx fallback より前に置く規約は残る。本 PR の効果は:

- **co-location**: 分類ロジックが variant 定義と同一ファイル
- **事前検知**: per-variant classify_tests で reorder 退行を `From` 経由せず検出 (旧 T-ER030 は事後検知)

完全な exhaustiveness 化は variant 分離 (例: `Api { 401 } → Unauthorized` への抽出) が必要で、本 PR の scope 外。

## フォローアップ

- #179: `BraveError::is_degradable()` を `classify().kind` ベースに統一して priority drift を防ぐ (polish レビューで検出)

## テスト計画

- [x] `cargo clippy --all-targets -- -D warnings` 通過
- [x] `cargo test --lib` 450 件成功 (旧 416 件 + 新 34 件)
- [x] 既存 regression test T-ER030 (401 → UsageError) 維持
- [x] T-ER001a–c (kind→exit code mapping) / T-ER020–026 (priority class) 維持

Closes #173