### PR TITLE
fix(output): 出力の外部 URL scheme と YAML マーカーをエスケープ (#187)

### DIFF
--- a/src/fetch/converter.rs
+++ b/src/fetch/converter.rs
@@ -70,8 +70,48 @@ fn format_with_frontmatter(article: &ExtractedArticle, markdown: &str) -> String
     }
 
     fm.push_str("---\n\n");
-    fm.push_str(markdown);
+    // The body is untrusted page content appended after the frontmatter; neutralize
+    // any column-0 `---`/`...` so it cannot inject a YAML document boundary.
+    fm.push_str(&neutralize_yaml_markers(markdown));
     fm
+}
+
+/// Neutralize YAML document markers in untrusted body text appended after a
+/// `---`-delimited frontmatter block.  A line that is exactly `---` or `...` (a
+/// YAML document start/end marker, and also a Markdown thematic break) is rewritten
+/// to `***`, which renders as the same thematic break but is not a YAML marker, so
+/// the body cannot inject a document boundary or a forged frontmatter block.  Only
+/// column-0 markers are rewritten; indented or inline `---` is ordinary content and
+/// left intact.
+pub(crate) fn neutralize_yaml_markers(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    for (i, line) in body.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        match yaml_marker_rest(line) {
+            // Bare marker (only trailing whitespace): collapse to `***`.
+            Some(rest) if rest.trim_matches([' ', '\t', '\r']).is_empty() => out.push_str("***"),
+            // Marker with content (`--- evil: true`): rewrite the leading token only,
+            // preserving the rest as ordinary text.
+            Some(rest) => {
+                out.push_str("***");
+                out.push_str(rest);
+            }
+            None => out.push_str(line),
+        }
+    }
+    out
+}
+
+/// If `line` is a YAML document marker (`---` start or `...` end) at column 0 —
+/// the three chars followed by end-of-line or whitespace — return the text after
+/// the marker (`""` for a bare marker).  `----` and `...foo` are not markers.
+fn yaml_marker_rest(line: &str) -> Option<&str> {
+    let token = line
+        .strip_prefix("---")
+        .or_else(|| line.strip_prefix("..."))?;
+    (token.is_empty() || token.starts_with([' ', '\t', '\r'])).then_some(token)
 }
 
 pub(crate) fn escape_yaml(s: &str) -> String {
@@ -145,5 +185,60 @@ mod tests {
             escape_yaml("She said \"hi\"\nand left\\"),
             "She said \\\"hi\\\"\\nand left\\\\"
         );
+    }
+
+    /// [T-FC005] neutralize_yaml_markers rewrites bare ---/... lines to ***
+    #[test]
+    fn neutralize_yaml_markers_rewrites_bare_doc_markers() {
+        assert_eq!(
+            neutralize_yaml_markers("before\n---\nmiddle\n...\nafter"),
+            "before\n***\nmiddle\n***\nafter"
+        );
+        // Trailing whitespace / CR on the marker line is tolerated.
+        assert_eq!(neutralize_yaml_markers("---  "), "***");
+        assert_eq!(neutralize_yaml_markers("...\r"), "***");
+    }
+
+    /// [T-FC006] neutralize_yaml_markers leaves indented and inline --- intact
+    #[test]
+    fn neutralize_yaml_markers_preserves_non_markers() {
+        // Indented `---` is not a YAML document marker (must be at column 0).
+        assert_eq!(neutralize_yaml_markers("  ---"), "  ---");
+        // `---` embedded in a line is ordinary content.
+        assert_eq!(neutralize_yaml_markers("a --- b"), "a --- b");
+        assert_eq!(neutralize_yaml_markers("----"), "----");
+        assert_eq!(neutralize_yaml_markers("...foo"), "...foo");
+        assert_eq!(neutralize_yaml_markers("plain"), "plain");
+    }
+
+    /// [T-FC007] neutralize_yaml_markers catches markers carrying inline content
+    /// (`--- evil: true`), which a YAML parser still honors as a document start
+    #[test]
+    fn neutralize_yaml_markers_rewrites_marker_with_content() {
+        assert_eq!(neutralize_yaml_markers("--- evil: true"), "*** evil: true");
+        assert_eq!(neutralize_yaml_markers("--- #x"), "*** #x");
+        assert_eq!(neutralize_yaml_markers("---\tfoo"), "***\tfoo");
+        assert_eq!(neutralize_yaml_markers("... bar"), "*** bar");
+    }
+
+    /// [T-FC008] format_with_frontmatter neutralizes doc markers in the page body
+    #[test]
+    fn frontmatter_body_cannot_inject_document_marker() {
+        let article = ExtractedArticle {
+            title: Some("T".into()),
+            byline: None,
+            published_time: None,
+            content_html: String::new(),
+            used_raw_fallback: false,
+        };
+        let body = "intro\n---\ninjected: pwned\nreal";
+        let out = format_with_frontmatter(&article, body);
+
+        let after_fm = out.split("---\n\n").nth(1).expect("body after frontmatter");
+        assert!(
+            !after_fm.lines().any(|l| l == "---" || l == "..."),
+            "page body must not introduce a bare YAML document marker:\n{out}"
+        );
+        assert!(after_fm.contains("injected: pwned"));
     }
 }

--- a/src/github/format.rs
+++ b/src/github/format.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use super::types::{IssueInfo, PullInfo, ReleaseInfo, RepoInfo, TreeEntry};
-use crate::markdown::{escape_md_inline, escape_md_link, shift_headings};
+use crate::markdown::{escape_md_inline, md_link, shift_headings};
 
 const MAX_README_BYTES: usize = 24_000;
 
@@ -200,9 +200,8 @@ fn format_issues_section(issues: &[IssueInfo], out: &mut String) {
             .unwrap_or_default();
         let _ = writeln!(
             out,
-            "- [#{}]({}) {}{}{}",
-            issue.number,
-            escape_md_link(&issue.html_url),
+            "- {} {}{}{}",
+            md_link(&format!("#{}", issue.number), &issue.html_url),
             escape_md_inline(&issue.title),
             escape_md_inline(&labels),
             user
@@ -229,9 +228,8 @@ fn format_pulls_section(pulls: &[PullInfo], out: &mut String) {
             .unwrap_or_default();
         let _ = writeln!(
             out,
-            "- [#{}]({}) {}{}{}",
-            pr.number,
-            escape_md_link(&pr.html_url),
+            "- {} {}{}{}",
+            md_link(&format!("#{}", pr.number), &pr.html_url),
             escape_md_inline(&pr.title),
             draft,
             user
@@ -259,9 +257,8 @@ fn format_releases_section(releases: &[ReleaseInfo], out: &mut String) {
         };
         let _ = writeln!(
             out,
-            "- [{}]({}) — {}{}",
-            escape_md_inline(name),
-            escape_md_link(&release.html_url),
+            "- {} — {}{}",
+            md_link(name, &release.html_url),
             date,
             pre
         );

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 
 /// Escape characters that break Markdown link syntax: `[`, `]`, `(`, `)`.
+/// Newlines are folded to spaces so an untrusted value cannot break onto a new
+/// line and inject block Markdown (a heading or list item).
 pub(crate) fn escape_md_link(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -9,10 +11,32 @@ pub(crate) fn escape_md_link(s: &str) -> String {
                 out.push('\\');
                 out.push(c);
             }
+            '\n' | '\r' => out.push(' '),
             _ => out.push(c),
         }
     }
     out
+}
+
+/// Render a Markdown link `[text](url)` only when `url` carries an http/https
+/// scheme.  Untrusted URLs with any other scheme (`javascript:`, `data:`, …) are
+/// emitted as inert escaped text `text (url)` so they can never become a
+/// clickable/executable link target.  Allowlisting fails closed: obfuscated or
+/// whitespace-prefixed schemes do not match http/https and are neutralized.
+pub(crate) fn md_link(text: &str, url: &str) -> String {
+    let lower = url.to_ascii_lowercase();
+    let scheme_ok = lower.starts_with("http://") || lower.starts_with("https://");
+    // A real URL carries no ASCII whitespace or control chars; a raw newline in the
+    // link target would break out of `[](…)` and inject Markdown, so route any such
+    // value to the inert branch (where newlines are collapsed to spaces).
+    let clean = !url
+        .bytes()
+        .any(|b| b.is_ascii_whitespace() || b.is_ascii_control());
+    if scheme_ok && clean {
+        format!("[{}]({})", escape_md_inline(text), escape_md_link(url))
+    } else {
+        format!("{} ({})", escape_md_inline(text), escape_md_inline(url))
+    }
 }
 
 /// Sanitize untrusted input for embedding in Markdown table cells and inline text.
@@ -118,6 +142,8 @@ mod tests {
     fn escapes_special_chars() {
         assert_eq!(escape_md_link("normal text"), "normal text");
         assert_eq!(escape_md_link("a[b]c(d)e"), r"a\[b\]c\(d\)e");
+        // Newlines fold to spaces so the value cannot inject a new Markdown line.
+        assert_eq!(escape_md_link("a\n## h"), "a ## h");
     }
 
     /// [T-MD002] escape_md_inline escapes pipes and replaces newlines
@@ -203,6 +229,53 @@ mod tests {
             result, "###### H5\n###### H6\n### H1",
             "shifted headings must clamp at h6 (6 hashes max)"
         );
+    }
+
+    /// [T-MD014] md_link renders a clickable link for http/https targets
+    #[test]
+    fn md_link_renders_safe_scheme() {
+        assert_eq!(md_link("A", "https://a.com"), "[A](https://a.com)");
+        assert_eq!(md_link("A", "http://a.com"), "[A](http://a.com)");
+    }
+
+    /// [T-MD015] md_link neutralizes javascript:/data: targets to inert text
+    #[test]
+    fn md_link_neutralizes_unsafe_scheme() {
+        assert_eq!(
+            md_link("click", "javascript:alert(1)"),
+            r"click (javascript:alert\(1\))"
+        );
+        assert_eq!(
+            md_link("x", "data:text/html,<script>"),
+            "x (data:text/html,<script>)"
+        );
+    }
+
+    /// [T-MD016] md_link fails closed on scheme obfuscation (case, leading space)
+    #[test]
+    fn md_link_unsafe_scheme_obfuscation_fails_closed() {
+        assert_eq!(
+            md_link("x", "JaVaScRiPt:alert(1)"),
+            r"x (JaVaScRiPt:alert\(1\))"
+        );
+        // Leading whitespace is not http/https -> inert (whitespace newlines collapsed).
+        assert_eq!(md_link("x", " javascript:1"), "x ( javascript:1)");
+    }
+
+    /// [T-MD017] md_link escapes link syntax in the visible text
+    #[test]
+    fn md_link_escapes_text() {
+        assert_eq!(md_link("a]b", "https://a.com"), r"[a\]b](https://a.com)");
+    }
+
+    /// [T-MD018] md_link routes a newline-bearing URL to the inert branch so it
+    /// cannot break out of `[](…)` and inject Markdown
+    #[test]
+    fn md_link_newline_in_url_cannot_break_out() {
+        let out = md_link("x", "https://a.com\n## Injected");
+        assert!(!out.contains("](https://"), "must not stay a link: {out}");
+        assert!(!out.contains('\n'), "newline must be collapsed: {out}");
+        assert_eq!(out, "x (https://a.com ## Injected)");
     }
 
     /// [T-MD011] truncate_with_note returns input unchanged when under limit

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -14,7 +14,7 @@ use crate::fetch;
 use crate::fetch::DnsResolver;
 use crate::fetch::converter::FetchResult;
 use crate::markdown::{
-    escape_md_inline, escape_md_link, sanitize_heading, shift_headings, truncate_with_note,
+    escape_md_inline, escape_md_link, md_link, sanitize_heading, shift_headings, truncate_with_note,
 };
 use crate::search::Lang;
 
@@ -169,12 +169,7 @@ fn format_sources(sources: &[SearchResult], out: &mut String) {
     }
     out.push_str("## Sources\n\n");
     for source in sources {
-        let _ = writeln!(
-            out,
-            "- [{}]({})",
-            escape_md_inline(&source.title),
-            escape_md_link(&source.url)
-        );
+        let _ = writeln!(out, "- {}", md_link(&source.title, &source.url));
     }
 }
 

--- a/src/search/engine/tests.rs
+++ b/src/search/engine/tests.rs
@@ -77,6 +77,26 @@ fn format_report_includes_sections() {
     assert!(text.contains("[A](https://a.com)"));
 }
 
+/// [T-SE010] a source URL with a non-http scheme is not emitted as a clickable link
+#[test]
+fn format_report_neutralizes_javascript_source_url() {
+    let report = ResearchReport {
+        fetched_pages: vec![],
+        failed_urls: vec![],
+        sources: vec![make_source("javascript:alert(1)", "Evil")],
+    };
+
+    let text = format_report(&report, "q");
+    assert!(
+        !text.contains("](javascript:"),
+        "javascript: URL must not become a clickable Markdown link, got:\n{text}"
+    );
+    assert!(
+        text.contains("Evil (javascript:"),
+        "the URL is preserved as inert text, got:\n{text}"
+    );
+}
+
 /// [T-7] AC-3.1: format_report does not emit "## Search Result" header
 #[test]
 fn format_report_omits_search_result_header() {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use tracing::{debug, warn};
 
 use crate::envelope::ErrorCode;
-use crate::fetch::converter::escape_yaml;
+use crate::fetch::converter::{escape_yaml, neutralize_yaml_markers};
 use crate::tools::Classification;
 
 mod client;
@@ -310,7 +310,7 @@ fn format_slack_output(
     out.push_str(&format!("url: \"{}\"\n", escape(&slack_url.raw_url)));
     out.push_str("---\n\n");
 
-    out.push_str(&first.text);
+    out.push_str(&neutralize_yaml_markers(&first.text));
 
     for msg in replies {
         let ts_suffix = if msg.ts.is_empty() {
@@ -320,7 +320,9 @@ fn format_slack_output(
         };
         out.push_str(&format!(
             "\n\n---\n\n{}{}:\n{}",
-            msg.author, ts_suffix, msg.text
+            neutralize_yaml_markers(&msg.author),
+            ts_suffix,
+            neutralize_yaml_markers(&msg.text)
         ));
     }
 

--- a/src/slack/url_tests.rs
+++ b/src/slack/url_tests.rs
@@ -68,6 +68,64 @@ parent body
     assert_eq!(output, expected);
 }
 
+/// [T-SK015] an untrusted message body starting with `---` cannot inject a YAML
+/// document boundary into scout's frontmatter output (a naive multi-document YAML
+/// reader splits on bare `---`/`...` lines; the body must contribute none).
+#[test]
+fn body_cannot_inject_yaml_document_marker() {
+    let slack_url = parse_slack_url("https://team.slack.com/archives/C123/p1111111111222222")
+        .expect("URL fixture should parse");
+    let first = ResolvedMessage {
+        author: "attacker".into(),
+        text: "---\ninjected: pwned\nreal body".into(),
+        ts: "1111111111.222222".into(),
+    };
+    let output = format_slack_output(&slack_url, "#general", &first, &[]);
+
+    let body = output
+        .split("---\n\n")
+        .nth(1)
+        .expect("body follows the frontmatter close delimiter");
+    assert!(
+        !body.lines().any(|l| l == "---" || l == "..."),
+        "untrusted body must not introduce a bare YAML document marker, got:\n{output}"
+    );
+    assert!(
+        body.contains("injected: pwned"),
+        "body content is preserved (only the marker line is rewritten):\n{output}"
+    );
+}
+
+/// [T-SK016] a reply author's untrusted display name (user-settable) cannot inject
+/// a YAML document marker into the body either
+#[test]
+fn reply_author_cannot_inject_yaml_document_marker() {
+    let slack_url = parse_slack_url("https://team.slack.com/archives/C123/p1111111111222222")
+        .expect("URL fixture should parse");
+    let first = ResolvedMessage {
+        author: "alice".into(),
+        text: "hello".into(),
+        ts: "1111111111.222222".into(),
+    };
+    let reply = ResolvedMessage {
+        author: "evil\n---\ninjected: pwned".into(),
+        text: "reply".into(),
+        ts: "1234567890.123456".into(),
+    };
+    let output = format_slack_output(&slack_url, "#general", &first, &[reply]);
+
+    // The only bare `---` lines scout emits are structural: the frontmatter open and
+    // close, plus one separator per reply. Untrusted content must add none.
+    let bare_markers = output
+        .lines()
+        .filter(|l| *l == "---" || *l == "...")
+        .count();
+    assert_eq!(
+        bare_markers, 3,
+        "expected 2 frontmatter delimiters + 1 reply separator and no injected marker, got:\n{output}"
+    );
+}
+
 fn msg(ts: &str, author: &str) -> ResolvedMessage {
     ResolvedMessage {
         author: author.into(),


### PR DESCRIPTION
## 概要

issue #187（priority:high / security）を修正。外部 API 由来の文字列が scout の出力（AI エージェントの context・Markdown レンダラに到達）に渡る際の、2つの注入 sink を塞ぐ。

Closes #187

## 修正内容

### Fix 1 — Markdown リンクの scheme allowlist
- `md_link(text, url)` を新設。http/https のみリンク化し、それ以外（`javascript:` / `data:` / protocol-relative `//` / 大小・空白・制御文字・改行混入）は inert な `text (url)` として出力（fail-closed）。
- 全リンクターゲット呼び出しを移行: Brave sources（`search/engine.rs`）、GitHub issue/PR/release（`github/format.rs`）。
- `escape_md_link` も改行を空白に畳み込み、failed-URL 経路の改行 breakout を封鎖。

### Fix 2 — YAML 文書境界注入
- `neutralize_yaml_markers(body)` を新設。`---` frontmatter ブロックの後に追記される本文の column-0 マーカー（`---` / `...`、`--- evil: true` のような content 付きも）を `***` に書き換え。
- 適用箇所: Slack メッセージ本文・author、および一次 fetch 経路のページ本文（`fetch/converter.rs`）。

## セキュリティ監査

`reviewer-security` を 2 巡（実装後 + 最終検証）実施。
- 1巡目: 一次 fetch 経路の未修正・marker 変種の取りこぼし・改行 breakout を検出 → 全て修正。
- 2巡目（検証）: 上記3件のクローズを確認し、reply author の未サニタイズ展開（ユーザ設定の Slack 表示名による同クラス注入）を新規検出 → 修正。

## テスト

- `md_link`: scheme allowlist / obfuscation fail-closed / 改行 breakout（T-MD014〜018）
- `neutralize_yaml_markers`: bare・content 付きマーカー・非マーカー（T-FC005〜008）
- Slack 本文・author の注入不可（T-SK015/016）、Brave source の javascript URL 無害化（T-SE010）
- 全 460 テスト green / `cargo fmt --check` / `cargo clippy` clean

## 既知のトレードオフ

`---` → `***` 変換は fetch ページ本文の YAML コードサンプル内 `---` も書き換えるため、その表示忠実度がわずかに低下する（render 上は同一の thematic break）。YAML 注入遮断を優先。
