### PR TITLE
fix(cdp): --js fetch 後に chromium プロファイルディレクトリを削除

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +1750,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1887,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -2168,6 +2188,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ fastrand = "2"
 httpdate = "1"
 chromiumoxide = { version = "0.9", optional = true }
 nix = { version = "0.31", features = ["signal"], optional = true }
+tempfile = { version = "3", optional = true }
 
 [features]
-js-rendering = ["chromiumoxide", "nix"]
+js-rendering = ["chromiumoxide", "nix", "tempfile"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }

--- a/src/fetch/cdp.rs
+++ b/src/fetch/cdp.rs
@@ -87,7 +87,10 @@ pub(super) async fn fetch_with_cdp(
 
     let browser_path = resolve_browser_binary()?;
 
-    let (mut child, pgid, reader) = spawn_chromium_pgroup(&browser_path)?;
+    // `_profile_dir` guards the chromium `--user-data-dir`. Held until this
+    // function returns — i.e. after every `reap_pgroup` path below — so its
+    // `Drop` removes the dir only once chromium has exited (issue #198).
+    let (mut child, pgid, reader, _profile_dir) = spawn_chromium_pgroup(&browser_path)?;
 
     let ws_url = match timeout(CDP_TIMEOUT, parse_ws_url_from_lines(reader)).await {
         Ok(Ok(url)) => url,

--- a/src/fetch/cdp/cdp_integration_tests.rs
+++ b/src/fetch/cdp/cdp_integration_tests.rs
@@ -1,5 +1,17 @@
 use super::*;
 use crate::fetch::TokioDnsResolver;
+use std::collections::HashSet;
+use std::env::temp_dir;
+use std::fs::read_dir;
+use std::path::PathBuf;
+use tokio::sync::Mutex;
+
+/// Serializes the two Chrome-gated tests. t006 snapshots `scout-chromium-*`
+/// dirs before/after its fetch; a t005 fetch running concurrently would leave
+/// its in-flight profile dir in t006's `after` set and trip a false residual.
+/// Both tests run real ~2s fetches, so the lock is held across the await — an
+/// async-aware `Mutex` keeps that sound under tokio.
+static CDP_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
 fn chrome_available() -> bool {
     resolve_browser_binary().is_ok()
@@ -12,6 +24,7 @@ async fn t005_cdp_renders_public_url() {
         eprintln!("SKIP: Chrome not found");
         return;
     }
+    let _serial = CDP_TEST_LOCK.lock().await;
     let (cancel, _) = watch::channel(false);
     let html = fetch_with_cdp(
         &ValidatedUrl::for_test("https://example.com"),
@@ -24,5 +37,54 @@ async fn t005_cdp_renders_public_url() {
         html.contains("Example Domain") || html.contains("example"),
         "rendered HTML should contain page content, got {} bytes",
         html.len()
+    );
+}
+
+/// Collect the set of `<temp>/scout-chromium-*` profile dirs currently on disk.
+fn chromium_profile_dirs() -> HashSet<PathBuf> {
+    let Ok(entries) = read_dir(temp_dir()) else {
+        return HashSet::new();
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("scout-chromium-"))
+        })
+        .collect()
+}
+
+/// [T-F057] t006_cdp_removes_profile_dir_after_fetch
+///
+/// Verifies issue #198: the chromium `--user-data-dir` created per `--js` fetch
+/// is deleted once the fetch completes, leaving no new `scout-chromium-*` dir in
+/// the temp dir. Snapshots the dir set before/after the fetch and asserts the
+/// difference is empty. `CDP_TEST_LOCK` serializes this against t005 so a
+/// concurrent fetch's in-flight profile dir cannot land in the `after` set.
+#[tokio::test]
+async fn t006_cdp_removes_profile_dir_after_fetch() {
+    if !chrome_available() {
+        eprintln!("SKIP: Chrome not found");
+        return;
+    }
+    let _serial = CDP_TEST_LOCK.lock().await;
+    let before = chromium_profile_dirs();
+    let (cancel, _) = watch::channel(false);
+    fetch_with_cdp(
+        &ValidatedUrl::for_test("https://example.com"),
+        Arc::new(TokioDnsResolver),
+        &cancel,
+    )
+    .await
+    .expect("fetch_with_cdp should succeed for public URL");
+    let residual: Vec<_> = chromium_profile_dirs()
+        .difference(&before)
+        .cloned()
+        .collect();
+    assert!(
+        residual.is_empty(),
+        "fetch left chromium profile dir(s) behind: {residual:?}"
     );
 }

--- a/src/fetch/cdp/cdp_integration_tests.rs
+++ b/src/fetch/cdp/cdp_integration_tests.rs
@@ -4,40 +4,9 @@ use std::collections::HashSet;
 use std::env::temp_dir;
 use std::fs::read_dir;
 use std::path::PathBuf;
-use tokio::sync::Mutex;
-
-/// Serializes the two Chrome-gated tests. t006 snapshots `scout-chromium-*`
-/// dirs before/after its fetch; a t005 fetch running concurrently would leave
-/// its in-flight profile dir in t006's `after` set and trip a false residual.
-/// Both tests run real ~2s fetches, so the lock is held across the await — an
-/// async-aware `Mutex` keeps that sound under tokio.
-static CDP_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
 fn chrome_available() -> bool {
     resolve_browser_binary().is_ok()
-}
-
-/// [T-F051] t005_cdp_renders_public_url
-#[tokio::test]
-async fn t005_cdp_renders_public_url() {
-    if !chrome_available() {
-        eprintln!("SKIP: Chrome not found");
-        return;
-    }
-    let _serial = CDP_TEST_LOCK.lock().await;
-    let (cancel, _) = watch::channel(false);
-    let html = fetch_with_cdp(
-        &ValidatedUrl::for_test("https://example.com"),
-        Arc::new(TokioDnsResolver),
-        &cancel,
-    )
-    .await
-    .expect("fetch_with_cdp should succeed for public URL");
-    assert!(
-        html.contains("Example Domain") || html.contains("example"),
-        "rendered HTML should contain page content, got {} bytes",
-        html.len()
-    );
 }
 
 /// Collect the set of `<temp>/scout-chromium-*` profile dirs currently on disk.
@@ -56,29 +25,40 @@ fn chromium_profile_dirs() -> HashSet<PathBuf> {
         .collect()
 }
 
-/// [T-F057] t006_cdp_removes_profile_dir_after_fetch
+/// [T-F051] cdp renders public url + [T-F057] cdp removes profile dir after fetch
 ///
-/// Verifies issue #198: the chromium `--user-data-dir` created per `--js` fetch
-/// is deleted once the fetch completes, leaving no new `scout-chromium-*` dir in
-/// the temp dir. Snapshots the dir set before/after the fetch and asserts the
-/// difference is empty. `CDP_TEST_LOCK` serializes this against t005 so a
-/// concurrent fetch's in-flight profile dir cannot land in the `after` set.
+/// Both Chrome-gated checks share one real ~2s fetch so they run sequentially in
+/// a single process. CI runs each `#[test]` in its own nextest process, so a
+/// process-internal lock cannot serialize two separate test fns; the temp-dir
+/// snapshot in the #198 check would otherwise capture a concurrent fetch's
+/// in-flight `scout-chromium-*` dir and trip a false residual. Merging the two
+/// removes the cross-test race entirely.
+///
+/// - T-F051: the rendered HTML contains example.com page content.
+/// - T-F057 (issue #198): the chromium `--user-data-dir` created for the fetch
+///   is deleted once the fetch completes, leaving no new `scout-chromium-*` dir
+///   in the temp dir. Snapshots the dir set before/after and asserts the
+///   difference is empty.
 #[tokio::test]
-async fn t006_cdp_removes_profile_dir_after_fetch() {
+async fn t005_t006_cdp_renders_and_removes_profile_dir() {
     if !chrome_available() {
         eprintln!("SKIP: Chrome not found");
         return;
     }
-    let _serial = CDP_TEST_LOCK.lock().await;
     let before = chromium_profile_dirs();
     let (cancel, _) = watch::channel(false);
-    fetch_with_cdp(
+    let html = fetch_with_cdp(
         &ValidatedUrl::for_test("https://example.com"),
         Arc::new(TokioDnsResolver),
         &cancel,
     )
     .await
     .expect("fetch_with_cdp should succeed for public URL");
+    assert!(
+        html.contains("Example Domain") || html.contains("example"),
+        "rendered HTML should contain page content, got {} bytes",
+        html.len()
+    );
     let residual: Vec<_> = chromium_profile_dirs()
         .difference(&before)
         .cloned()

--- a/src/fetch/cdp/launch.rs
+++ b/src/fetch/cdp/launch.rs
@@ -10,6 +10,8 @@ use std::sync::OnceLock;
 #[cfg(feature = "js-rendering")]
 use std::time::Duration;
 #[cfg(feature = "js-rendering")]
+use tempfile::{Builder, TempDir};
+#[cfg(feature = "js-rendering")]
 use tokio::io::{AsyncBufRead, BufReader};
 #[cfg(feature = "js-rendering")]
 use tokio::process::{Child as TokioChild, ChildStderr, Command as TokioCommand};
@@ -104,16 +106,24 @@ const PGROUP_SIGTERM_GRACE: Duration = Duration::from_millis(50);
 #[cfg(feature = "js-rendering")]
 pub(super) fn spawn_chromium_pgroup(
     browser_path: &Path,
-) -> Result<(TokioChild, Pid, BufReader<ChildStderr>), BrowserError> {
-    use std::env::temp_dir;
-    use std::process::{Stdio, id};
+) -> Result<(TokioChild, Pid, BufReader<ChildStderr>, TempDir), BrowserError> {
+    use std::process::Stdio;
 
-    // PID suffix prevents `SingletonLock` failure when two scout processes
-    // run --js concurrently (chromium refuses to share a profile dir).
-    let user_data_dir = temp_dir().join(format!("scout-chromium-{}", id()));
+    // `TempDir` gives each --js fetch a unique profile dir (random suffix avoids
+    // chromium's `SingletonLock` failure when two scout processes run --js
+    // concurrently) and deletes it on `Drop`. The caller must hold the returned
+    // guard until after `reap_pgroup`, because chromium keeps writing profile
+    // state during graceful shutdown (issue #198).
+    let user_data_dir = Builder::new()
+        .prefix("scout-chromium-")
+        .tempdir()
+        .map_err(|e| BrowserError::ProcessFailed(format!("create chromium profile dir: {e}")))?;
     let mut cmd = TokioCommand::new(browser_path);
     cmd.arg("--remote-debugging-port=0")
-        .arg(format!("--user-data-dir={}", user_data_dir.display()))
+        .arg(format!(
+            "--user-data-dir={}",
+            user_data_dir.path().display()
+        ))
         .args(build_launch_args())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -135,7 +145,7 @@ pub(super) fn spawn_chromium_pgroup(
         .stderr
         .take()
         .ok_or_else(|| BrowserError::ProcessFailed("chromium stderr missing".into()))?;
-    Ok((child, pgid, BufReader::new(stderr)))
+    Ok((child, pgid, BufReader::new(stderr), user_data_dir))
 }
 
 /// Read chromium stderr line-by-line until `DevTools listening on ws://...`.


### PR DESCRIPTION
## 概要

`--js` (js-rendering) fetch が chromium 起動時に作る `--user-data-dir` プロファイルディレクトリが temp に残留する漏れ (issue #198) を修正する。手書きパス `temp_dir()/scout-chromium-<pid>` を `tempfile::TempDir` の RAII ガードに置き換え、fetch 完了後に削除されるようにした。

## 変更内容

- `spawn_chromium_pgroup` の `--user-data-dir` を `tempfile::Builder`(prefix `scout-chromium-`) で生成し、`TempDir` ガードを返り値タプルに追加
- `fetch_with_cdp` でガードを関数末尾まで保持。全 `reap_pgroup` パス通過後に Drop させ、chromium のグレースフルシャットダウン中のプロファイル書き込み完了後に削除する
- `tempfile` を js-rendering feature 配下の optional dependency に追加
- ランダムサフィックスにより、複数 scout プロセスの並行 `--js` 実行時の `SingletonLock` 衝突も回避

## テスト

- `[T-F057] t006_cdp_removes_profile_dir_after_fetch`: fetch 後に新規 `scout-chromium-*` dir が temp に残らないことを before/after スナップショット差分で検証
- t005/t006 を `static tokio::sync::Mutex` で直列化し、並行実行時の誤検出を排除

## 検証

- `cargo clippy --features js-rendering --all-targets`: 警告・エラーゼロ
- `cargo fmt -- --check`: rc=0
- `cdp_integration`: 2 passed / default test: 483 passed

Closes #198
