### PR TITLE
refactor(error): エラー envelope の serde バイパス解消と serialize 単一化 (#192)

### DIFF
--- a/.antigravitycli/8f9827e8-be6f-4798-89c5-df15ae7bc37a.json
+++ b/.antigravitycli/8f9827e8-be6f-4798-89c5-df15ae7bc37a.json
@@ -1,0 +1,1 @@
+/Users/thkt/.gemini/config/projects/8f9827e8-be6f-4798-89c5-df15ae7bc37a.json

--- a/docs/audit/2026-05-30-outcome-simplicity-audit.md
+++ b/docs/audit/2026-05-30-outcome-simplicity-audit.md
@@ -1,0 +1,73 @@
+# Outcome & Simplicity Audit: 2026-05-30
+
+アウトカム整合・シンプルさ・open issue 方向性の横断監査。`.claude/OUTCOME.md` を基準に、コマンド表面の end-to-end 実証、複雑性コストセンターの計測、issue 群の Progressive Enhancement staging を行った。手法は OUTCOME 照合 + 実機実証 + issue 集約判定 + advisor adversarial challenge。
+
+## Summary
+
+| Metric | Value |
+| ------ | ----- |
+| 結論（向かう方向） | 正しい。capability 達成済み、backlog は残バグ + 内部品質 polish へ健全にシフト |
+| Behavior 実証 | `scout fetch https://example.com` が中間要約なしで本文を Markdown 取得（実機 exit 0） |
+| コマンド表面 | 6 コマンド全て「一次ソース取得」に収束。逸脱なし |
+| アウトカムドリフト | 1 件（Slack が OUTCOME.md Behavior 未記載） |
+| open issue 総数 | 19 |
+| うち OUTCOME 直結 | ~6（SSRF #184/#193, OOM #186, timeout #185, escape #187, slack #188 + 新規 #198/#199） |
+| うち直交する内部品質 | ~13（DI seam, alloc 削減, trait 昇格, 構造化ログ）。正当だが gold-plating 注意 |
+| 複雑性コストセンター | CDP/js-rendering: 本体 562 行 + `cfg(js-rendering)` 42 箇所散在。default 無効の opt-in 隔離 |
+| ディレクトリ最大深さ | 4（`src/fetch/cdp/launch/*_tests.rs`）。STRUCTURE.md 3 階層超だが LANG.md 分割 + framework override 範囲内 |
+| テスト規模 | 438 関数（#[test]/#[tokio::test]） |
+
+## 1. アウトカム整合性 — 高い（実証済み）
+
+| 観点 | 判定 | 根拠 |
+| ---- | ---- | ---- |
+| Behavior 達成 | 達成 | `scout fetch https://example.com` が YAML frontmatter + clean Markdown を返し、中間 LLM 要約を挟まない。README "Read the sources, not a summary" と一致 |
+| コマンド表面 | 整合 | search / fetch / research / repo-tree / repo-read / repo-overview が全て一次ソース取得に収束 |
+| Non-goal 遵守 | 遵守 | MCP 提供なし、ローカルファイル処理なし、対話操作なし。js-rendering は SPA 本文取得であって対話操作ではないと README で切り分け済み |
+
+### ドリフト: Slack（要修正）
+
+- 実態: `scout fetch <slack-url>` として fetch に統合、README に `SLACK_TOKEN` 明記。API トークン認証であり Non-goal の「ログインフロー/対話操作」には該当しない。Slack スレッドは一次ソースであり、アウトカムの精神には合致する。
+- 問題: OUTCOME.md の Behavior は「Web ページや GitHub リポジトリ」のみで Slack を名指ししていない。コードが文書を追い越している。
+- 修正方向: Slack を削るのではなく、OUTCOME の Behavior に source type を明記する（web / GitHub / Slack）。
+
+### フラグ: OUTCOME.md が `.gitignore` 配下
+
+`.claude/` ごと gitignore されており、アウトカムへの整合が現状はチーム非可視の個人文書への整合に留まる。北極星が共有されていない点は、参照基準としての弱さ。共有の可否は運用方針のためユーザー判断。
+
+## 2. シンプルさ判定
+
+| 対象 | 判定 | 理由 |
+| ---- | ---- | ---- |
+| コア（search/fetch/research/repo-*） | シンプル | 最大ファイル 392 行（閾値 400 内）、素直な pipeline 構造、逸脱なし |
+| CDP / js-rendering | keep（隔離は正しい） | 本体 562 行 + `cfg(js-rendering)` 42 箇所散在。chromiumoxide + nix + signal + process-group kill + orphan reap が複雑性の集中点。ただし default 無効の opt-in でコアのシンプルさは侵さない。SPA という最も薄いアウトカムスライスに複雑性が集中する構造は認識すべき。42 箇所散在は将来の simplify 候補 |
+| ディレクトリ深さ | 許容 | 最大 4 階層は全て CDP launch のテストファイル。LANG.md の `sub.rs` + `sub/child.rs` 分割と framework override の範囲内。直近の split campaign は概ね可読性に寄与（最大 392 行に収束） |
+
+## 3. issue 見直し — 規律ある backlog、優先順位の明示が必要
+
+backlog 自体は健全。YAGNI gate 明記（#177「trigger 条件待ち」、#175「seam 1 個なので許容」）、トレーサビリティ完備（RC 番号、reviewer 収束数、critic-evidence verified）。close は推奨しない（trigger 条件の記録を捨てるため）。レバーは close ではなく sequencing と labeling。
+
+Progressive Enhancement staging:
+
+| Stage | issue | 扱い |
+| ----- | ----- | ---- |
+| Work / Resilient（バグ） | #184/#193 SSRF, #186 OOM, #185 timeout, #187 escape漏れ, #188 slack無音fallback, #198/#199 新規 | 本丸。次にやる。OUTCOME Constraint と品質に直結 |
+| Fast（perf） | #190 decode_body 全コピー等（実害 verified） | 正当だが bug の後 |
+| Flexible（trait/seam） | #174-177, #175, #191 | 2nd impl なし、YAGNI gate 付き。正しく deferred |
+
+19 open のうち OUTCOME 直結は ~6 件、残り ~13 件は正当だが直交する内部品質。これは「機能未完成」ではなく「機能達成後の polish フェーズ」の姿勢。意図的なら正しいが、内部品質に偏った backlog は gold-plating に転びうるため、本丸バグの優先を明示しておく。
+
+### 優先決着 1 件: #193
+
+「TOCTOU DNS rebinding を IP pin で塞ぐか OUTCOME 制約に例外明記するか」。OUTCOME Constraint「全 fetch 経路で SSRF 防御を必須（private IP 帯への到達を遮断）」に直接関わる、文書判断を含むバグ。コード修正と OUTCOME 文書のどちらを動かすかの決定が保留されている。最優先で決める。
+
+## 推奨アクション（最小）
+
+| # | アクション | 性質 |
+| - | ---------- | ---- |
+| 1 | OUTCOME.md の Behavior に Slack を source type として明記 | 文書を実態に追従。OUTCOME 級のため文案確認 |
+| 2 | #193 を最優先で決着（IP pin 実装 or OUTCOME 制約への例外明記） | OUTCOME に触る判断のため先送りしない |
+| 3 | priority:low の trait/seam 系に deferred 運用（close せずラベル/整理で本丸バグと分離） | backlog の優先純度 |
+| 4 | OUTCOME.md の `.gitignore` 除外を検討（北極星のチーム共有） | 運用方針、ユーザー判断 |
+
+これ以上のコード変更・抽象化追加は不要。現状は「シンプルに保たれ、正しい方向を向いている」。

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -224,6 +224,16 @@ pub(crate) struct ErrorEnvelope {
     pub error: ErrorPayload,
 }
 
+impl ErrorEnvelope {
+    /// Serialize as the one-line JSON error envelope per ADR-0010. Single
+    /// serialize point so every error consumer (CLI runtime, clap usage-error
+    /// path) shares one infallible-serialize contract instead of duplicating
+    /// `serde_json::to_string(..).expect(..)`.
+    pub(crate) fn to_json_line(&self) -> String {
+        serde_json::to_string(self).expect("ErrorEnvelope is Serialize")
+    }
+}
+
 /// Error payload nested under `ErrorEnvelope::error` per ADR-0010.
 #[derive(Debug, Serialize)]
 pub(crate) struct ErrorPayload {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -224,14 +224,12 @@ pub(crate) struct ErrorEnvelope {
     pub error: ErrorPayload,
 }
 
-impl ErrorEnvelope {
-    /// Serialize as the one-line JSON error envelope per ADR-0010. Single
-    /// serialize point so every error consumer (CLI runtime, clap usage-error
-    /// path) shares one infallible-serialize contract instead of duplicating
-    /// `serde_json::to_string(..).expect(..)`.
-    pub(crate) fn to_json_line(&self) -> String {
-        serde_json::to_string(self).expect("ErrorEnvelope is Serialize")
-    }
+/// Serialize an output envelope as its one-line JSON form per ADR-0010. The
+/// single serialize point for both `SuccessEnvelope` and `ErrorEnvelope`: these
+/// crate-owned types serialize infallibly, so the `expect` is unreachable and
+/// callers stay free of a `Result` they could only `.expect()` themselves.
+pub(crate) fn to_json_line<T: Serialize>(envelope: &T) -> String {
+    serde_json::to_string(envelope).expect("envelope is Serialize")
 }
 
 /// Error payload nested under `ErrorEnvelope::error` per ADR-0010.

--- a/src/envelope/tests.rs
+++ b/src/envelope/tests.rs
@@ -78,10 +78,11 @@ fn error_envelope_wraps_payload_under_error_key() {
     );
 }
 
-/// [T-EN016] `ErrorEnvelope::to_json_line` is the single serialize point per
-/// ADR-0010 and emits the same one-line JSON as direct `serde_json::to_string`.
+/// [T-EN016] `to_json_line` is the single serialize point per ADR-0010 and
+/// emits the same one-line JSON as direct `serde_json::to_string` for an
+/// `ErrorEnvelope`.
 #[test]
-fn error_envelope_to_json_line_matches_direct_serialize() {
+fn to_json_line_matches_direct_serialize() {
     let env = ErrorEnvelope {
         error: ErrorPayload {
             code: ErrorCode::Internal,
@@ -91,7 +92,7 @@ fn error_envelope_to_json_line_matches_direct_serialize() {
             retryable: false,
         },
     };
-    let line = env.to_json_line();
+    let line = to_json_line(&env);
     assert_eq!(line, serde_json::to_string(&env).unwrap());
     assert!(line.starts_with(r#"{"error":"#), "got: {line}");
     assert!(line.contains(r#""code":"INTERNAL""#), "got: {line}");

--- a/src/envelope/tests.rs
+++ b/src/envelope/tests.rs
@@ -78,6 +78,29 @@ fn error_envelope_wraps_payload_under_error_key() {
     );
 }
 
+/// [T-EN016] `ErrorEnvelope::to_json_line` is the single serialize point per
+/// ADR-0010 and emits the same one-line JSON as direct `serde_json::to_string`.
+#[test]
+fn error_envelope_to_json_line_matches_direct_serialize() {
+    let env = ErrorEnvelope {
+        error: ErrorPayload {
+            code: ErrorCode::Internal,
+            message: String::from("failed to serialize fetch result"),
+            next_step: None,
+            candidates: vec![],
+            retryable: false,
+        },
+    };
+    let line = env.to_json_line();
+    assert_eq!(line, serde_json::to_string(&env).unwrap());
+    assert!(line.starts_with(r#"{"error":"#), "got: {line}");
+    assert!(line.contains(r#""code":"INTERNAL""#), "got: {line}");
+    assert!(
+        !line.contains('\n'),
+        "envelope must be one line, got: {line}"
+    );
+}
+
 /// [T-EN005] SuccessEnvelope serializes data + degraded + notes
 #[test]
 fn success_envelope_serializes_required_fields() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ fn render_json_success(output: CommandOutput) -> String {
 /// Serialize a `ScoutError` as a one-line JSON envelope per ADR-0010.
 /// Uses `err.message()` (bare) so `next_step` is not duplicated in `message`.
 fn render_json_error(err: &ScoutError) -> String {
-    let envelope = ErrorEnvelope {
+    ErrorEnvelope {
         error: ErrorPayload {
             code: err.error_kind(),
             message: err.message().to_owned(),
@@ -198,8 +198,8 @@ fn render_json_error(err: &ScoutError) -> String {
             candidates: err.candidates().to_vec(),
             retryable: err.retryable(),
         },
-    };
-    serde_json::to_string(&envelope).expect("envelope is Serialize")
+    }
+    .to_json_line()
 }
 
 /// Handle a `clap::Error` from `Cli::try_parse()`. Help/version display
@@ -214,7 +214,7 @@ fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
         }
         _ => {
             if json_mode {
-                let envelope = ErrorEnvelope {
+                let line = ErrorEnvelope {
                     error: ErrorPayload {
                         code: ErrorCode::UsageError,
                         message: err.to_string().trim().to_owned(),
@@ -222,8 +222,8 @@ fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
                         candidates: Vec::new(),
                         retryable: false,
                     },
-                };
-                let line = serde_json::to_string(&envelope).expect("envelope is Serialize");
+                }
+                .to_json_line();
                 eprintln!("{line}");
             } else {
                 let _ = err.print();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,27 @@ mod tests {
 
     use clap::CommandFactory;
 
-    use super::{init_tracing, write_output};
+    use super::{CommandOutput, init_tracing, render_json_success, write_output};
+
+    /// [T-RJS001] render_json_success serializes a `CommandOutput` as a one-line
+    /// success envelope per ADR-0010: `data` payload preserved, `degraded:false`,
+    /// no embedded newline. Pins the `--json` happy-path boundary so a regression
+    /// in `into_envelope` / `to_json_line` wiring fails here.
+    #[test]
+    fn render_json_success_emits_one_line_success_envelope() {
+        let output = CommandOutput::ok(
+            String::from("hello"),
+            serde_json::json!({"markdown": "hello"}),
+        );
+        let line = render_json_success(output);
+        assert!(line.starts_with(r#"{"data":"#), "got: {line}");
+        assert!(line.contains(r#""markdown":"hello""#), "got: {line}");
+        assert!(line.contains(r#""degraded":false"#), "got: {line}");
+        assert!(
+            !line.contains('\n'),
+            "envelope must be one line, got: {line}"
+        );
+    }
 
     /// [T-INIT001] init_tracing tolerates a second invocation (issue #103).
     /// `.init()` would panic on the duplicate; `.try_init()` returns Err which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Parser;
-use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload};
+use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload, to_json_line};
 use signals::{InterruptSignal, wait_for_signal};
 use tokio::time::timeout;
 use tools::{Command, Scout, ScoutError};
@@ -184,13 +184,13 @@ pub async fn run() -> ExitCode {
 /// Takes `CommandOutput` by value so `data` and `notes` move into the envelope
 /// instead of being deep-cloned.
 fn render_json_success(output: CommandOutput) -> String {
-    serde_json::to_string(&output.into_envelope()).expect("envelope is Serialize")
+    to_json_line(&output.into_envelope())
 }
 
 /// Serialize a `ScoutError` as a one-line JSON envelope per ADR-0010.
 /// Uses `err.message()` (bare) so `next_step` is not duplicated in `message`.
 fn render_json_error(err: &ScoutError) -> String {
-    ErrorEnvelope {
+    to_json_line(&ErrorEnvelope {
         error: ErrorPayload {
             code: err.error_kind(),
             message: err.message().to_owned(),
@@ -198,8 +198,7 @@ fn render_json_error(err: &ScoutError) -> String {
             candidates: err.candidates().to_vec(),
             retryable: err.retryable(),
         },
-    }
-    .to_json_line()
+    })
 }
 
 /// Handle a `clap::Error` from `Cli::try_parse()`. Help/version display
@@ -214,7 +213,7 @@ fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
         }
         _ => {
             if json_mode {
-                let line = ErrorEnvelope {
+                let line = to_json_line(&ErrorEnvelope {
                     error: ErrorPayload {
                         code: ErrorCode::UsageError,
                         message: err.to_string().trim().to_owned(),
@@ -222,8 +221,7 @@ fn handle_parse_error(err: &clap::Error, json_mode: bool) -> ExitCode {
                         candidates: Vec::new(),
                         retryable: false,
                     },
-                }
-                .to_json_line();
+                });
                 eprintln!("{line}");
             } else {
                 let _ = err.print();

--- a/src/tools/builder.rs
+++ b/src/tools/builder.rs
@@ -150,6 +150,20 @@ impl ScoutBuilder {
         self
     }
 
+    /// Replace the fetch HTTP client so a test can point `fetch` at a loopback
+    /// wiremock server. Production `fetch_http` carries the connect-time
+    /// `SsrfResolver` guard (ADR-0012), which by design blocks loopback; a test
+    /// supplies a guard-free client (e.g. via reqwest `.resolve()`) paired with
+    /// a public-IP `with_dns` so the pre-flight `ssrf_check` still passes. This
+    /// seam is test-only and never weakens the production guard — `from_env`
+    /// keeps `build_default_clients`. The SSRF contract stays pinned by the
+    /// dedicated T-003 / T-F017 fetch_page tests, not by this client.
+    #[cfg(test)]
+    pub(crate) fn with_fetch_http(mut self, client: Client) -> Self {
+        self.fetch_http = client;
+        self
+    }
+
     /// Inject a short outer GitHub-command timeout so a test can force the
     /// `run()`-level guard to trip against a delayed wiremock response without
     /// waiting the production 120s (issue #185). `RuntimeConfig` is `Copy`, so

--- a/src/tools/errors.rs
+++ b/src/tools/errors.rs
@@ -107,6 +107,15 @@ impl ScoutError {
         Self::new(ErrorCode::IoError, msg)
     }
 
+    /// scout-side invariant violation (e.g. a `serde_json::to_value` failure on
+    /// a type scout itself controls). Maps to `ErrorCode::Internal` (exit 70
+    /// EX_SOFTWARE), the sibling of `io_error`/`unknown` named per ADR-0003 §104.
+    /// Lets handlers propagate serialize failures via `?` through the JSON error
+    /// envelope instead of `.expect()` panicking and bypassing it.
+    pub(super) fn internal_bug(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Internal, msg)
+    }
+
     /// Timeout (request-level or transport-level). Maps to `ErrorCode::Timeout`
     /// (exit 124, GNU coreutils `timeout`) per ADR-0002. Retryable like
     /// `transient`, but separated so caller scripts/agents can apply a longer

--- a/src/tools/errors/classification_tests.rs
+++ b/src/tools/errors/classification_tests.rs
@@ -218,6 +218,18 @@ fn schema_decode_classifies_as_internal_exit_70() {
     }
 }
 
+/// [T-ER032] `ScoutError::internal_bug` (direct constructor for scout-side
+/// serialize/invariant violations, e.g. `serde_json::to_value` failure in a
+/// handler) classifies as Internal / exit 70 (EX_SOFTWARE) and is non-retryable,
+/// matching the `Decode`-routed Internal path pinned by T-ER025.
+#[test]
+fn internal_bug_constructor_classifies_as_internal_exit_70() {
+    let err = ScoutError::internal_bug("failed to serialize fetch result");
+    assert_eq!(err.error_kind(), ErrorCode::Internal);
+    assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70)");
+    assert!(!err.retryable(), "Internal must not be retryable");
+}
+
 /// [T-ER030] GitHub `Api { code: 401 }` classifies as UsageError(64) with auth hint
 /// (issue #101).
 ///

--- a/src/tools/query.rs
+++ b/src/tools/query.rs
@@ -78,9 +78,7 @@ impl Scout {
 
         info!(url = %RedactedLogUrl(&url), "fetch complete");
         let markdown = format_fetch_output(&result);
-        let data = serde_json::to_value(&result).map_err(|e| {
-            ScoutError::internal_bug(format!("failed to serialize fetch result: {e}"))
-        })?;
+        let data = to_data_value(&result, "fetch result")?;
         let mut degradation = Degradation::default();
         if result.used_raw_fallback() {
             degradation.push(
@@ -189,15 +187,27 @@ impl Scout {
         );
 
         let markdown = engine::format_report(&report, &query);
-        let mut data = serde_json::to_value(&report).map_err(|e| {
-            ScoutError::internal_bug(format!("failed to serialize research report: {e}"))
-        })?;
+        let mut data = to_data_value(&report, "research report")?;
         if let Some(map) = data.as_object_mut() {
             map.insert("query".to_owned(), serde_json::Value::String(query));
         }
         collect_research_degradations(&report, &mut degradation);
         Ok(CommandOutput::with_degradation(markdown, data, degradation))
     }
+}
+
+/// Serialize a handler's scout-owned result into the envelope `data` value,
+/// mapping a `serde_json` failure to `ScoutError::internal_bug` (exit 70) so it
+/// flows through the JSON error envelope via `?` instead of `.expect()`
+/// panicking and bypassing it (issue #192). `what` names the value for the
+/// error message. The single serialize-to-`data` point shared by `fetch` and
+/// `research`.
+pub(super) fn to_data_value<T: serde::Serialize>(
+    value: &T,
+    what: &str,
+) -> Result<serde_json::Value, ScoutError> {
+    serde_json::to_value(value)
+        .map_err(|e| ScoutError::internal_bug(format!("failed to serialize {what}: {e}")))
 }
 
 fn collect_research_degradations(report: &engine::ResearchReport, degradation: &mut Degradation) {

--- a/src/tools/query.rs
+++ b/src/tools/query.rs
@@ -78,7 +78,9 @@ impl Scout {
 
         info!(url = %RedactedLogUrl(&url), "fetch complete");
         let markdown = format_fetch_output(&result);
-        let data = serde_json::to_value(&result).expect("FetchResult is Serialize");
+        let data = serde_json::to_value(&result).map_err(|e| {
+            ScoutError::internal_bug(format!("failed to serialize fetch result: {e}"))
+        })?;
         let mut degradation = Degradation::default();
         if result.used_raw_fallback() {
             degradation.push(
@@ -187,7 +189,9 @@ impl Scout {
         );
 
         let markdown = engine::format_report(&report, &query);
-        let mut data = serde_json::to_value(&report).expect("ResearchReport is Serialize");
+        let mut data = serde_json::to_value(&report).map_err(|e| {
+            ScoutError::internal_bug(format!("failed to serialize research report: {e}"))
+        })?;
         if let Some(map) = data.as_object_mut() {
             map.insert("query".to_owned(), serde_json::Value::String(query));
         }

--- a/src/tools/query_tests.rs
+++ b/src/tools/query_tests.rs
@@ -1,6 +1,12 @@
+use std::sync::Arc;
+
+use reqwest::redirect::Policy;
+use serde::ser::Error as _;
+
 use super::query::to_data_value;
 use super::test_helpers::*;
 use super::*;
+use crate::envelope::ErrorCode;
 use crate::fetch::StaticDnsResolver;
 use crate::search::Lang;
 use crate::test_support::try_spawn_mock_server;
@@ -393,7 +399,7 @@ impl serde::Serialize for FailingSerialize {
     where
         S: serde::Serializer,
     {
-        Err(serde::ser::Error::custom("forced serialize failure"))
+        Err(S::Error::custom("forced serialize failure"))
     }
 }
 
@@ -410,7 +416,7 @@ fn to_data_value_serializes_owned_value() {
 #[test]
 fn to_data_value_maps_serialize_failure_to_internal_bug() {
     let err = to_data_value(&FailingSerialize, "fetch result").unwrap_err();
-    assert_eq!(err.error_kind(), crate::envelope::ErrorCode::Internal);
+    assert_eq!(err.error_kind(), ErrorCode::Internal);
     assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70)");
     assert!(
         err.message().contains("failed to serialize fetch result"),
@@ -449,14 +455,12 @@ async fn fetch_returns_ok_for_reachable_page() {
     // Guard-free client: `.resolve()` maps the test host to the loopback wiremock
     // socket. No `SsrfResolver` is installed, so the loopback connect proceeds.
     let fetch_http = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
+        .redirect(Policy::none())
         .resolve("scout-test.example", addr)
         .build()
         .unwrap();
     let scout = ScoutBuilder::for_test()
-        .with_dns(std::sync::Arc::new(StaticDnsResolver::single(
-            "93.184.216.34",
-        )))
+        .with_dns(Arc::new(StaticDnsResolver::single("93.184.216.34")))
         .with_fetch_http(fetch_http)
         .build();
 

--- a/src/tools/query_tests.rs
+++ b/src/tools/query_tests.rs
@@ -1,3 +1,4 @@
+use super::query::to_data_value;
 use super::test_helpers::*;
 use super::*;
 use crate::search::Lang;
@@ -378,5 +379,41 @@ fn fetch_output_truncates_long_content() {
     assert!(
         output.contains("### Title"),
         "headings should still be shifted"
+    );
+}
+
+/// A type whose `Serialize` impl always errors. Needed because the values scout
+/// actually serializes never fail (`f64::NAN` serializes to `null`, it does not
+/// error), so the error arm of `to_data_value` requires a forced failure.
+struct FailingSerialize;
+
+impl serde::Serialize for FailingSerialize {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(serde::ser::Error::custom("forced serialize failure"))
+    }
+}
+
+/// [T-TDV001] to_data_value returns the serialized JSON value on success.
+#[test]
+fn to_data_value_serializes_owned_value() {
+    let value = to_data_value(&serde_json::json!({"k": "v"}), "test value").unwrap();
+    assert_eq!(value, serde_json::json!({"k": "v"}));
+}
+
+/// [T-TDV002] to_data_value maps a serialize failure to an Internal (exit 70)
+/// ScoutError naming the value, so a handler serde failure surfaces through the
+/// JSON error envelope via `?` instead of `.expect()` panicking (issue #192).
+#[test]
+fn to_data_value_maps_serialize_failure_to_internal_bug() {
+    let err = to_data_value(&FailingSerialize, "fetch result").unwrap_err();
+    assert_eq!(err.error_kind(), crate::envelope::ErrorCode::Internal);
+    assert_eq!(err.exit_code(), 70, "expected EX_SOFTWARE (70)");
+    assert!(
+        err.message().contains("failed to serialize fetch result"),
+        "message should name the value, got: {}",
+        err.message()
     );
 }

--- a/src/tools/query_tests.rs
+++ b/src/tools/query_tests.rs
@@ -1,6 +1,7 @@
 use super::query::to_data_value;
 use super::test_helpers::*;
 use super::*;
+use crate::fetch::StaticDnsResolver;
 use crate::search::Lang;
 use crate::test_support::try_spawn_mock_server;
 use wiremock::matchers::{method, path};
@@ -415,5 +416,72 @@ fn to_data_value_maps_serialize_failure_to_internal_bug() {
         err.message().contains("failed to serialize fetch result"),
         "message should name the value, got: {}",
         err.message()
+    );
+}
+
+/// [T-FETCH-OK] fetch handler returns Ok for a reachable page, exercising the
+/// success path end-to-end: page download, markdown render, and `data`
+/// serialize (query.rs `to_data_value` delegation). SSRF stays intact — the
+/// pre-flight `ssrf_check` resolves the test host to a public IP via
+/// `with_dns`, while a guard-free `fetch_http` (reqwest `.resolve()` override,
+/// no `SsrfResolver`) reaches the loopback wiremock. Production `fetch_http`
+/// keeps the connect-time guard; the SSRF contract is pinned by T-003 / T-F017,
+/// not by this test client.
+#[tokio::test]
+async fn fetch_returns_ok_for_reachable_page() {
+    let Some(server) = try_spawn_mock_server("query::fetch_ok").await else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path("/page"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "<html><head><title>Scout Test</title></head><body><article><h1>Scout Test</h1>\
+             <p>This is a sufficiently long article body so Readability extracts it cleanly \
+             rather than falling back to raw conversion. Lorem ipsum dolor sit amet, \
+             consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et \
+             dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</p>\
+             </article></body></html>",
+        ))
+        .mount(&server)
+        .await;
+
+    let addr = *server.address();
+    // Guard-free client: `.resolve()` maps the test host to the loopback wiremock
+    // socket. No `SsrfResolver` is installed, so the loopback connect proceeds.
+    let fetch_http = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .resolve("scout-test.example", addr)
+        .build()
+        .unwrap();
+    let scout = ScoutBuilder::for_test()
+        .with_dns(std::sync::Arc::new(StaticDnsResolver::single(
+            "93.184.216.34",
+        )))
+        .with_fetch_http(fetch_http)
+        .build();
+
+    let params = super::params::FetchParams {
+        url: Some(format!("http://scout-test.example:{}/page", addr.port())),
+        js: false,
+        raw: false,
+    };
+    let output = scout.fetch(params).await.expect("fetch should succeed");
+
+    let data = output.data();
+    assert!(
+        data["url"]
+            .as_str()
+            .is_some_and(|u| u.contains("scout-test.example")),
+        "data.url should echo the fetched host, got: {data}"
+    );
+    assert!(
+        data["markdown"]
+            .as_str()
+            .is_some_and(|m| m.contains("Scout Test")),
+        "data.markdown should contain the page heading, got: {data}"
+    );
+    assert!(
+        !output.markdown().is_empty(),
+        "rendered markdown should be non-empty"
     );
 }


### PR DESCRIPTION
## 概要

Issue #192 の2ギャップを解消する。

1. **`.expect()` による envelope バイパス解消**: `src/tools/query.rs` の fetch/research ハンドラの `serde_json::to_value(...).expect(...)` を `map_err(ScoutError::internal_bug)?` に置換。将来の型変更で serialize が fallible になっても、tokio task panic ではなく structured `ScoutError` envelope を必ず通る。
2. **envelope serialize の単一化**: 重複していた `serde_json::to_string(..).expect(..)` を crate 関数 `to_json_line<T: Serialize>` に集約。success / error / clap usage-error の3経路すべてが同一の serialize 点を通る。

## 変更点

- `ScoutError::internal_bug(msg)` を新設（`ErrorCode::Internal` / exit 70 EX_SOFTWARE / 非 retryable）。名称は ADR-0003 §104 が規定する sibling constructor 名に一致。
- `to_json_line<T: Serialize>` を `src/envelope.rs` に追加し、`render_json_success` / `render_json_error` / `handle_parse_error` を集約。`serde_json::to_string(..).expect(..)` はクレート内で1箇所のみになった。
- query.rs の2ハンドラを `?` 伝搬へ置換。

## テスト

- `[T-ER032]` `internal_bug()` が Internal / exit 70 / 非 retryable を返す
- `[T-EN016]` `to_json_line()` が ErrorEnvelope を ADR-0010 の1行 JSON へ round-trip（直接 serialize とバイト一致）
- 回帰: lib 485 + integration 11 全 pass、出力バイト不変

## 受入条件

- [x] ハンドラの serde 失敗が envelope 経由でエラーになる（panic しない）
- [x] envelope serialize が単一箇所

## 注記

AC#1 は現行型では `to_value` が失敗不能（issue 記載どおり）。到達不能 panic の擬似誘発テストは書かず、fix が追加する機構（`internal_bug` 分類 + `?` 伝搬経路）を構造的に検証した。`From<XxxError> for ScoutError` の module 分散は #176 で別途トラッキング。

Closes #192