### PR TITLE
refactor(brave): BraveError::is_degradable() を classify().kind ベースに統一して priority drift を防ぐ

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -61,23 +61,16 @@ impl BraveError {
     /// Returns `true` when the error is a transient infrastructure failure that callers
     /// may legitimately surface as a degraded result instead of propagating.
     ///
-    /// Configuration errors (`ApiKeyNotSet`, `Unauthorized`, `ParseUrl`,
-    /// `InsecureBaseUrl`), the scout-side invariants `ParseJson` and
-    /// `ResponseTooLarge`, and 4xx `Api` codes stay propagated — they require
-    /// user action or signal a scout/upstream invariant violation.
+    /// Derived from [`classify`](Self::classify) so the degradable set stays a
+    /// single source of truth: only `TempFailure` and `Timeout` (retryable
+    /// infrastructure faults) degrade. Everything else propagates, including
+    /// the `Unknown` escape hatch — a non-4xx/5xx `Api` code surfaces as an
+    /// error rather than masking an unrecognized status as an empty result.
     pub(crate) fn is_degradable(&self) -> bool {
-        match self {
-            Self::ApiKeyNotSet
-            | Self::Unauthorized
-            | Self::ParseJson(_)
-            | Self::ResponseTooLarge
-            | Self::ParseUrl(_)
-            | Self::InsecureBaseUrl => false,
-            Self::Api { code, .. } if (400..500).contains(code) => false,
-            Self::RateLimited { .. } | Self::Server(_) | Self::Network(_) | Self::Api { .. } => {
-                true
-            }
-        }
+        matches!(
+            self.classify().kind,
+            ErrorCode::TempFailure | ErrorCode::Timeout
+        )
     }
 
     /// Map each variant to its ADR-0011 priority-table [`Classification`].

--- a/src/brave/client/classify_tests.rs
+++ b/src/brave/client/classify_tests.rs
@@ -89,3 +89,43 @@ fn api_non_4xx_5xx_is_unknown() {
     .classify();
     assert_eq!(c.kind, ErrorCode::Unknown);
 }
+
+/// [T-BRC007] is_degradable is true exactly for TempFailure/Timeout infra faults.
+#[test]
+fn temp_failure_variants_are_degradable() {
+    let cases: Vec<BraveError> = vec![
+        BraveError::Server(503),
+        BraveError::RateLimited { retry_after: None },
+        BraveError::Api {
+            code: 502,
+            message: "bad gateway".into(),
+        },
+    ];
+    for case in &cases {
+        assert!(case.is_degradable(), "{case:?}");
+    }
+}
+
+/// [T-BRC008] is_degradable is false for config, data, internal, and Unknown
+/// variants. The `Api { code: 304 }` case pins the classify-derived behavior
+/// against [T-BRC006]: an Unknown status propagates rather than degrading.
+#[test]
+fn non_temp_failure_variants_are_not_degradable() {
+    let cases: Vec<BraveError> = vec![
+        BraveError::ApiKeyNotSet,
+        BraveError::Unauthorized,
+        BraveError::InsecureBaseUrl,
+        BraveError::ResponseTooLarge,
+        BraveError::Api {
+            code: 400,
+            message: "bad".into(),
+        },
+        BraveError::Api {
+            code: 304,
+            message: "not modified".into(),
+        },
+    ];
+    for case in &cases {
+        assert!(!case.is_degradable(), "{case:?}");
+    }
+}


### PR DESCRIPTION
## 概要

`is_degradable()` を `matches!(self.classify().kind, TempFailure | Timeout)` に統一し、priority 決定の単一情報源化を実現する。従来は `is_degradable()` と `classify()` が同じ priority を二箇所で表現しており、variant 追加時に片方だけ更新する drift リスクがあった (#173 レビューで発覚)。

## 変更点

- `is_degradable()` を `classify().kind` 由来に書き換え。`classify()` の網羅 match が単一情報源となり drift を構造的に排除
- doc comment を classify 参照へ更新
- テスト [T-BRC007]/[T-BRC008] を追加。`is_degradable` は従来テストゼロだった

## 挙動変更

唯一の差分は非 4xx/5xx の `Api` エラー (例 `Api { code: 304 }`)。research 経路 (query.rs:157) で従来は degraded 空レポートを返していたが、`Unknown` 分類となり degradable から外れて propagate するよう変わる。未知ステータスを「結果なし」で隠さず fail-loud にする方向。Brave API 仕様上 1xx/3xx の Api 応答は来ないため実害のない死パス。`Network` を含む他 variant は判定不変。

## テスト

- `cargo test --lib`: 472 passed
- `cargo clippy --lib` / `cargo fmt -- --check`: クリーン
- [T-BRC008] の 304 ケースが [T-BRC006] (304 → Unknown) と対で drift を catch

## レビュー観点

挙動変更の妥当性 (304 flip が research 経路で許容できるか) が主。実装自体は機械的。

Closes #179