### PR TITLE
失敗フォールバックの構造化ログ欠如を横断的に解消する

### DIFF
--- a/src/brave/client.rs
+++ b/src/brave/client.rs
@@ -253,7 +253,9 @@ impl BraveClient {
             BraveError::from,
         )
         .await?;
-        let parsed: WebSearchResponse = serde_json::from_slice(&bytes)?;
+        let parsed: WebSearchResponse = serde_json::from_slice(&bytes).inspect_err(|e| {
+            warn!(query_len, error = %e, "Brave search response parse failed");
+        })?;
 
         info!(
             query_len,

--- a/src/brave/client/http_tests.rs
+++ b/src/brave/client/http_tests.rs
@@ -304,6 +304,41 @@ async fn search_malformed_json_returns_parse_error() {
     }
 }
 
+/// [T-BC-LOG002] (issue #189)
+/// Setup: wiremock returns a 200 with a malformed JSON body.
+/// Action: `client.search("foobar", None)` is invoked under `traced_test`.
+/// Expected: a WARN-level `Brave search response parse failed` event fires,
+/// carrying `query_len=6` and the serde `error` field, so operators can see a
+/// schema-drift fallback without the raw query text leaking.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn search_logs_warn_on_parse_failure() {
+    let Some(server) = try_spawn_mock_server("brave::http").await else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{\"web\":"))
+        .mount(&server)
+        .await;
+
+    let client = BraveClient::with_base_url(Client::new(), &server.uri());
+    let _ = client.search("foobar", None).await;
+
+    assert!(
+        logs_contain("Brave search response parse failed"),
+        "expected the parse-failure WARN event"
+    );
+    assert!(logs_contain("WARN"), "event level should be WARN");
+    assert!(
+        logs_contain("query_len=6"),
+        "event should carry query_len (length, not the raw query)"
+    );
+    assert!(
+        logs_contain("error="),
+        "event should carry the serde error field"
+    );
+}
+
 // T-RC001: from_env_with_returns_api_key_not_set_when_closure_errs
 /// FR-001 / FR-002: closure returning `Err(VarError::NotPresent)` must surface
 /// as `BraveError::ApiKeyNotSet` from `from_env_with`. Exercises the injectable

--- a/src/fetch/extractor.rs
+++ b/src/fetch/extractor.rs
@@ -1,6 +1,14 @@
 use dom_smoothie::{Config, Readability};
 use tracing::warn;
 
+use super::RedactedLogUrl;
+
+/// Render an optional source URL for logging with credentials redacted.
+/// `url` is `None` only in tests; production fetch paths always pass `Some`.
+fn log_url(url: Option<&str>) -> String {
+    url.map_or_else(|| "(none)".to_owned(), |u| RedactedLogUrl(u).to_string())
+}
+
 pub(super) struct ExtractedArticle {
     pub title: Option<String>,
     pub byline: Option<String>,
@@ -15,7 +23,7 @@ pub(super) fn extract_article(html: &str, url: Option<&str>) -> ExtractedArticle
     let mut readability = match Readability::new(html, url, Some(Config::default())) {
         Ok(r) => r,
         Err(e) => {
-            warn!(%e, "readability init failed, using raw fallback");
+            warn!(url = %log_url(url), error = %e, "readability init failed, using raw fallback");
             return raw_fallback(html);
         }
     };
@@ -33,7 +41,7 @@ pub(super) fn extract_article(html: &str, url: Option<&str>) -> ExtractedArticle
             }
         }
         Err(e) => {
-            warn!(%e, "readability parse failed, using raw fallback");
+            warn!(url = %log_url(url), error = %e, "readability parse failed, using raw fallback");
             raw_fallback(html)
         }
     }
@@ -185,5 +193,47 @@ mod tests {
         // to_ascii_lowercase preserves byte offsets, preventing panic on slice.
         let html = "<html><head><TITLE>My Title</TITLE></head><body>İİİ</body></html>";
         assert_eq!(extract_title_from_html(html), Some("My Title".to_owned()));
+    }
+
+    /// [T-FX011] (issue #189) readability fallback emits a WARN event whose `url`
+    /// field has credentials redacted, so the raw userinfo never reaches the log.
+    #[tracing_test::traced_test]
+    #[test]
+    fn fallback_logs_warn_with_redacted_url() {
+        // Empty HTML drives readability into the fallback path.
+        let result = extract_article("", Some("https://user:s3cret@example.com/page"));
+
+        assert!(result.used_raw_fallback);
+        assert!(
+            logs_contain("using raw fallback"),
+            "expected the fallback WARN event"
+        );
+        assert!(logs_contain("WARN"), "event level should be WARN");
+        assert!(
+            logs_contain("example.com"),
+            "url field should retain the host for diagnosis"
+        );
+        assert!(
+            !logs_contain("s3cret"),
+            "url credentials must be redacted before logging"
+        );
+    }
+
+    /// [T-FX012] (issue #189) the fallback `url` field renders a placeholder when
+    /// no source URL is available, instead of leaking a Rust `None` debug form.
+    #[tracing_test::traced_test]
+    #[test]
+    fn fallback_logs_placeholder_when_url_absent() {
+        let result = extract_article("", None);
+
+        assert!(result.used_raw_fallback);
+        assert!(
+            logs_contain("using raw fallback"),
+            "expected the fallback WARN event"
+        );
+        assert!(
+            logs_contain("url=(none)"),
+            "absent url should render as the (none) placeholder"
+        );
     }
 }

--- a/src/github/encoding.rs
+++ b/src/github/encoding.rs
@@ -3,6 +3,7 @@ use std::str;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use chardetng::{EncodingDetector, Iso2022JpDetection, Utf8Detection};
 use encoding_rs::Encoding;
+use tracing::debug;
 
 use super::GitHubError;
 
@@ -82,7 +83,13 @@ fn decode_explicit(bytes: &[u8], label: &str) -> Result<DecodeResult, GitHubErro
 
 fn decode_bom(bytes: &[u8]) -> Option<DecodeResult> {
     let (encoding, bom_len) = Encoding::for_bom(bytes)?;
-    let (decoded, _) = encoding.decode_without_bom_handling(&bytes[bom_len..]);
+    let (decoded, had_errors) = encoding.decode_without_bom_handling(&bytes[bom_len..]);
+    if had_errors {
+        debug!(
+            encoding = encoding.name(),
+            had_errors, "BOM-identified encoding produced replacement characters during decode"
+        );
+    }
     Some(DecodeResult {
         text: decoded.into_owned(),
         encoding: encoding.name().to_ascii_lowercase(),
@@ -145,7 +152,10 @@ fn decode_detect(bytes: &[u8]) -> Result<DecodeResult, GitHubError> {
         }
     }
 
-    // FR-007: chardetng inconclusive or had errors; try strict UTF-8
+    // FR-007: chardetng inconclusive or had errors; try strict UTF-8.
+    // Note: with `Utf8Detection::Allow`, chardetng already guesses UTF-8 for any
+    // valid-UTF-8 bytes, so this branch is unreachable in practice; it remains as a
+    // defensive backstop for the documented detection priority (FR-007).
     if let Ok(s) = str::from_utf8(bytes) {
         return Ok(DecodeResult {
             text: s.to_owned(),

--- a/src/github/encoding/tests.rs
+++ b/src/github/encoding/tests.rs
@@ -295,6 +295,36 @@ fn decode_base64_invalid_input_returns_decode_error() {
     );
 }
 
+// ── Fallback logging (issue #189) ──
+
+/// [T-GE015] decode_bom emits a debug event when the BOM-identified encoding
+/// produces replacement characters (had_errors=true).
+/// Action: decode UTF-16BE BOM + lone high surrogate (D800) under `traced_test`.
+#[tracing_test::traced_test]
+#[test]
+fn decode_bom_logs_debug_on_replacement_characters() {
+    // UTF-16BE BOM (FE FF) + lone high surrogate (D8 00) with no trailing low
+    // surrogate → encoding_rs substitutes U+FFFD and sets had_errors=true.
+    let bytes: &[u8] = &[0xFE, 0xFF, 0xD8, 0x00];
+
+    let result = decode_bytes(bytes, None).unwrap();
+
+    assert_eq!(result.source, DetectionSource::Bom);
+    assert!(
+        logs_contain("BOM-identified encoding produced replacement characters"),
+        "expected the BOM replacement-character debug event"
+    );
+    assert!(logs_contain("DEBUG"), "event level should be DEBUG");
+    assert!(
+        logs_contain("had_errors=true"),
+        "had_errors field should be true"
+    );
+    assert!(
+        logs_contain("UTF-16BE"),
+        "encoding field should name the BOM encoding"
+    );
+}
+
 // ── Helper ──
 
 fn base64_encode(input: &[u8]) -> String {

--- a/src/token_source.rs
+++ b/src/token_source.rs
@@ -77,8 +77,13 @@ where
     .ok()?;
 
     if !output.status.success() {
+        // SEC: `gh auth token` stderr can echo back the token or other secrets,
+        // so the raw stderr is dropped; only the exit code is reported.
         warn!(
-            stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+            redacted_reason = %format!(
+                "non-zero exit (code {}); stderr withheld",
+                output.status.code().unwrap_or(-1)
+            ),
             "gh auth token failed; falling back to unauthenticated"
         );
         return None;


### PR DESCRIPTION
## 概要

失敗フォールバックが無言で握り潰されるか不揃いなログを出していたため、スキーマ変動・デコード劣化・認証フォールバックを運用者が観測できなかった。issue #189 の対象 4 サイトに構造化 `tracing` イベントを追加し、機密はログ前に redaction する。

## 変更点

| サイト | ファイル                          | event                                 | level | fields                   |
| ------ | --------------------------------- | ------------------------------------- | ----- | ------------------------ |
| #1     | `github/encoding.rs` `decode_bom` | BOM デコードで置換文字発生            | debug | `encoding`, `had_errors` |
| #3     | `brave/client.rs` `search`        | JSON parse 失敗                       | warn  | `query_len`, `error`     |
| #5     | `fetch/extractor.rs`              | readability init/parse フォールバック | warn  | `url`(redacted), `error` |
| #6     | `token_source.rs`                 | `gh auth token` 非ゼロ終了            | warn  | `redacted_reason`        |

## ログ規律

- `query_len` は生クエリではなく長さのみ。検索語の漏洩を防ぐ。
- `url` は `RedactedLogUrl` 経由で userinfo を除去（認証情報をログに残さない）。`None` 時は `(none)` プレースホルダ。
- site #6 は `gh` の stderr がトークンを echo し得るため raw stderr を破棄し、終了コードのみ `redacted_reason` で報告（セキュリティ修正、別コミットに分離）。

## 非対象

- **site #2 (AssumedUtf8 分岐)**: `Utf8Detection::Allow` 下では chardetng が valid-UTF-8 バイトを常に UTF-8 と推定するため、この分岐は到達不能。ログは追加せず、文書化されたバックストップとして分岐自体は残置。
- **site #7 (clock.rs pre-epoch)**: 到達不能のため非対象（Overeagerness 回避）。

新規 ADR は追加しない（Occam / Overeagerness）。ログ規律はコミットメッセージと本文に記載。

## テスト

`cargo test --lib` 476 passed / 0 failed、`cargo fmt -- --check` clean、`cargo clippy --all-targets` clean。

- `T-GE015` decode_bom が置換文字発生時に DEBUG を出す
- `T-BC-LOG002` parse 失敗時に WARN + `query_len=6` + `error=`
- `T-FX011` フォールバック WARN で url 認証情報が redaction される（`s3cret` 不在を検証）
- `T-FX012` url 不在時に `url=(none)` プレースホルダ

site #6 はサブプロセスに注入 seam が無く（Overeagerness 回避のため追加せず）、raw stderr が消えたことを静的検査で確認。
