### PR TITLE
Slack スレッド取得の取りこぼし・無音フォールバック・users.info 過剰呼び出しを修正

### DIFF
--- a/docs/audit/2026-06-14-slack-188-postimpl-audit.md
+++ b/docs/audit/2026-06-14-slack-188-postimpl-audit.md
@@ -1,0 +1,61 @@
+# Slack #188 実装後監査: 2026-06-14
+
+#188 の Slack 修正（`src/slack.rs`, `src/slack/client.rs` の `main..HEAD` diff、5 commit）を対象とした実装後監査。対象変更は ①無音 ID フォールバックへの `warn!` 追加、②`conversations.replies` のページネーション、③`users.info` lookup の上限 cap + 著者優先、④reply parent の重複排除。手法は reviewer fan-out → critic-audit (challenge) → critic-evidence (verify) → team-integration。pre-flight は `cargo test`（54 件 green）、`cargo fmt --check`、`cargo clippy`（いずれも clean）。
+
+## Summary
+
+| Metric                             | Value                                                                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 結論                               | #188 のスコープ内に修正すべき欠陥なし。変更は issue 推奨に整合し、テストも green                                         |
+| pre-flight                         | test 54 件 pass / fmt clean / clippy clean                                                                               |
+| ① warn 採用の妥当性                | 妥当。Result 化は呼び出し側 4 箇所の波及を生むのに対し、`String` 戻り値 + `warn!` は等コストで観測性のみ追加。Occam 適合 |
+| ② page 上限 50・dedup・cursor 終端 | 正しい。`has_more` && cursor 非空で継続、`ts` を `HashSet` で dedup、上限到達時は `warn!` + `Ok(truncated)`              |
+| ③ cap=50・著者優先                 | ロジックは正しい。著者を先に take し残枠を mention で埋める。Tier-4 (50 req/min) 整合                                    |
+| 確定した actionable                | 0（スコープ内）。スコープ外の既存課題 1 件（F1）を申し送り                                                               |
+| F1（既存・スコープ外）             | thread 切り詰め時の `not found in thread` が exit 64 (UsageError) に誤分類。該当行は 521b488b 由来で #188 diff 外        |
+
+## ① 無音 ID フォールバックへの warn 追加 — 妥当
+
+issue は「無音フォールバックを Result 化」を推奨していたが、採用された `String` 戻り値 + `warn!`（`resolve_channel` / `fetch_user_name`, client.rs 226-258）は以下の理由で妥当。
+
+| 観点           | 判定                                                                                                            |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| 観測性         | `warn!(channel/user, "...falling back to raw ID")` で無音性は解消。運用ログに残る                               |
+| コスト         | Result 化は呼び出し側の `?` 伝播・エラー型分岐を 4 箇所に強制。`String` 維持は等機能で indirection を増やさない |
+| アウトカム整合 | name 解決失敗でも raw ID で本文取得を継続でき、「一次ソース取得」の Behavior を壊さない                         |
+
+Result 化が優位になるのは「name 解決失敗を fetch 全体の失敗として扱う」仕様変更時のみ。現仕様（best-effort 解決）では `warn!` が最小。
+
+## ② conversations.replies ページネーション — 正しい
+
+`fetch_replies`（client.rs 285-326）。
+
+| 要素            | 検証結果                                                                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cursor 終端判定 | `MessagesBody::next_cursor`（slack.rs 152-166）が `!has_more` または cursor 空/欠落で `None` を返す。無限ループなし                                   |
+| dedup           | thread parent が各 reply ページ先頭に再掲される Slack 仕様に対し、`ts` を `HashSet` で `seen.insert` 判定し重複排除（commit 140e16d, T-SK045 で固定） |
+| ページ上限      | `SLACK_MAX_REPLY_PAGES=50`。上限到達時は `warn!` + `Ok(messages)` で truncated を返す（client.rs 319-325）                                            |
+
+## ③ users.info lookup cap + 著者優先 — ロジック正しい
+
+`fetch_message`（client.rs 367-422）。
+
+| 要素     | 検証結果                                                                                                                                                   |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cap 値   | `SLACK_MAX_USER_LOOKUPS=50`。Slack `users.info` は Tier-4 (50 req/min)。1 メッセージ取得あたり 50 lookups は分あたり上限に整合                             |
+| 著者優先 | cap 超過時 `authors.into_iter().take(50)` で著者を先取りし、残枠を mention で充填（commit ebaf4e4, T-SK044）。著者名は本文表示に必須なので優先順位は正しい |
+| 並列度   | `SLACK_USERS_CONCURRENCY=5` で `users.info` を並列。バースト緩和                                                                                           |
+
+注記（F4・スコープ外）: `authors` は `HashSet` のため著者数 > 50 のとき `take(50)` の取得順が非決定的。ただしこれは「どの 50 著者を引くか」の順序非決定であって著者優先ロジック自体の誤りではない。実害は稀（単一メッセージに 50 超の distinct 著者）で、影響はテスト再現性に限られる。
+
+## F1: thread 切り詰め時のエラー誤分類（既存・#188 スコープ外）
+
+`fetch_replies` がページ上限 50 で truncated を `Ok` で返す（②）と、対象 `ts` が切り詰められたページにある場合 `extract_target` が `None` を返し、`format!("message {} not found in thread", ts)`（client.rs 415-418）が生成される。この文字列は `classify()`（slack.rs 59-60）の NOT*FOUND アーム（`"message not found"` ＝接尾辞 `in thread` なし、の完全一致）にマッチせず `*` に落ち、**UsageError (exit 64)** に分類される。実態は「対象が見つからない/切り詰め」なので **NotFound (exit 66)** が適切。
+
+- 既存性: 該当行は `git blame` で commit 521b488b（2026-05-30）。#188 の 5 commit（aba8998..140e16d）の外。
+- #188 の関与: pagination は到達範囲を 1 ページ → 50 ページに拡張しただけで、誤分類自体は導入していない（pagination 前も page 1 外の target は同じ文字列で失敗していた）。
+- 判定: #188 のスコープ内修正ではない。修正するなら別タスク（文字列を `"message not found"` に寄せる、または classify に接頭辞マッチを追加）。
+
+## 結論
+
+#188 の変更 ①〜④ はいずれも issue 推奨に整合し、ロジックは正しく、テストは green。スコープ内に修正すべき欠陥は検出されなかった。F1 は #188 が導入した欠陥ではなく既存の誤分類で、扱いはユーザー判断に委ねる。

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -145,6 +145,29 @@ pub(crate) fn parse_slack_url(url: &str) -> Option<SlackUrl> {
 struct MessagesBody {
     #[serde(default)]
     messages: Vec<Message>,
+    #[serde(default)]
+    has_more: bool,
+    response_metadata: Option<ResponseMetadata>,
+}
+
+impl MessagesBody {
+    /// The non-empty `next_cursor` to fetch the following page, if Slack
+    /// signalled more results. Returns `None` when `has_more` is false or the
+    /// cursor is absent/empty, so the pagination loop terminates.
+    fn next_cursor(&self) -> Option<&str> {
+        if !self.has_more {
+            return None;
+        }
+        self.response_metadata
+            .as_ref()
+            .and_then(|m| m.next_cursor.as_deref())
+            .filter(|c| !c.is_empty())
+    }
+}
+
+#[derive(Deserialize)]
+struct ResponseMetadata {
+    next_cursor: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -214,7 +214,10 @@ impl SlackClient {
                 .channel
                 .and_then(|c| c.name)
                 .map(|n| format!("#{n}"))
-                .unwrap_or_else(|| id.to_owned()),
+                .unwrap_or_else(|| {
+                    warn!(channel_id = %id, "channel name missing in response, using raw ID");
+                    id.to_owned()
+                }),
             Err(e) => {
                 warn!(channel_id = %id, error = %e, "channel resolution failed, using raw ID");
                 id.to_owned()
@@ -234,7 +237,10 @@ impl SlackClient {
                         .and_then(|p| p.display_name.filter(|n| !n.is_empty()))
                         .or(u.real_name)
                 })
-                .unwrap_or_else(|| id.to_owned()),
+                .unwrap_or_else(|| {
+                    warn!(user_id = %id, "user name missing in response, using raw ID");
+                    id.to_owned()
+                }),
             Err(e) => {
                 warn!(user_id = %id, error = %e, "user resolution failed, using raw ID");
                 id.to_owned()

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -362,22 +362,38 @@ impl SlackClient {
             });
         }
 
-        let mut user_ids = HashSet::new();
+        // Authors render on every message, so when distinct IDs exceed the
+        // lookup cap they take priority over mentions: an unresolved author
+        // degrades visible output more than an unresolved mention.
+        let mut authors = HashSet::new();
+        let mut mentions = HashSet::new();
         for msg in &fetched.messages {
             if let Some(uid) = &msg.user {
-                user_ids.insert(uid.clone());
+                authors.insert(uid.clone());
             }
-            collect_mention_ids(&msg.text, &mut user_ids);
+            collect_mention_ids(&msg.text, &mut mentions);
         }
 
-        if user_ids.len() > SLACK_MAX_USER_LOOKUPS {
+        let distinct_total = authors.union(&mentions).count();
+        let user_ids: HashSet<String> = if distinct_total > SLACK_MAX_USER_LOOKUPS {
             warn!(
-                distinct_users = user_ids.len(),
+                distinct_users = distinct_total,
                 cap = SLACK_MAX_USER_LOOKUPS,
-                "too many distinct user IDs; capping users.info lookups, excess mentions degrade to raw IDs"
+                "too many distinct user IDs; capping users.info lookups, excess IDs render as raw IDs (authors kept first)"
             );
-            user_ids = user_ids.into_iter().take(SLACK_MAX_USER_LOOKUPS).collect();
-        }
+            let mut kept: HashSet<String> =
+                authors.into_iter().take(SLACK_MAX_USER_LOOKUPS).collect();
+            for id in mentions {
+                if kept.len() >= SLACK_MAX_USER_LOOKUPS {
+                    break;
+                }
+                kept.insert(id);
+            }
+            kept
+        } else {
+            authors.extend(mentions);
+            authors
+        };
 
         let (channel_name, users) = tokio::join!(
             self.resolve_channel(&slack_url.channel),

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -64,6 +64,12 @@ const SLACK_REPLIES_LIMIT: &str = "200";
 /// (issue #155 / OPS-009 / CHX-001).
 const SLACK_USERS_CONCURRENCY: usize = 5;
 
+/// Upper bound on `conversations.replies` pages fetched per thread. At
+/// `SLACK_REPLIES_LIMIT` (200) messages per page this covers threads up to
+/// ~10k replies; the cap stops an unbounded paging loop from re-introducing
+/// the rate-limit exhaustion that claim 3 bounds (issue #188 claim 2).
+const SLACK_MAX_REPLY_PAGES: usize = 50;
+
 impl SlackClient {
     pub fn new(http: Client, token: Redacted, max_retries: u32) -> Self {
         Self {
@@ -265,21 +271,49 @@ impl SlackClient {
             .await
     }
 
+    /// Fetch every reply in a thread, following `response_metadata.next_cursor`
+    /// across pages up to `SLACK_MAX_REPLY_PAGES`. Without this loop a target
+    /// message past the first `SLACK_REPLIES_LIMIT` page is silently dropped and
+    /// surfaces as "not found" (issue #188 claim 2).
+    async fn fetch_replies(&self, channel: &str, ts: &str) -> Result<Vec<Message>, SlackError> {
+        let mut messages = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..SLACK_MAX_REPLY_PAGES {
+            // Scope `params` so its borrow of `cursor` ends before the
+            // reassignment below.
+            let body: MessagesBody = {
+                let mut params = vec![
+                    ("channel", channel),
+                    ("ts", ts),
+                    ("limit", SLACK_REPLIES_LIMIT),
+                ];
+                if let Some(c) = cursor.as_deref() {
+                    params.push(("cursor", c));
+                }
+                self.api_get("conversations.replies", &params).await?
+            };
+            let next = body.next_cursor().map(str::to_owned);
+            messages.extend(body.messages);
+            match next {
+                Some(c) => cursor = Some(c),
+                None => return Ok(messages),
+            }
+        }
+        warn!(
+            channel = %channel,
+            ts = %ts,
+            max_pages = SLACK_MAX_REPLY_PAGES,
+            "conversations.replies hit the page cap, thread truncated"
+        );
+        Ok(messages)
+    }
+
     async fn fetch_thread(&self, slack_url: &SlackUrl) -> Result<FetchedThread, SlackError> {
         let ch = &slack_url.channel;
         if let Some(ref thread_ts) = slack_url.thread_ts {
-            let body: MessagesBody = self
-                .api_get(
-                    "conversations.replies",
-                    &[
-                        ("channel", ch),
-                        ("ts", thread_ts),
-                        ("limit", SLACK_REPLIES_LIMIT),
-                    ],
-                )
-                .await?;
+            let messages = self.fetch_replies(ch, thread_ts).await?;
             return Ok(FetchedThread {
-                messages: body.messages,
+                messages,
                 is_thread: true,
             });
         }
@@ -300,18 +334,9 @@ impl SlackClient {
             .first()
             .is_some_and(|m| m.reply_count.unwrap_or(0) > 0);
         if has_replies {
-            let thread: MessagesBody = self
-                .api_get(
-                    "conversations.replies",
-                    &[
-                        ("channel", ch),
-                        ("ts", &slack_url.ts),
-                        ("limit", SLACK_REPLIES_LIMIT),
-                    ],
-                )
-                .await?;
+            let messages = self.fetch_replies(ch, &slack_url.ts).await?;
             Ok(FetchedThread {
-                messages: thread.messages,
+                messages,
                 is_thread: true,
             })
         } else {

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -70,6 +70,13 @@ const SLACK_USERS_CONCURRENCY: usize = 5;
 /// the rate-limit exhaustion that claim 3 bounds (issue #188 claim 2).
 const SLACK_MAX_REPLY_PAGES: usize = 50;
 
+/// Upper bound on distinct user IDs resolved via `users.info` per message.
+/// A single message can mention an unbounded number of users; without a cap a
+/// mass-mention burst can exhaust Slack's Tier-4 per-minute budget. IDs beyond
+/// the cap are not looked up and degrade to their raw `<@UID>` form (issue
+/// #188 claim 3).
+const SLACK_MAX_USER_LOOKUPS: usize = 50;
+
 impl SlackClient {
     pub fn new(http: Client, token: Redacted, max_retries: u32) -> Self {
         Self {
@@ -361,6 +368,15 @@ impl SlackClient {
                 user_ids.insert(uid.clone());
             }
             collect_mention_ids(&msg.text, &mut user_ids);
+        }
+
+        if user_ids.len() > SLACK_MAX_USER_LOOKUPS {
+            warn!(
+                distinct_users = user_ids.len(),
+                cap = SLACK_MAX_USER_LOOKUPS,
+                "too many distinct user IDs; capping users.info lookups, excess mentions degrade to raw IDs"
+            );
+            user_ids = user_ids.into_iter().take(SLACK_MAX_USER_LOOKUPS).collect();
         }
 
         let (channel_name, users) = tokio::join!(

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -284,6 +284,10 @@ impl SlackClient {
     /// surfaces as "not found" (issue #188 claim 2).
     async fn fetch_replies(&self, channel: &str, ts: &str) -> Result<Vec<Message>, SlackError> {
         let mut messages = Vec::new();
+        // conversations.replies is observed to repeat the thread parent as
+        // messages[0] on each page; the official reference is silent, so dedup
+        // by ts defensively. Safe because ts is unique per message in a channel.
+        let mut seen: HashSet<String> = HashSet::new();
         let mut cursor: Option<String> = None;
         for _ in 0..SLACK_MAX_REPLY_PAGES {
             // Scope `params` so its borrow of `cursor` ends before the
@@ -300,7 +304,13 @@ impl SlackClient {
                 self.api_get("conversations.replies", &params).await?
             };
             let next = body.next_cursor().map(str::to_owned);
-            messages.extend(body.messages);
+            for msg in body.messages {
+                // A message with no ts cannot be deduped; keep it as-is.
+                match &msg.ts {
+                    Some(t) if !seen.insert(t.clone()) => continue,
+                    _ => messages.push(msg),
+                }
+            }
             match next {
                 Some(c) => cursor = Some(c),
                 None => return Ok(messages),

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
 use reqwest::Client;
 use tracing_test::traced_test;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, ResponseTemplate};
 
 /// [T-SK001] HTTP 429 response maps to SlackError::RateLimited
@@ -214,4 +214,64 @@ async fn fetch_user_name_null_user_warns_then_falls_back() {
         "expected a warn for the null user name"
     );
     assert!(logs_contain("WARN"));
+}
+
+/// [T-SK042] conversations.replies pagination: a thread whose target message
+/// lands on the second page (page 1 returns has_more:true + next_cursor) is
+/// still found. Before the pagination loop, serde dropped has_more/next_cursor
+/// and only page 1 was fetched, so a >200-reply thread lost the target and
+/// fetch_message returned "not found" (issue #188 claim 2).
+#[tokio::test]
+async fn fetch_replies_paginates_to_find_target_on_page_two() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    let target_ts = "1000.000500";
+    // Page 1: parent + filler, has_more with a cursor. Target is NOT here.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .and(query_param_is_missing("cursor"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "U1", "text": "parent", "ts": parent_ts},
+                {"user": "U1", "text": "filler", "ts": "1000.000002"}
+            ],
+            "has_more": true,
+            "response_metadata": {"next_cursor": "PAGE2"}
+        })))
+        .mount(&server)
+        .await;
+    // Page 2: contains the target message, no further pages.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .and(query_param("cursor", "PAGE2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "U1", "text": "the target reply", "ts": target_ts}
+            ],
+            "has_more": false,
+            "response_metadata": {"next_cursor": ""}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: target_ts.into(),
+        thread_ts: Some(parent_ts.into()),
+        raw_url: "https://acme.slack.com/archives/C1/p1000000500".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("target message on page 2 is found via pagination");
+    assert!(
+        out.contains("the target reply"),
+        "expected the page-2 target in output, got: {out}"
+    );
 }

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -398,3 +398,85 @@ async fn fetch_message_prioritizes_authors_over_mentions_when_capping() {
         "every author should resolve to a name, but a raw author ID leaked: {out}"
     );
 }
+
+/// [T-SK045] conversations.replies repeats the thread parent as messages[0] on
+/// every page. The pagination loop flat-extends pages, so a parent that recurs
+/// across pages was counted once per page: extract_target removes only the
+/// first copy, leaving the rest as duplicate replies that inflate
+/// context_messages and re-render the parent body. Dedup by ts so the parent
+/// appears once regardless of page count (issue #188 audit RU1/RU2).
+#[tokio::test]
+async fn fetch_replies_dedups_parent_repeated_across_pages() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    // Page 1: parent + first reply, more pages follow.
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"user": "U1", "text": "PARENT_BODY", "ts": parent_ts, "reply_count": 2}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .and(query_param_is_missing("cursor"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "U1", "text": "PARENT_BODY", "ts": parent_ts},
+                {"user": "U2", "text": "first reply", "ts": "1000.000002"}
+            ],
+            "has_more": true,
+            "response_metadata": {"next_cursor": "PAGE2"}
+        })))
+        .mount(&server)
+        .await;
+    // Page 2: parent repeats as messages[0], plus the second reply.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .and(query_param("cursor", "PAGE2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "U1", "text": "PARENT_BODY", "ts": parent_ts},
+                {"user": "U3", "text": "second reply", "ts": "1000.000003"}
+            ],
+            "has_more": false,
+            "response_metadata": {"next_cursor": ""}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: parent_ts.into(),
+        thread_ts: Some(parent_ts.into()),
+        raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("thread spanning two pages resolves");
+    assert!(
+        out.contains("context_messages: 2"),
+        "two distinct replies expected, parent duplicate must not inflate the count: {out}"
+    );
+    assert_eq!(
+        out.matches("PARENT_BODY").count(),
+        1,
+        "the parent body should render once, not once per page: {out}"
+    );
+}

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -275,3 +275,53 @@ async fn fetch_replies_paginates_to_find_target_on_page_two() {
         "expected the page-2 target in output, got: {out}"
     );
 }
+
+/// [T-SK043] A message mentioning far more distinct users than
+/// SLACK_MAX_USER_LOOKUPS caps the number of users.info requests at the limit,
+/// so a mass-mention message cannot exhaust Slack's per-minute rate budget.
+/// Excess mentions degrade to raw IDs. The `.expect(cap)` on the users.info
+/// mock fails on server drop if the cap is not enforced (issue #188 claim 3).
+#[tokio::test]
+async fn fetch_message_caps_users_info_lookups_on_mass_mentions() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let total = SLACK_MAX_USER_LOOKUPS + 50;
+    let mentions = (0..total)
+        .map(|i| format!("<@U{i}>"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    // Single message (no thread): conversations.history returns it directly.
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"text": mentions, "ts": "1000.000001"}]
+        })))
+        .mount(&server)
+        .await;
+    // users.info must be hit exactly SLACK_MAX_USER_LOOKUPS times, not `total`.
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .expect(SLACK_MAX_USER_LOOKUPS as u64)
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: "1000.000001".into(),
+        thread_ts: None,
+        raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
+    };
+    client
+        .fetch_message(&url)
+        .await
+        .expect("mass-mention message resolves");
+    // The `.expect(cap)` is verified when `server` drops at end of scope.
+}

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -325,3 +325,76 @@ async fn fetch_message_caps_users_info_lookups_on_mass_mentions() {
         .expect("mass-mention message resolves");
     // The `.expect(cap)` is verified when `server` drops at end of scope.
 }
+
+/// [T-SK044] When distinct IDs exceed SLACK_MAX_USER_LOOKUPS, message authors
+/// are kept in the lookup set ahead of mentions. Authors render on every
+/// message, so dropping one degrades visible output more than dropping a
+/// mention. The earlier cap took an arbitrary HashSet slice, so authors could
+/// be evicted nondeterministically (issue #188 audit RU7/SF-1). Here three
+/// distinct authors compete with thousands of mentions for a 50-slot cap; with
+/// author-first priority every author resolves to a name, so no raw "UAUTHOR"
+/// ID leaks into the rendered output.
+#[tokio::test]
+async fn fetch_message_prioritizes_authors_over_mentions_when_capping() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    // Far more mentions than the cap, so an arbitrary slice would almost
+    // certainly evict at least one of the three authors.
+    let mentions = (0..3000)
+        .map(|i| format!("<@U{i}>"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    // Thread probe: the root has replies, so fetch_replies is used.
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"user": "UAUTHOR0", "text": "parent", "ts": parent_ts, "reply_count": 2}]
+        })))
+        .mount(&server)
+        .await;
+    // Replies carry three distinct authors; the mass mention lives in one reply.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "UAUTHOR0", "text": "parent", "ts": parent_ts},
+                {"user": "UAUTHOR1", "text": mentions, "ts": "1000.000002"},
+                {"user": "UAUTHOR2", "text": "carol reply", "ts": "1000.000003"}
+            ],
+            "has_more": false,
+            "response_metadata": {"next_cursor": ""}
+        })))
+        .mount(&server)
+        .await;
+    // Any looked-up user resolves to a name, so a resolved author cannot leave
+    // its raw ID in the output.
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: parent_ts.into(),
+        thread_ts: Some(parent_ts.into()),
+        raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("thread with capped lookups resolves");
+    assert!(
+        !out.contains("UAUTHOR"),
+        "every author should resolve to a name, but a raw author ID leaked: {out}"
+    );
+}

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -480,3 +480,120 @@ async fn fetch_replies_dedups_parent_repeated_across_pages() {
         "the parent body should render once, not once per page: {out}"
     );
 }
+
+/// [T-SK046] A thread whose reply pages never stop (every page returns
+/// has_more:true + a cursor) stops paginating at SLACK_MAX_REPLY_PAGES and
+/// emits a WARN that the thread was truncated, rather than looping forever
+/// (issue #188 claim 2, cap path). Covers the post-loop cap-hit branch in
+/// fetch_replies. The parent recurs on every page and is deduped by ts, so the
+/// returned thread is the parent alone and fetch_message still succeeds.
+#[tokio::test]
+#[traced_test]
+async fn fetch_replies_stops_at_page_cap_and_warns() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    // Every page advertises another page, so the loop only ends at the cap.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"user": "U1", "text": "PARENT_BODY", "ts": parent_ts}],
+            "has_more": true,
+            "response_metadata": {"next_cursor": "MORE"}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: parent_ts.into(),
+        thread_ts: Some(parent_ts.into()),
+        raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("a truncated thread still returns the pages fetched so far");
+    assert!(
+        out.contains("PARENT_BODY"),
+        "expected the parent body in the truncated output, got: {out}"
+    );
+    assert!(
+        logs_contain("hit the page cap"),
+        "expected a WARN that the thread was truncated at the page cap"
+    );
+    assert!(logs_contain("WARN"));
+}
+
+/// [T-SK047] A message-permalink URL (no thread_ts) whose target has replies
+/// triggers the conversations.history reply_count probe; when reply_count > 0
+/// fetch_thread re-fetches the full thread via conversations.replies and marks
+/// the result as a thread, so the replies render (issue #188 claim 2, probe
+/// path). Covers the has_replies branch in fetch_thread. Without it a permalink
+/// to a thread root would show only the root with no replies.
+#[tokio::test]
+async fn fetch_message_link_with_replies_fetches_thread() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    // The probe reports the target has one reply, so fetch_replies runs next.
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"user": "U1", "text": "parent", "ts": parent_ts, "reply_count": 1}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "U1", "text": "parent", "ts": parent_ts},
+                {"user": "U2", "text": "a reply", "ts": "1000.000002"}
+            ],
+            "has_more": false,
+            "response_metadata": {"next_cursor": ""}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: parent_ts.into(),
+        thread_ts: None,
+        raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("a permalink to a thread root resolves the full thread");
+    assert!(
+        out.contains("a reply"),
+        "expected the probed thread's reply in output, got: {out}"
+    );
+}

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
 use reqwest::Client;
+use tracing_test::traced_test;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -160,4 +161,57 @@ async fn api_get_once_2xx_mid_stream_drop_returns_network() {
         "expected SlackError::Network for mid-stream drop, got: {result:?}"
     );
     let _ = handle.join();
+}
+
+/// [T-SK040] conversations.info 200 with a null channel.name emits a WARN
+/// before falling back to the raw channel ID. Without it the label-resolution
+/// degradation is silent to operators (issue #188 claim 1). The Err branch
+/// already warns; this covers the Ok-but-null path.
+#[tokio::test]
+#[traced_test]
+async fn resolve_channel_null_name_warns_then_falls_back() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path("/conversations.info"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"ok": true, "channel": {"id": "C123"}})),
+        )
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let name = client.resolve_channel("C123").await;
+    assert_eq!(name, "C123", "falls back to the raw channel ID");
+    assert!(
+        logs_contain("channel name missing"),
+        "expected a warn for the null channel name"
+    );
+    assert!(logs_contain("WARN"));
+}
+
+/// [T-SK041] users.info 200 with a null user emits a WARN before falling back
+/// to the raw user ID (issue #188 claim 1). Mirrors T-SK040 for the user path.
+#[tokio::test]
+#[traced_test]
+async fn fetch_user_name_null_user_warns_then_falls_back() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let name = client.fetch_user_name("U123").await;
+    assert_eq!(name, "U123", "falls back to the raw user ID");
+    assert!(
+        logs_contain("user name missing"),
+        "expected a warn for the null user name"
+    );
+    assert!(logs_contain("WARN"));
 }


### PR DESCRIPTION
## 概要

#188 の Slack 修正。スレッド取得の取りこぼし・無音フォールバック・`users.info` 過剰呼び出しを解消する。

## 変更内容

| commit | 内容 |
| ------ | ---- |
| `aba8998` | channel/user 名が null のとき raw ID フォールバック前に `warn!` を出し、無音性を解消 |
| `9c4464e` | `conversations.replies` をページネーションし、page 1 以降のメッセージも取得（上限 `SLACK_MAX_REPLY_PAGES=50`、到達時は `warn!` + truncated を返す） |
| `6c6d726` | 1 メッセージあたりの distinct `users.info` lookup を `SLACK_MAX_USER_LOOKUPS=50` で cap（Tier-4 50 req/min 整合）、並列度 5 |
| `ebaf4e4` | cap 超過時は著者を優先 take し、残枠を mention で充填（著者名は本文表示に必須） |
| `140e16d` | reply 各ページ先頭に再掲される thread parent を `ts` で dedup |

## テスト

`src/slack/client/http_tests.rs` に +321 行（wiremock ベース）。pagination・cap・著者優先・dedup・null 名 warn の各経路を検証。`cargo test` 54 件 green / `cargo fmt --check` / `cargo clippy` clean。

## 監査

実装後監査を `docs/audit/2026-06-14-slack-188-postimpl-audit.md` に記録。スコープ内に修正すべき欠陥なし。スコープ外の既存課題（thread 切り詰め時の exit 64 誤分類）は #224 に分離。

Closes #188
