### PR TITLE
test: 実装を言い換えただけのテストを排除

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -731,35 +731,6 @@ mod http_tests {
             "production constructor must not skip HTTPS check"
         );
     }
-
-    /// [T-BC-CLK001] `BraveClient::with_clock` installs the supplied Arc into
-    /// `BraveClient.clock`. Mirrors `T-SB001` for ScoutBuilder. Guards against
-    /// silent drop of the injected clock in a future refactor.
-    #[test]
-    fn with_clock_installs_supplied_arc() {
-        use crate::clock::FixedClock;
-        let injected: Arc<dyn Clock> = Arc::new(FixedClock(42));
-        let client = BraveClient::with_base_url(Client::new(), "http://test.local")
-            .with_clock(injected.clone());
-        assert!(
-            Arc::ptr_eq(&client.clock, &injected),
-            "with_clock must install the supplied Arc into BraveClient.clock"
-        );
-    }
-
-    /// [T-BC-RNG001] `BraveClient::with_rng` installs the supplied Arc into
-    /// `BraveClient.rng`.
-    #[test]
-    fn with_rng_installs_supplied_arc() {
-        use crate::rng::SeededRng;
-        let injected: Arc<dyn Rng> = Arc::new(SeededRng::new(7));
-        let client = BraveClient::with_base_url(Client::new(), "http://test.local")
-            .with_rng(injected.clone());
-        assert!(
-            Arc::ptr_eq(&client.rng, &injected),
-            "with_rng must install the supplied Arc into BraveClient.rng"
-        );
-    }
 }
 
 #[cfg(test)]

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -36,14 +36,6 @@ impl Clock for FixedClock {
 mod tests {
     use super::*;
 
-    /// [T-CLOCK001] FixedClock echoes its constructor argument so callers can
-    /// pin `now` for deterministic retry-after arithmetic tests.
-    #[test]
-    fn fixed_clock_returns_constructor_value() {
-        let c = FixedClock(1_700_000_000);
-        assert_eq!(c.now_secs(), 1_700_000_000);
-    }
-
     /// [T-CLOCK002] SystemClock returns a unix epoch second that is plausibly
     /// "now" (after 2020-01-01). Guards against an accidental `Duration::ZERO`
     /// regression in the unwrap_or branch.

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -60,17 +60,6 @@ mod tests {
         }
     }
 
-    /// [T-RNG002] Two SeededRng with the same seed produce the same sequence,
-    /// proving deterministic seam works across calls (not just instances).
-    #[test]
-    fn seeded_rng_is_reproducible_under_identical_seed() {
-        let a = SeededRng::new(42);
-        let b = SeededRng::new(42);
-        for _ in 0..5 {
-            assert_eq!(a.u64_below(1_000_000), b.u64_below(1_000_000));
-        }
-    }
-
     /// [T-RNG003] Repeated calls on the same SeededRng advance the internal
     /// state — guards against the earlier `self.0.clone()` bug where every
     /// call returned the seed's first sample.

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -421,30 +421,4 @@ mod tests {
             .unwrap_err();
         assert!(matches!(err, BraveError::RateLimited { .. }));
     }
-
-    /// [T-SE011] fetch_sources sort restores input order after buffer_unordered
-    #[test]
-    fn fetch_sources_sort_restores_input_order() {
-        let mut indexed_pages: Vec<(usize, FetchResult)> = vec![
-            (
-                2,
-                FetchResult::for_test("https://c.com".into(), String::new(), false),
-            ),
-            (
-                0,
-                FetchResult::for_test("https://a.com".into(), String::new(), false),
-            ),
-            (
-                1,
-                FetchResult::for_test("https://b.com".into(), String::new(), false),
-            ),
-        ];
-
-        indexed_pages.sort_by_key(|(idx, _)| *idx);
-        let pages: Vec<_> = indexed_pages.into_iter().map(|(_, page)| page).collect();
-
-        assert_eq!(pages[0].url(), "https://a.com");
-        assert_eq!(pages[1].url(), "https://b.com");
-        assert_eq!(pages[2].url(), "https://c.com");
-    }
 }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1186,41 +1186,6 @@ parent body
             assert_eq!(resolved[0].author, "UXXX");
         }
     }
-
-    mod injection_tests {
-        use super::*;
-        use reqwest::Client;
-
-        /// [T-SK-CLK001] `SlackClient::with_clock` installs the supplied Arc
-        /// into `SlackClient.clock`. Mirrors `T-SB001` for ScoutBuilder.
-        /// Guards against silent drop of the injected clock in a future
-        /// refactor of `api_get_once`.
-        #[test]
-        fn with_clock_installs_supplied_arc() {
-            use crate::clock::FixedClock;
-            let injected: Arc<dyn Clock> = Arc::new(FixedClock(42));
-            let client = SlackClient::with_base_url(Client::new(), "http://test.local")
-                .with_clock(injected.clone());
-            assert!(
-                Arc::ptr_eq(&client.clock, &injected),
-                "with_clock must install the supplied Arc into SlackClient.clock"
-            );
-        }
-
-        /// [T-SK-RNG001] `SlackClient::with_rng` installs the supplied Arc
-        /// into `SlackClient.rng`.
-        #[test]
-        fn with_rng_installs_supplied_arc() {
-            use crate::rng::SeededRng;
-            let injected: Arc<dyn Rng> = Arc::new(SeededRng::new(7));
-            let client = SlackClient::with_base_url(Client::new(), "http://test.local")
-                .with_rng(injected.clone());
-            assert!(
-                Arc::ptr_eq(&client.rng, &injected),
-                "with_rng must install the supplied Arc into SlackClient.rng"
-            );
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/token_source.rs
+++ b/src/token_source.rs
@@ -118,24 +118,4 @@ mod tests {
         .await;
         assert_eq!(token.as_ref().map(Redacted::expose), Some("real-token"));
     }
-
-    /// [T-TS003] StaticTokenSource(Some(...)) propagates the constructor value
-    /// to fetch() callers without ever spawning the gh subprocess.
-    #[tokio::test]
-    async fn static_token_source_returns_constructor_value() {
-        let source = StaticTokenSource(Some(
-            Redacted::new("fixed").expect("static literal is non-empty"),
-        ));
-        let token = source.fetch().await;
-        assert_eq!(token.as_ref().map(Redacted::expose), Some("fixed"));
-    }
-
-    /// [T-TS004] StaticTokenSource(None) simulates the unauthenticated path so
-    /// callers can verify rate-limit-tier handling.
-    #[tokio::test]
-    async fn static_token_source_none_returns_none() {
-        let source = StaticTokenSource(None);
-        let token = source.fetch().await;
-        assert!(token.is_none());
-    }
 }

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -107,11 +107,6 @@ impl ScoutError {
         Self::new(ErrorCode::IoError, msg)
     }
 
-    #[cfg(test)]
-    pub(super) fn transient(msg: impl Into<String>) -> Self {
-        Self::new(ErrorCode::TempFailure, msg)
-    }
-
     /// Timeout (request-level or transport-level). Maps to `ErrorCode::Timeout`
     /// (exit 124, GNU coreutils `timeout`) per ADR-0002. Retryable like
     /// `transient`, but separated so caller scripts/agents can apply a longer
@@ -239,20 +234,6 @@ pub(super) fn unwrap_or_degraded<T>(
 mod tests {
     use super::*;
 
-    /// [T-ER010] user_error returns ErrorCode::UsageError
-    #[test]
-    fn user_error_kind_is_usage() {
-        let err = ScoutError::user_error("test");
-        assert_eq!(err.error_kind(), ErrorCode::UsageError);
-    }
-
-    /// [T-ER011] transient returns ErrorCode::TempFailure
-    #[test]
-    fn transient_kind_is_temp_failure() {
-        let err = ScoutError::transient("test");
-        assert_eq!(err.error_kind(), ErrorCode::TempFailure);
-    }
-
     /// [T-ER012] io_error returns ErrorCode::IoError
     #[test]
     fn io_error_kind_is_io_error() {
@@ -360,34 +341,6 @@ mod tests {
         let err = ScoutError::io_error("io failure");
         let display = err.to_string();
         assert_eq!(display, "io failure");
-    }
-
-    /// [T-ER013] GitHubError::NotFound classifies as ErrorCode::NotFound
-    #[test]
-    fn github_not_found_classifies_as_not_found() {
-        let err = ScoutError::from(github::GitHubError::NotFound("/test".into()));
-        assert_eq!(err.error_kind(), ErrorCode::NotFound);
-    }
-
-    /// [T-ER014] GitHubError::InvalidRepo classifies as ErrorCode::DataError
-    #[test]
-    fn github_invalid_repo_classifies_as_data_error() {
-        let err = ScoutError::from(github::GitHubError::InvalidRepo("bad".into()));
-        assert_eq!(err.error_kind(), ErrorCode::DataError);
-    }
-
-    /// [T-ER015] FetchError::InvalidScheme classifies as ErrorCode::DataError
-    #[test]
-    fn fetch_invalid_scheme_classifies_as_data_error() {
-        let err = ScoutError::from(FetchError::InvalidScheme);
-        assert_eq!(err.error_kind(), ErrorCode::DataError);
-    }
-
-    /// [T-ER016] FetchError::Status(404) classifies as ErrorCode::NotFound
-    #[test]
-    fn fetch_status_404_classifies_as_not_found() {
-        let err = ScoutError::from(FetchError::Status(404));
-        assert_eq!(err.error_kind(), ErrorCode::NotFound);
     }
 
     /// [T-ER020] SlackError::Api with internal_error classifies as TempFailure (ADR-0003)


### PR DESCRIPTION
## 概要

実装をただ言い換えただけで観察可能な振る舞いを検証しないテスト15件 (+ テスト専用ヘルパ1件) を削除しました。7ファイル / 176行削除・0行追加。

## 削除したテストと根拠

### ① mock/fixture の往復確認
- `FixedClock`/`SeededRng`/`StaticTokenSource` の echo テスト、`BraveClient`/`SlackClient` の `with_clock`/`with_rng` ptr_eq setter テスト (clock T-CLOCK001, rng T-RNG002, token_source T-TS003/004, brave T-BC-CLK001/RNG001, slack T-SK-CLK001/RNG001)。
- fixture 定義自体は維持。振る舞いは retry (T-R007/009/010) / github (T-GH018/019) / ScoutBuilder seam (T-SB001-004) テストで exercise 済み。`with_clock`/`with_rng` は production で使用継続のため dead code 化なし。

### ② トートロジー
- engine `fetch_sources_sort_restores_input_order` (T-SE011) は SUT を呼ばずテスト本体で sort 式を再現していた (false coverage)。`fetch_sources` はネットワーク依存のため軽量代替は追加しない。

### ④ 実装分岐のなぞりにすぎないエラー確認
- errors.rs の `error_kind()` のみ検証するテスト (T-ER010/011/013/014/015/016)。exit-code 契約テスト (T-ER001a/b/c) の厳密サブセット、または config T-CFG010 で behavioral にカバー済み。
- 削除した T-ER011 専用の `ScoutError::transient` ヘルパも除去。

## 維持した判断

- 書き換え0件: 契約 pin (exit-code テーブル T-EN014, wire format, SSRF allowlist, signals 130/143, lang ja/en) は既にリテラル/集合一致で記述済。
- ADR 参照の契約テスト (T-SB/T-DNS/T-GH011/T-ER001/T-ER020-030 等)、classify_tests、isolated+e2e seam は意図的設計のため不変更。
- audit docs (時点スナップショット) は据え置き。

## 確認

- `cargo test --all-features`: lib 440 + integration 11 緑
- `cargo clippy --all-features --all-targets -- -D warnings`: 緑