### PR TITLE
fetch の body 読み取りを read_body_capped に統一

### DIFF
--- a/src/fetch/download.rs
+++ b/src/fetch/download.rs
@@ -6,6 +6,7 @@ use tracing::{debug, warn};
 
 use super::ssrf::{DnsResolver, RedactedLogUrl, ValidatedUrl, ssrf_check};
 use super::{FetchError, MAX_RESPONSE_BYTES};
+use crate::retry::read_body_capped;
 
 /// Caller MUST pass a [`Client`] with [`reqwest::redirect::Policy::none()`].
 ///
@@ -73,28 +74,13 @@ pub(super) async fn download(
             },
         }
 
-        let content_length = response.content_length();
-        if let Some(len) = content_length
-            && usize::try_from(len).unwrap_or(usize::MAX) > MAX_RESPONSE_BYTES
-        {
-            return Err(FetchError::TooLarge);
-        }
-
-        let capacity = content_length
-            .map(|len| {
-                usize::try_from(len)
-                    .unwrap_or(usize::MAX)
-                    .min(MAX_RESPONSE_BYTES)
-            })
-            .unwrap_or(8192);
-        let mut body = Vec::with_capacity(capacity);
-        let mut stream = response;
-        while let Some(chunk) = stream.chunk().await? {
-            body.extend_from_slice(&chunk);
-            if body.len() > MAX_RESPONSE_BYTES {
-                return Err(FetchError::TooLarge);
-            }
-        }
+        let body = read_body_capped(
+            response,
+            MAX_RESPONSE_BYTES,
+            || FetchError::TooLarge,
+            FetchError::from,
+        )
+        .await?;
         let html = decode_body(&body, charset.as_deref());
         return Ok((current_url, html));
     }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -46,8 +46,8 @@ pub(crate) const MAX_GITHUB_RESPONSE_BYTES: usize = 10_000_000;
 /// is pre-checked before any allocation; the chunk loop also rejects bodies that
 /// exceed the cap when the header is absent or lies. Callers pass the cap that
 /// matches their backend's legitimate payload size (`MAX_API_RESPONSE_BYTES` for
-/// Brave/Slack, `MAX_GITHUB_RESPONSE_BYTES` for GitHub). `fetch.rs` keeps its own
-/// copy because it interleaves charset and redirect handling around the same loop.
+/// Brave/Slack, `MAX_GITHUB_RESPONSE_BYTES` for GitHub, `MAX_RESPONSE_BYTES` for
+/// `fetch`'s HTML downloads).
 pub(crate) async fn read_body_capped<E>(
     response: reqwest::Response,
     cap: usize,


### PR DESCRIPTION
## 概要

`src/fetch/download.rs` の HTML download だけが独自の body 読み取りループ (content-length precheck + capacity 計算 + chunk loop) を持ち、4 backend 中唯一 `read_body_capped` を経由していなかった。この22行を `read_body_capped` 呼び出しに置換し、全 backend を単一の capped-read 経路に統一する。

Closes #178

## 変更内容

- `src/fetch/download.rs`: 重複ループ(76-97行)を削除し `read_body_capped(response, MAX_RESPONSE_BYTES, || FetchError::TooLarge, FetchError::from)` に置換
- `src/retry.rs`: 陳腐化した分離理由コメント(「fetch.rs keeps its own copy」)を訂正、`MAX_RESPONSE_BYTES` を cap 列挙に追加

## 挙動

no-op(挙動保存)。precheck と chunk-loop cap は `read_body_capped` 内で同一。エラーマッピングは `FetchError::from`(= `FetchError::Http`、`#[from]`)で bit 一致。

## テスト

`cargo test` 481件全通過。`[T-F011] download_too_large_body_rejected`(TooLarge pin)は変更せず通過。fmt --check / clippy --all-targets 無警告。

## レビュー観点

`read_body_capped` への置換で content-length 二重読みが発生していないか(precheck と capacity 計算を両方削除済み)。