### PR TITLE
fix(github): API レスポンスのボディを上限管理して OOM リスクを抑える (#186)

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -253,8 +253,13 @@ impl BraveClient {
             .await?;
 
         let response = classify_response(response, self.clock.as_ref()).await?;
-        let bytes =
-            read_body_capped(response, || BraveError::ResponseTooLarge, BraveError::from).await?;
+        let bytes = read_body_capped(
+            response,
+            MAX_API_RESPONSE_BYTES,
+            || BraveError::ResponseTooLarge,
+            BraveError::from,
+        )
+        .await?;
         let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
 
         info!(

--- a/src/github.rs
+++ b/src/github.rs
@@ -17,8 +17,8 @@ use crate::redacted::{Redacted, validate_https};
 #[cfg(test)]
 use crate::retry::DEFAULT_MAX_RETRIES;
 use crate::retry::{
-    is_schema_decode_fail, is_transient_network, parse_retry_after, retry_after_within_cap,
-    retry_with_rate_limit,
+    MAX_GITHUB_RESPONSE_BYTES, is_transient_network, parse_retry_after, read_body_capped,
+    retry_after_within_cap, retry_with_rate_limit,
 };
 use crate::rng::{FastrandRng, Rng};
 use crate::token_source::TokenSource;
@@ -162,16 +162,22 @@ impl GitHubClient {
         let status = response.status();
         debug!(path, status = %status, "github API response");
         match status.as_u16() {
-            // Schema fail → Decode (terminal). Transport drop / connect /
-            // timeout → Network → retry loop. See `is_schema_decode_fail`
-            // for the source-chain discrimination (issue #113).
-            200..=299 => response.json().await.map_err(|e| {
-                if is_schema_decode_fail(&e) {
-                    GitHubError::Decode(e.to_string())
-                } else {
-                    e.into()
-                }
-            }),
+            // Body capped at `MAX_GITHUB_RESPONSE_BYTES` to bound the memory an
+            // oversized response can consume (issue #186). Splitting the read
+            // from the parse also separates failure modes: a transport drop is
+            // mapped to `Network` by `GitHubError::from` (→ retry loop), while a
+            // schema mismatch surfaces from `serde_json::from_slice` as terminal
+            // `Decode` (issue #113).
+            200..=299 => {
+                let bytes = read_body_capped(
+                    response,
+                    MAX_GITHUB_RESPONSE_BYTES,
+                    || GitHubError::ResponseTooLarge,
+                    GitHubError::from,
+                )
+                .await?;
+                serde_json::from_slice(&bytes).map_err(|e| GitHubError::Decode(e.to_string()))
+            }
             404 => Err(GitHubError::NotFound(path.to_owned())),
             429 => {
                 let retry_after = parse_retry_after(response.headers(), self.clock.as_ref());

--- a/src/github/errors.rs
+++ b/src/github/errors.rs
@@ -1,4 +1,5 @@
 use crate::envelope::ErrorCode;
+use crate::retry::MAX_GITHUB_RESPONSE_BYTES;
 use crate::tools::Classification;
 
 #[derive(Debug, thiserror::Error)]
@@ -34,6 +35,9 @@ pub(crate) enum GitHubError {
 
     #[error("Invalid glob pattern: {0}")]
     InvalidPattern(String),
+
+    #[error("GitHub API response too large (>{MAX_GITHUB_RESPONSE_BYTES} bytes)")]
+    ResponseTooLarge,
 
     #[error("Content decode error: {0}")]
     Decode(String),
@@ -93,8 +97,11 @@ impl GitHubError {
             Self::Api { code, .. } if (500..=599).contains(code) => {
                 Classification::transient_retry()
             }
-            // Priority 5: INTERNAL — scout-side bug (unexpected schema)
-            Self::Decode(_) => Classification::new(ErrorCode::Internal),
+            // Priority 5: INTERNAL — scout-side bug (unexpected schema) or a
+            // response that overran the byte cap (issue #186; peer to
+            // BraveError::ResponseTooLarge). Non-retriable: a retry would refetch
+            // the same oversized body.
+            Self::Decode(_) | Self::ResponseTooLarge => Classification::new(ErrorCode::Internal),
             // Unknown — Api codes that did not match 4xx or 5xx (e.g., 1xx/3xx leak)
             Self::Api { .. } => Classification::new(ErrorCode::Unknown),
         }

--- a/src/github/errors/classify_tests.rs
+++ b/src/github/errors/classify_tests.rs
@@ -128,6 +128,14 @@ fn decode_is_internal() {
     assert_eq!(c.kind, ErrorCode::Internal);
 }
 
+/// [T-GHC010] ResponseTooLarge classifies as Internal per ADR-0011 priority 5,
+/// peer to Decode (issue #186). End-to-end non-retriability is pinned by T-GH020.
+#[test]
+fn response_too_large_is_internal() {
+    let c = GitHubError::ResponseTooLarge.classify();
+    assert_eq!(c.kind, ErrorCode::Internal);
+}
+
 /// [T-GHC009] Api codes outside 4xx/5xx (e.g., 1xx/3xx leak) land on Unknown.
 #[test]
 fn api_non_4xx_5xx_is_unknown() {

--- a/src/github/http_tests.rs
+++ b/src/github/http_tests.rs
@@ -288,6 +288,32 @@ async fn get_json_2xx_mid_stream_drop_exhausts_retries() {
     let _ = handle.join();
 }
 
+/// [T-GH020] A 2xx response whose body exceeds `MAX_GITHUB_RESPONSE_BYTES`
+/// returns `ResponseTooLarge` instead of buffering the whole body (issue #186).
+/// The variant is non-retriable, so the mock is hit exactly once.
+#[tokio::test]
+async fn get_json_2xx_oversized_body_returns_too_large() {
+    let Some(server) = try_spawn_mock_server("github::http").await else {
+        return;
+    };
+    // One byte past the cap. wiremock sets a matching Content-Length, so this
+    // exercises the pre-check arm (the chunk-loop arm guards a lying/absent header).
+    let body = vec![b'x'; MAX_GITHUB_RESPONSE_BYTES + 1];
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = GitHubClient::with_base_url(Client::new(), &server.uri());
+    let result: Result<RepoInfo, _> = client.get_json("/repos/owner/repo").await;
+    assert!(
+        matches!(result, Err(GitHubError::ResponseTooLarge)),
+        "expected ResponseTooLarge for oversized 2xx body, got: {result:?}"
+    );
+}
+
 /// [T-GH014] secs_until_ratelimit_reset subtracts the injected clock
 /// from the x-ratelimit-reset header. Pinning the clock removes wall-clock
 /// flakiness from the arithmetic test.

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -33,34 +33,41 @@ pub(crate) const DEFAULT_MAX_RETRIES: u32 = 2;
 /// not human pages.
 pub(crate) const MAX_API_RESPONSE_BYTES: usize = 1024 * 1024;
 
-/// Drain `response` into a `Vec<u8>` while enforcing `MAX_API_RESPONSE_BYTES`.
-/// Content-Length is pre-checked before any allocation; the chunk loop also
-/// rejects bodies that exceed the cap when the header is absent or lies.
-/// `fetch.rs` keeps its own copy because it interleaves charset and redirect
-/// handling around the same loop.
+/// Upper bound on JSON response body bytes accepted from the GitHub backend
+/// (issue #186). GitHub's payloads are an order of magnitude larger than
+/// Brave/Slack: `git/trees?recursive=1` is served up to GitHub's own ~7 MB
+/// truncation ceiling, and `git/blobs` returns base64-inflated file content.
+/// 10 MB matches `fetch.rs`'s `MAX_RESPONSE_BYTES` (the largest content scout
+/// already returns) so legitimate large-repo trees and files are not rejected,
+/// while still bounding the memory a hostile or runaway response can consume.
+pub(crate) const MAX_GITHUB_RESPONSE_BYTES: usize = 10_000_000;
+
+/// Drain `response` into a `Vec<u8>` while enforcing `cap` bytes. Content-Length
+/// is pre-checked before any allocation; the chunk loop also rejects bodies that
+/// exceed the cap when the header is absent or lies. Callers pass the cap that
+/// matches their backend's legitimate payload size (`MAX_API_RESPONSE_BYTES` for
+/// Brave/Slack, `MAX_GITHUB_RESPONSE_BYTES` for GitHub). `fetch.rs` keeps its own
+/// copy because it interleaves charset and redirect handling around the same loop.
 pub(crate) async fn read_body_capped<E>(
     response: reqwest::Response,
+    cap: usize,
     too_large: impl Fn() -> E,
     network: impl Fn(reqwest::Error) -> E,
 ) -> Result<Vec<u8>, E> {
     let content_length = response.content_length();
     if let Some(len) = content_length
-        && usize::try_from(len).unwrap_or(usize::MAX) > MAX_API_RESPONSE_BYTES
+        && usize::try_from(len).unwrap_or(usize::MAX) > cap
     {
         return Err(too_large());
     }
     let capacity = content_length
-        .map(|len| {
-            usize::try_from(len)
-                .unwrap_or(usize::MAX)
-                .min(MAX_API_RESPONSE_BYTES)
-        })
+        .map(|len| usize::try_from(len).unwrap_or(usize::MAX).min(cap))
         .unwrap_or(8192);
     let mut body = Vec::with_capacity(capacity);
     let mut stream = response;
     while let Some(chunk) = stream.chunk().await.map_err(&network)? {
         body.extend_from_slice(&chunk);
-        if body.len() > MAX_API_RESPONSE_BYTES {
+        if body.len() > cap {
             return Err(too_large());
         }
     }
@@ -75,15 +82,6 @@ pub(crate) fn jittered_backoff(attempt: u32, rng: &dyn Rng) -> u64 {
 
 pub(crate) fn is_transient_network(e: &Error) -> bool {
     e.is_connect() || e.is_timeout() || is_transient_decode(e)
-}
-
-/// True only when a `Decode`-classified reqwest error originates in a
-/// schema mismatch (serde failure), not a transport-level IO failure.
-/// Body-decode call sites use this to route schema fails to terminal
-/// `Decode` while letting transport drops fall through to `Network` for
-/// the retry loop (issue #113).
-pub(crate) fn is_schema_decode_fail(e: &Error) -> bool {
-    e.is_decode() && !is_transient_decode(e)
 }
 
 /// True when a `Decode`-classified reqwest error originates in a transport

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -170,6 +170,7 @@ impl SlackClient {
 
         let bytes = read_body_capped(
             resp,
+            MAX_API_RESPONSE_BYTES,
             || {
                 SlackError::Decode(format!(
                     "response too large (>{MAX_API_RESPONSE_BYTES} bytes)"


### PR DESCRIPTION
## 概要

GitHub API レスポンスのボディにバイト上限がなく OOM リスクがあった(#186)。`get_json_once` の 2xx 経路が `response.json()` で全文をバッファしていたのを、`read_body_capped` による上限付き読み込みへ変更。最も risk が高いのは `get_tree?recursive=1`(最大 ~7MB)。

## 変更

- `read_body_capped`(`src/retry.rs`)に `cap` 引数を追加。GitHub は新設 `MAX_GITHUB_RESPONSE_BYTES`(10MB、`fetch.rs` の `MAX_RESPONSE_BYTES` に合わせる)、Brave/Slack は従来の `MAX_API_RESPONSE_BYTES`(1MiB)を渡す
- `get_json_once` の 2xx を「上限付き read → `serde_json::from_slice` parse」に分離。transport drop は `Network`(retry)、schema mismatch は `Decode`(terminal)へ構造的に振り分け(#113 を継承し `is_schema_decode_fail` を廃止)
- `GitHubError::ResponseTooLarge` バリアントを追加。classify は Internal(非リトライ)で `BraveError::ResponseTooLarge` と peer

## テスト

- `[T-GH020]` overflow した 2xx ボディで `ResponseTooLarge` を返し、非リトライ(mock 1 回ヒット)
- `[T-GHC010]` `ResponseTooLarge` が ADR-0011 priority 5 で Internal に分類される
- `cargo test --lib` 462 passed / clippy clean / fmt --check OK

## 補足

- #186 の文面は `MAX_API_RESPONSE_BYTES`(1MiB)を指すが、名指しの最高 risk 経路 `get_tree?recursive=1` が正当に ~7MB を返すため GitHub 専用 10MB を採用
- chunk ループ経路(Content-Length 欠落/詐称時の上限)のカバレッジは 3 バックエンド共通の既存ギャップのため #219 に分離

Closes #186
