### PR TITLE
refactor(fetch,markdown): ホットパスの不要なアロケーション削減 (Cow・所有権移動) (#190)

### DIFF
--- a/src/fetch/converter.rs
+++ b/src/fetch/converter.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Write;
 
 use serde::Serialize;
@@ -114,13 +115,28 @@ fn yaml_marker_rest(line: &str) -> Option<&str> {
     (token.is_empty() || token.starts_with([' ', '\t', '\r'])).then_some(token)
 }
 
-pub(crate) fn escape_yaml(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
-        .replace('\0', "")
+pub(crate) fn escape_yaml(s: &str) -> Cow<'_, str> {
+    // The common frontmatter value (a plain title/author/date) carries no escapable
+    // char, so borrow it untouched instead of allocating a copy.
+    if !s
+        .bytes()
+        .any(|b| matches!(b, b'\\' | b'"' | b'\n' | b'\r' | b'\t' | b'\0'))
+    {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => {}
+            _ => out.push(c),
+        }
+    }
+    Cow::Owned(out)
 }
 
 #[cfg(test)]
@@ -185,6 +201,12 @@ mod tests {
             escape_yaml("She said \"hi\"\nand left\\"),
             "She said \\\"hi\\\"\\nand left\\\\"
         );
+    }
+
+    /// [T-FC012] escape_yaml borrows input that needs no escaping (no allocation)
+    #[test]
+    fn escape_yaml_borrows_when_no_escape_needed() {
+        assert!(matches!(escape_yaml("plain title 2026"), Cow::Borrowed(_)));
     }
 
     /// [T-FC005] neutralize_yaml_markers rewrites bare ---/... lines to ***

--- a/src/fetch/download.rs
+++ b/src/fetch/download.rs
@@ -81,7 +81,7 @@ pub(super) async fn download(
             FetchError::from,
         )
         .await?;
-        let html = decode_body(&body, charset.as_deref());
+        let html = decode_body(body, charset.as_deref());
         return Ok((current_url, html));
     }
 
@@ -112,7 +112,7 @@ fn extract_charset(content_type: &str) -> Option<String> {
     })
 }
 
-fn decode_body(bytes: &[u8], charset: Option<&str>) -> String {
+fn decode_body(bytes: Vec<u8>, charset: Option<&str>) -> String {
     let label = charset.unwrap_or("utf-8");
     let encoding = encoding_rs::Encoding::for_label(label.as_bytes()).unwrap_or_else(|| {
         warn!(
@@ -122,9 +122,14 @@ fn decode_body(bytes: &[u8], charset: Option<&str>) -> String {
         encoding_rs::UTF_8
     });
     if encoding == encoding_rs::UTF_8 {
-        return String::from_utf8_lossy(bytes).into_owned();
+        // Valid UTF-8 (the overwhelming majority) moves the buffer with no copy;
+        // only invalid bytes fall back to a lossy re-encode.
+        return match String::from_utf8(bytes) {
+            Ok(s) => s,
+            Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
+        };
     }
-    let (decoded, _, had_errors) = encoding.decode(bytes);
+    let (decoded, _, had_errors) = encoding.decode(&bytes);
     if had_errors {
         warn!(
             charset = label,

--- a/src/fetch/download/charset_tests.rs
+++ b/src/fetch/download/charset_tests.rs
@@ -27,9 +27,11 @@ fn returns_none_when_no_charset() {
 /// [T-F003] decode_body_handles_utf8
 #[test]
 fn decode_body_handles_utf8() {
-    let bytes = "こんにちは".as_bytes();
-    assert_eq!(decode_body(bytes, Some("utf-8")), "こんにちは");
-    assert_eq!(decode_body(bytes, None), "こんにちは");
+    assert_eq!(
+        decode_body("こんにちは".into(), Some("utf-8")),
+        "こんにちは"
+    );
+    assert_eq!(decode_body("こんにちは".into(), None), "こんにちは");
 }
 
 /// [T-F004] decode_body_handles_shift_jis
@@ -37,7 +39,7 @@ fn decode_body_handles_utf8() {
 fn decode_body_handles_shift_jis() {
     let encoding = encoding_rs::SHIFT_JIS;
     let (bytes, _, _) = encoding.encode("テスト");
-    assert_eq!(decode_body(&bytes, Some("shift_jis")), "テスト");
+    assert_eq!(decode_body(bytes.to_vec(), Some("shift_jis")), "テスト");
 }
 
 /// [T-F005] decode_body_handles_euc_jp
@@ -45,12 +47,14 @@ fn decode_body_handles_shift_jis() {
 fn decode_body_handles_euc_jp() {
     let encoding = encoding_rs::EUC_JP;
     let (bytes, _, _) = encoding.encode("日本語");
-    assert_eq!(decode_body(&bytes, Some("euc-jp")), "日本語");
+    assert_eq!(decode_body(bytes.to_vec(), Some("euc-jp")), "日本語");
 }
 
 /// [T-F006] decode_body_falls_back_to_utf8_for_unknown
 #[test]
 fn decode_body_falls_back_to_utf8_for_unknown() {
-    let bytes = "hello".as_bytes();
-    assert_eq!(decode_body(bytes, Some("unknown-encoding")), "hello");
+    assert_eq!(
+        decode_body(b"hello".to_vec(), Some("unknown-encoding")),
+        "hello"
+    );
 }

--- a/src/fetch/extractor.rs
+++ b/src/fetch/extractor.rs
@@ -66,13 +66,26 @@ fn make_raw(html: &str, used_raw_fallback: bool) -> ExtractedArticle {
 }
 
 /// Fallback when dom_smoothie fails to parse the HTML.
+///
+/// Scans the bytes case-insensitively in place rather than lowercasing the whole
+/// document, which would copy up to the full (multi-MB) input on the warm path.
 fn extract_title_from_html(html: &str) -> Option<String> {
-    let lower = html.to_ascii_lowercase();
-    let tag_start = lower.find("<title")?;
-    let content_start = tag_start + lower[tag_start..].find('>')? + 1;
-    let content_end = content_start + lower[content_start..].find("</title>")?;
+    let bytes = html.as_bytes();
+    let tag_start = find_ascii_ci(bytes, b"<title")?;
+    // `>` is ASCII, so a byte search is exact even inside multi-byte UTF-8 content.
+    let content_start = tag_start + bytes[tag_start..].iter().position(|&b| b == b'>')? + 1;
+    let content_end = content_start + find_ascii_ci(&bytes[content_start..], b"</title>")?;
     let title = html[content_start..content_end].trim();
     (!title.is_empty()).then(|| title.to_owned())
+}
+
+/// Byte offset of the first case-insensitive (ASCII) match of `needle` in `haystack`,
+/// or `None`.  Offsets index into the original bytes, so slicing the source `&str` at
+/// the returned position stays on a char boundary (`needle` is ASCII).
+fn find_ascii_ci(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|w| w.eq_ignore_ascii_case(needle))
 }
 
 #[cfg(test)]
@@ -189,8 +202,9 @@ mod tests {
     /// [T-FX010] title_extraction_safe_with_unicode_case_expansion
     #[test]
     fn title_extraction_safe_with_unicode_case_expansion() {
-        // Turkish İ (U+0130) expands from 2→3 bytes under full to_lowercase().
-        // to_ascii_lowercase preserves byte offsets, preventing panic on slice.
+        // The byte-window scan matches the uppercase <TITLE> tag without lowercasing,
+        // and returns byte offsets, so slicing the source &str past multibyte content
+        // (İ, U+0130, 2 bytes) stays on a char boundary and does not panic.
         let html = "<html><head><TITLE>My Title</TITLE></head><body>İİİ</body></html>";
         assert_eq!(extract_title_from_html(html), Some("My Title".to_owned()));
     }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -58,7 +58,13 @@ pub(crate) fn escape_md_inline(s: &str) -> String {
 
 /// Sanitize user input for embedding in a Markdown heading.
 /// Replaces newlines (which would break heading structure) with spaces.
-pub(crate) fn sanitize_heading(s: &str) -> String {
+///
+/// Returns the input borrowed when it carries no newline, which is the common case
+/// for headings (titles, URLs), so no allocation happens on that path.
+pub(crate) fn sanitize_heading(s: &str) -> Cow<'_, str> {
+    if !s.contains(['\n', '\r']) {
+        return Cow::Borrowed(s);
+    }
     s.chars()
         .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
         .collect()
@@ -174,6 +180,15 @@ mod tests {
     fn sanitize_heading_replaces_newlines() {
         assert_eq!(sanitize_heading("line1\nline2\rline3"), "line1 line2 line3");
         assert_eq!(sanitize_heading("no newlines"), "no newlines");
+    }
+
+    /// [T-MD011] sanitize_heading borrows input without newlines (no allocation)
+    #[test]
+    fn sanitize_heading_borrows_when_no_newline() {
+        assert!(matches!(
+            sanitize_heading("plain heading"),
+            Cow::Borrowed(_)
+        ));
     }
 
     /// [T-MD006] shift_headings deepens levels by N


### PR DESCRIPTION
## 概要

issue #190。scout のホットパスで発生していた不要なヒープアロケーションを、`Cow` と所有権ムーブで削減する。

## 変更点

- **decode_body** (`src/fetch/download.rs`): 引数を `&[u8]` → `Vec<u8>` に変更し、有効 UTF-8(大多数)はバッファをムーブ。無効バイトのみ `from_utf8_lossy` にフォールバック。従来は有効 UTF-8 でも全文コピーしていた
- **escape_yaml** (`src/fetch/converter.rs`): 戻り値を `Cow<'_, str>` に変更。エスケープ対象文字がない入力(通常の title/author/date)は借用で返し無アロケート。必要時のみ 1 パス + `with_capacity`(従来は 6 連 `.replace()` で多重アロケート)
- **extract_title_from_html** (`src/fetch/extractor.rs`): 全文 `to_ascii_lowercase()`(最大数 MB コピー)を廃止し、大文字小文字無視の byte-window scan に。タグ検出のアロケーションをゼロに
- **sanitize_heading** (`src/markdown.rs`): 戻り値を `Cow<'_, str>` に変更。改行を含まない見出し(title/URL の通常ケース)は借用で返す

## 受け入れ基準

- [x] decode_body が有効 UTF-8 を余分にコピーしない
- [x] escape_yaml がエスケープ不要入力でアロケートしない

新規テスト T-FC012・T-MD011 が借用(無アロケート)パスを `matches!(.., Cow::Borrowed(_))` で検証。

## スコープ外(実利益なしと判断)

- **shift_headings → Cow**: 全呼び出し元が `levels=2/3` 固定で `levels=0` を渡さないため、本番では借用が成立せず純粋な churn。tools.rs 側も `.into_owned()` が必要になる
- **decode_base64 の改行除去**: GitHub は常に改行入り base64 を返すため whitespace フィルタのコピーは不可避。ストリーミングデコーダなしでは利得なし

## 検証

- `cargo test --lib`: 478 passed / 0 failed
- `cargo clippy --all-targets`: clean
- `cargo fmt -- --check`: clean