### PR TITLE
テスト容易性: SlackClient::from_env_with + ScoutBuilder Slack 注入 seam

### DIFF
--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -91,14 +91,29 @@ impl SlackClient {
         }
     }
 
-    pub fn from_env(http: Client, max_retries: u32) -> Result<Self, SlackError> {
-        let raw = env::var("SLACK_TOKEN").map_err(|_| SlackError::TokenNotSet)?;
+    pub(crate) fn from_env(http: Client, max_retries: u32) -> Result<Self, SlackError> {
+        Self::from_env_with(http, max_retries, |k| env::var(k))
+    }
+
+    /// Wraps [`Self::from_env`] with a caller-supplied env reader so unit
+    /// tests can exercise the token-not-set / whitespace branches without
+    /// `unsafe { std::env::set_var(...) }` (forbidden by `unsafe_code = "forbid"`).
+    /// Mirrors [`crate::brave::client::BraveClient::from_env_with`] (ADR-0007).
+    pub(crate) fn from_env_with<F>(
+        http: Client,
+        max_retries: u32,
+        get_var: F,
+    ) -> Result<Self, SlackError>
+    where
+        F: Fn(&str) -> Result<String, env::VarError>,
+    {
+        let raw = get_var("SLACK_TOKEN").map_err(|_| SlackError::TokenNotSet)?;
         let token = Redacted::new(&raw).ok_or(SlackError::TokenNotSet)?;
         Ok(Self::new(http, token, max_retries))
     }
 
     #[cfg(test)]
-    fn with_base_url(http: Client, base_url: &str) -> Self {
+    pub(crate) fn with_base_url(http: Client, base_url: &str) -> Self {
         Self {
             http,
             token: Redacted::new("xoxp-test").expect("static literal is non-empty"),

--- a/src/slack/client/constructor_tests.rs
+++ b/src/slack/client/constructor_tests.rs
@@ -21,3 +21,45 @@ async fn t010_with_base_url_constructs_usable_client() {
     let result: Result<DummyBody, _> = client.api_get_once("auth.test", &[]).await;
     assert!(result.is_ok());
 }
+
+/// [T-SK033] from_env_with surfaces a closure `Err(VarError::NotPresent)` as
+/// `SlackError::TokenNotSet` — the token-unset path that `unsafe_code = "forbid"`
+/// blocks from being reached via `env::set_var` (ADR-0007, issue #191).
+#[test]
+fn t033_from_env_with_returns_token_not_set_when_closure_errs() {
+    // `.map(|_| ())` drops the `SlackClient` (no `Debug`) so the failure
+    // message can format the `Result`.
+    let result = SlackClient::from_env_with(Client::new(), DEFAULT_MAX_RETRIES, |_| {
+        Err(env::VarError::NotPresent)
+    })
+    .map(|_| ());
+    assert!(
+        matches!(result, Err(SlackError::TokenNotSet)),
+        "expected TokenNotSet, got: {result:?}"
+    );
+}
+
+/// [T-SK034] from_env_with rejects a whitespace-only token as `TokenNotSet`
+/// (parity with `Redacted::new` rejecting blank secrets).
+#[test]
+fn t034_from_env_with_rejects_whitespace_only_token() {
+    let result =
+        SlackClient::from_env_with(Client::new(), DEFAULT_MAX_RETRIES, |_| Ok("   ".to_owned()))
+            .map(|_| ());
+    assert!(
+        matches!(result, Err(SlackError::TokenNotSet)),
+        "expected TokenNotSet for whitespace-only token, got: {result:?}"
+    );
+}
+
+/// [T-SK035] from_env_with with a real token yields `Ok(client)` whose token
+/// round-trips through `Redacted::expose()` and whose `base_url` is `API_BASE`.
+#[test]
+fn t035_from_env_with_constructs_client_with_api_base_and_exposed_token() {
+    let result = SlackClient::from_env_with(Client::new(), DEFAULT_MAX_RETRIES, |_| {
+        Ok("xoxp-real".to_owned())
+    });
+    let client = result.expect("expected Ok(client) from valid token");
+    assert_eq!(client.token.expose(), "xoxp-real");
+    assert_eq!(client.base_url, API_BASE);
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -34,6 +34,7 @@ use crate::fetch::converter::{FetchResult, RAW_FALLBACK_NOTE};
 use crate::github::GitHubClient;
 use crate::markdown::{shift_headings, truncate_with_note};
 use crate::rng::Rng;
+use crate::slack::SlackClient;
 use crate::token_source::TokenSource;
 
 // Re-imported under `cfg(test)` so the in-module test files (which reach them
@@ -164,6 +165,10 @@ pub struct Scout {
     /// Lazy-initialized on first GitHub API call. Non-GitHub commands
     /// (search, fetch, research) never pay the `gh auth token` cost.
     github: OnceCell<GitHubClient>,
+    /// Lazy-initialized on first Slack permalink fetch. Mirrors `github`:
+    /// non-Slack commands never read `SLACK_TOKEN`. Tests pre-set the cell via
+    /// `ScoutBuilder::with_slack_endpoint`.
+    slack: OnceCell<SlackClient>,
     /// Sticky shutdown flag. `lib::run` flips this to `true` on SIGINT or
     /// SIGTERM. Each `fetch_with_cdp` invocation subscribes a fresh receiver
     /// so the cancellation is delivered to fetches that start after the
@@ -227,6 +232,19 @@ impl Scout {
         self.brave
             .as_ref()
             .ok_or_else(|| ScoutError::from(BraveError::ApiKeyNotSet))
+    }
+
+    /// Lazy Slack client, mirroring `github()`. `get_or_try_init` defers the
+    /// fallible `from_env` (token read) to the first Slack fetch; tests inject a
+    /// wiremock-backed client by pre-setting the `OnceCell` in `build()`.
+    async fn slack(&self) -> Result<&SlackClient, ScoutError> {
+        self.slack
+            .get_or_try_init(|| async {
+                SlackClient::from_env(self.http.clone(), self.config.max_retries)
+                    .map(|c| c.with_clock(self.clock.clone()).with_rng(self.rng.clone()))
+                    .map_err(ScoutError::from)
+            })
+            .await
     }
 
     /// Wrap a GitHub command future in the outer `github_timeout`. The inner

--- a/src/tools/builder.rs
+++ b/src/tools/builder.rs
@@ -14,6 +14,8 @@ use crate::fetch::{DnsResolver, SsrfResolver, TokioDnsResolver};
 #[cfg(test)]
 use crate::github::GitHubClient;
 use crate::rng::{FastrandRng, Rng};
+#[cfg(test)]
+use crate::slack::SlackClient;
 use crate::token_source::{GhCliSource, TokenSource};
 
 use super::{RuntimeConfig, Scout, ScoutError};
@@ -45,6 +47,11 @@ pub(crate) struct ScoutBuilder {
     /// `from_env_with_source`. `None` (production) preserves lazy init.
     #[cfg(test)]
     github_endpoint: Option<String>,
+    /// Pre-init `Scout.slack` (`OnceCell`) with a test client pointed at this
+    /// base URL so `Scout::slack()` returns it without reading `SLACK_TOKEN`.
+    /// `None` (production) preserves lazy init. Mirrors `github_endpoint`.
+    #[cfg(test)]
+    slack_endpoint: Option<String>,
 }
 
 /// Build the two `reqwest::Client`s shared between production and test paths
@@ -91,6 +98,8 @@ impl ScoutBuilder {
             config,
             #[cfg(test)]
             github_endpoint: None,
+            #[cfg(test)]
+            slack_endpoint: None,
         })
     }
 
@@ -113,6 +122,7 @@ impl ScoutBuilder {
             cancel: watch::channel(false).0,
             config: RuntimeConfig::default(),
             github_endpoint: None,
+            slack_endpoint: None,
         }
     }
 
@@ -167,12 +177,30 @@ impl ScoutBuilder {
         self
     }
 
+    /// Stores `endpoint`; `build()` uses the current `clock` / `rng` to pre-init
+    /// the `slack` `OnceCell`. Composes with `with_clock` / `with_rng` (call
+    /// those before `build`). Mirrors `with_github_endpoint`.
+    #[cfg(test)]
+    pub(crate) fn with_slack_endpoint(mut self, endpoint: &str) -> Self {
+        self.slack_endpoint = Some(endpoint.to_owned());
+        self
+    }
+
     pub(crate) fn build(self) -> Scout {
         let github = OnceCell::new();
         #[cfg(test)]
         if let Some(endpoint) = self.github_endpoint.as_deref() {
             let _ = github.set(
                 GitHubClient::with_base_url(self.http.clone(), endpoint)
+                    .with_clock(self.clock.clone())
+                    .with_rng(self.rng.clone()),
+            );
+        }
+        let slack = OnceCell::new();
+        #[cfg(test)]
+        if let Some(endpoint) = self.slack_endpoint.as_deref() {
+            let _ = slack.set(
+                SlackClient::with_base_url(self.http.clone(), endpoint)
                     .with_clock(self.clock.clone())
                     .with_rng(self.rng.clone()),
             );
@@ -185,6 +213,7 @@ impl ScoutBuilder {
             fetch_http: self.fetch_http,
             brave,
             github,
+            slack,
             cancel: self.cancel,
             config: self.config,
             clock: self.clock,

--- a/src/tools/builder_tests.rs
+++ b/src/tools/builder_tests.rs
@@ -153,3 +153,46 @@ async fn scout_builder_clock_reaches_github_client_via_seam() {
         "expected retry_after = 600 (reset 1600 - clock 1000), got: {result:?}"
     );
 }
+
+/// [T-SB005] `with_slack_endpoint` で inject した wiremock endpoint が
+/// `fetch`(slack permalink) → `fetch_slack` → `slack()` の production 経路で
+/// 構築される `SlackClient` まで届くことを end-to-end で確認する。`slack()` の
+/// `OnceCell` を build() で pre-set するため `SLACK_TOKEN` 未設定でも注入
+/// クライアントが使われ、`conversations.history` に到達して本文を取得できる。
+/// 注入が wire できていなければ `from_env` が `TokenNotSet` を返し落ちる
+/// (issue #191)。
+#[tokio::test]
+async fn scout_builder_slack_endpoint_reaches_fetch_slack_via_seam() {
+    let Some(server) = try_spawn_mock_server("tools::scout_builder_slack_seam").await else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"type": "message", "text": "hello from wiremock", "ts": "1773819598.273499"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+
+    let result = scout
+        .fetch(FetchParams {
+            url: Some("https://team.slack.com/archives/C123/p1773819598273499".into()),
+            js: false,
+            raw: false,
+        })
+        .await;
+    let output =
+        result.expect("injected slack endpoint must serve fetch_slack without SLACK_TOKEN");
+    assert!(
+        output.markdown().contains("hello from wiremock"),
+        "fetch output must carry the wiremock message body, got: {}",
+        output.markdown()
+    );
+}

--- a/src/tools/query.rs
+++ b/src/tools/query.rs
@@ -9,7 +9,7 @@ use crate::fetch::converter::FetchResult;
 use crate::fetch::{FetchError, FetchOptions, RedactedLogUrl, fetch_page};
 use crate::markdown::truncate_with_note;
 use crate::search::engine;
-use crate::slack::{SlackClient, SlackError, SlackUrl, parse_slack_url};
+use crate::slack::{SlackError, SlackUrl, parse_slack_url};
 
 use super::params::{FetchParams, ResearchParams, SearchParams};
 use super::{MAX_FETCH_OUTPUT_BYTES, Scout, ScoutError, format_fetch_output, resolve_stdin_arg};
@@ -93,9 +93,7 @@ impl Scout {
 
     async fn fetch_slack(&self, slack_url: SlackUrl) -> Result<CommandOutput, ScoutError> {
         info!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), "fetch (slack)");
-        let client = SlackClient::from_env(self.http.clone(), self.config.max_retries)?
-            .with_clock(self.clock.clone())
-            .with_rng(self.rng.clone());
+        let client = self.slack().await?;
         let slack_timeout = self.config.slack_timeout;
         let output = timeout(slack_timeout, client.fetch_message(&slack_url))
             .await

--- a/src/tools/repo_lazy_tests.rs
+++ b/src/tools/repo_lazy_tests.rs
@@ -1,5 +1,6 @@
 use super::test_helpers::*;
 use super::*;
+use crate::ErrorCode;
 use crate::search::Lang;
 use crate::test_support::try_spawn_mock_server;
 use std::time::Duration;
@@ -411,5 +412,42 @@ async fn github_lazy_init_from_empty_cell() {
     assert!(
         ptr::eq(client, client2),
         "second call returns the same cached reference"
+    );
+}
+
+/// [T-TS023] slack() lazily routes the non-injected production path through
+/// `SlackClient::from_env`, and a missing `SLACK_TOKEN` surfaces as a
+/// `ScoutError` without poisoning the `OnceCell` (`get_or_try_init` does not
+/// cache errors). This covers the lazy seam that `with_slack_endpoint` bypasses
+/// in T-SB005 (issue #191).
+///
+/// Guarded like `try_spawn_mock_server`: when the ambient environment provides a
+/// real `SLACK_TOKEN` (developer shell), `from_env` would succeed and this spec
+/// no longer applies, so skip rather than assert a different spec. CI runs with
+/// `SLACK_TOKEN` unset, exercising the asserted `TokenNotSet` branch.
+#[tokio::test]
+async fn slack_lazy_init_surfaces_token_not_set_without_token() {
+    use std::env;
+    if env::var("SLACK_TOKEN").is_ok_and(|t| !t.trim().is_empty()) {
+        return;
+    }
+    let s = scout_lazy("http://localhost:0");
+    assert!(s.slack.get().is_none(), "slack OnceCell starts empty");
+
+    // `.map(|_| ())` drops the `&SlackClient` (no `Debug`) so `expect_err` can
+    // format the `Ok` side on failure.
+    let err = s
+        .slack()
+        .await
+        .map(|_| ())
+        .expect_err("unset SLACK_TOKEN must surface as an error");
+    assert_eq!(
+        err.error_kind(),
+        ErrorCode::UsageError,
+        "missing Slack token maps to UsageError (SlackError::TokenNotSet)"
+    );
+    assert!(
+        s.slack.get().is_none(),
+        "get_or_try_init must not cache a failed initialization"
     );
 }


### PR DESCRIPTION
## 概要と背景

Slack backend の DI seam を BraveClient 確立済みの `from_env_with<F>` パターン(ADR-0007)へ横展開する。`unsafe_code = "forbid"` 下で到達不能だった「SLACK_TOKEN 未設定」パスを unit test 可能にし、ScoutBuilder 経由で SlackClient を wiremock に向けて注入できるようにする。

## 変更点

- `SlackClient::from_env_with<F>` を追加し、`from_env` はこれに委譲。env 読み取りを注入可能化
- `from_env` / `with_base_url` を `pub(crate)` へ narrow(BraveClient と可視性を揃える。`SlackClient` は `pub(crate)` 再エクスポートのため `pub` は元々クレート外不達)
- `Scout.slack: OnceCell<SlackClient>` + `slack()` アクセサを追加(`get_or_try_init`、`github()` を踏襲)。`fetch_slack` を per-call `from_env` から `self.slack().await?` に変更 — Slack 以外のコマンドは `SLACK_TOKEN` を読まない lazy init を維持
- `ScoutBuilder::with_slack_endpoint` + `build()` での OnceCell pre-set(`with_github_endpoint` を踏襲)

## 設計判断

- 注入方式は brave 型(常時保持フィールド)ではなく github 型(`OnceCell` 遅延初期化)を採用。Slack は niche path(slack permalink のみ)で、brave の `from_env` が毎回 warn するのに対し、毎呼び出しのトークン読み取り/警告を避ける狙い。production アクセサに `#[cfg(test)]` 分岐を持ち込まず cfg-clean を維持する
- github の `get_or_init`(infallible)に対し Slack は fallible のため `get_or_try_init` を採用。エラー時は OnceCell 未初期化のまま retry 可能で、旧 per-call `from_env` の挙動を保存

## スコープ

- **含まないもの**: SSRF connect-time 再検証(#201)等、本 issue 範囲外の Slack 経路変更は含まない

## テスト手順

1. `cargo test --lib slack:: tools::builder_tests::scout_builder_slack_endpoint` → 緑
2. AC#1: T-SK033/034/035 が `from_env_with` のトークン未設定/空白/有効を検証
3. AC#2: T-SB005 が `with_slack_endpoint` 注入 → `fetch`(slack permalink)→ wiremock 到達を end-to-end 検証

## 関連

- Closes #191