### PR TITLE
ci: diff coverage gate を追加 (ubuntu variant)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,41 @@ jobs:
 
       - name: Format check
         run: cargo fmt -- --check
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cde8c9e634f4a17bc06b61413ac0ef75450eac46 # v2.81.4
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --features js-rendering --lcov --output-path lcov.info
+
+      - name: Diff coverage gate
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install diff-cover
+          .venv/bin/diff-cover lcov.info --compare-branch=origin/main --fail-under=95
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/*
 !docs/audit/
 target/
 workspace/
+*.profraw
+/lcov.info


### PR DESCRIPTION
## 概要

cli/ 配下への diff coverage gate 横断展開の一環 (#183)。test job と security job の間に `coverage` job を追加し、PR の変更行カバレッジが 95% を下回ると fail させる。未テストの新規 `pub fn` / 分岐の merge を防ぐ。全体 percent の floor は持たない (到達不可コードの誤検知回避)。

## 変更内容

- `.github/workflows/ci.yml`: `coverage` job を追加 (Format check の後ろ)
  - `runs-on: ubuntu-latest` / `timeout-minutes: 20` / `if: pull_request` / `permissions: contents: read`
  - `cargo-llvm-cov` で `--features js-rendering` (test job と一致)
  - `diff-cover` を venv 隔離し `--compare-branch=origin/main --fail-under=95`
- `.gitignore`: coverage 生成物 (`*.profraw` / `/lcov.info`) を追加

## 判断ポイント

- Action SHA は issue 記載の旧 pin ではなくリポジトリ現行 pin (checkout v6.0.3 / install-action v2.81.4) に統一。Renovate の一括管理に揃えるため。
- features は「テストと一致」原則で `--features js-rendering` を採用。重すぎる/isolation 起因で fail する場合は `cargo llvm-cov nextest` か default features への fallback あり (CI で確認)。

## 完了条件

- ci.yml / .gitignore のみの変更のため、coverage job は **N/A pass** ("No lines with coverage information in this diff") となる想定。

Closes #183