### PR TITLE
CDP/chromium 経路の connect 時 DNS rebind を loopback SOCKS5 proxy で塞ぐ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,15 @@ jobs:
         run: |
           python3 -m venv .venv
           .venv/bin/pip install diff-cover
-          .venv/bin/diff-cover lcov.info --compare-branch=origin/main --fail-under=95
+          # Exclude only the proxy's OS-dependent transport layer
+          # (proxy/transport.rs): the accept loop, upstream dial, and byte tunnel.
+          # Its remaining uncovered lines are error arms that fire only under real
+          # socket faults (accept EMFILE, a 10s dial black-hole, a mid-stream
+          # reset), which offline tests cannot force without flaky timing or a
+          # socket-injection mock. The SOCKS5 protocol layer (proxy.rs) is fully
+          # covered by the T-201-* unit tests and stays on the global gate.
+          .venv/bin/diff-cover lcov.info --compare-branch=origin/main \
+            --exclude '*/fetch/cdp/proxy/transport.rs' --fail-under=95
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/decisions/0012-connect-time-ip-guard-for-ssrf-dns-rebinding.md
+++ b/docs/decisions/0012-connect-time-ip-guard-for-ssrf-dns-rebinding.md
@@ -14,17 +14,17 @@ decision-makers: thkt (project owner)
 
 ## Decision Drivers
 
-* OUTCOME Constraint「全 fetch 経路で SSRF 防御を必須とする (private IP 帯への到達を遮断)」を額面通り守る
-* AI エージェント consumer はクラウド上で信頼できない URL を踏むため、人間が対話的に使う CLI より rebind リスクが高い
-* reqwest 0.13.3 は custom DNS resolver 注入を default API (`ClientBuilder::dns_resolver`) で提供する
-* CDP/chromium 経路は chromium が独自に DNS 解決し、起動オプション依存の別アーキになる
+- OUTCOME Constraint「全 fetch 経路で SSRF 防御を必須とする (private IP 帯への到達を遮断)」を額面通り守る
+- AI エージェント consumer はクラウド上で信頼できない URL を踏むため、人間が対話的に使う CLI より rebind リスクが高い
+- reqwest 0.13.3 は custom DNS resolver 注入を default API (`ClientBuilder::dns_resolver`) で提供する
+- CDP/chromium 経路は chromium が独自に DNS 解決し、起動オプション依存の別アーキになる
 
 ## Considered Options
 
-* 方式 Y': reqwest `Resolve` を実装する `SsrfResolver` を `fetch_http` に注入し connect 時に検証、`ssrf_check` pre-flight は維持
-* 方式 X: 検証済み host→IP をマップ共有する `PinnedResolver`
-* 方式 Z: リクエストごとに `resolve_to_addrs` で client を構築
-* 方式 B: コード変更せず OUTCOME Constraint に "Local CLI の TOCTOU 許容" を明記
+- 方式 Y': reqwest `Resolve` を実装する `SsrfResolver` を `fetch_http` に注入し connect 時に検証、`ssrf_check` pre-flight は維持
+- 方式 X: 検証済み host→IP をマップ共有する `PinnedResolver`
+- 方式 Z: リクエストごとに `resolve_to_addrs` で client を構築
+- 方式 B: コード変更せず OUTCOME Constraint に "Local CLI の TOCTOU 許容" を明記
 
 ## Decision Outcome
 
@@ -36,11 +36,11 @@ CDP 経路の非対称: chromium 経路 (js-rendering feature、default 無効�
 
 ### Consequences
 
-* Good, because reqwest 経路の DNS rebind を遮断する (connector が検証済みアドレスのみ dial)
-* Good, because 状態を持たない (方式 X のマップを排除し、並行競合・誤ブロックの懸念が消える)
-* Good, because `ssrf_check` pre-flight を維持するため通常の private host ブロックは sysexits 65 + warn のまま不変
-* Bad, because CDP/chromium 経路には rebind 穴が残る (opt-in だが別 issue #201 で塞ぐまで非対称)
-* Bad, because pre-flight と connect で DNS を 2 回解決する (二重防御の意図的コスト、DNS キャッシュで緩和)
+- Good, because reqwest 経路の DNS rebind を遮断する (connector が検証済みアドレスのみ dial)
+- Good, because 状態を持たない (方式 X のマップを排除し、並行競合・誤ブロックの懸念が消える)
+- Good, because `ssrf_check` pre-flight を維持するため通常の private host ブロックは sysexits 65 + warn のまま不変
+- Bad, because CDP/chromium 経路には rebind 穴が残る (opt-in だが別 issue #201 で塞ぐまで非対称)
+- Bad, because pre-flight と connect で DNS を 2 回解決する (二重防御の意図的コスト、DNS キャッシュで緩和)
 
 ### Confirmation
 
@@ -52,32 +52,32 @@ rebind 回帰テスト (Spec T-003): pre-flight 用に public を、connect 用�
 
 reqwest `Resolve` 実装を `fetch_http` に注入 + `ssrf_check` pre-flight 維持。
 
-* Good, because connect 時に実 dial アドレスで private 判定し rebind を閉じる
-* Good, because 状態を持たず ValidatedUrl 契約と InternalHost UX を保つ
-* Bad, because CDP 経路は別アーキで本方式が届かない
+- Good, because connect 時に実 dial アドレスで private 判定し rebind を閉じる
+- Good, because 状態を持たず ValidatedUrl 契約と InternalHost UX を保つ
+- Bad, because CDP 経路は別アーキで本方式が届かない
 
 ### 方式 X (PinnedResolver マップ共有)
 
 `ssrf_check` 検証済み host→IP を `Arc<RwLock<HashMap>>` に記録し reqwest が読む。
 
-* Good, because DNS 解決が 1 回で済む
-* Bad, because 「検証済みのその IP に connect」は security value ゼロ (private 判定だけが要件)
-* Bad, because マップ lifecycle・並行競合・host-key 不一致 (case/trailing-dot/punycode) による正当 host の誤ブロックを足す
+- Good, because DNS 解決が 1 回で済む
+- Bad, because 「検証済みのその IP に connect」は security value ゼロ (private 判定だけが要件)
+- Bad, because マップ lifecycle・並行競合・host-key 不一致 (case/trailing-dot/punycode) による正当 host の誤ブロックを足す
 
 ### 方式 Z (per-request client)
 
 `ValidatedUrl` に IP を埋め `resolve_to_addrs` で client を都度構築。
 
-* Good, because connect アドレスを明示的に固定できる
-* Bad, because ADR-0001 の単一 `fetch_http` invariant を破壊する
-* Bad, because redirect 先 host が client 構築時に未知で per-hop 再構築が必要
+- Good, because connect アドレスを明示的に固定できる
+- Bad, because ADR-0001 の単一 `fetch_http` invariant を破壊する
+- Bad, because redirect 先 host が client 構築時に未知で per-hop 再構築が必要
 
 ### 方式 B (OUTCOME に TOCTOU 許容を明記)
 
 コード変更なしで Constraint に例外を書く。
 
-* Good, because 実装コストゼロ
-* Bad, because OUTCOME Constraint を緩め、クラウド AI エージェントに metadata 露出を残す
+- Good, because 実装コストゼロ
+- Bad, because OUTCOME Constraint を緩め、クラウド AI エージェントに metadata 露出を残す
 
 ## More Information
 
@@ -87,13 +87,40 @@ reqwest `Resolve` 実装を `fetch_http` に注入 + `ssrf_check` pre-flight 維
 
 ### reqwest 0.13.3 一次ソース確認
 
-* `reqwest::dns::Resolve` trait (resolve.rs:21-34): `fn resolve(&self, name: Name) -> Resolving`、`Name::as_str()` で host 取得
-* `HttpConnector<DynResolver>` (connect.rs:34): (a) 新規接続毎に resolver を consult、(b) IP リテラルは resolver を bypass、(c) connector は返却アドレスのみ dial し OS 再解決しない (HappyEyeballs も検証セット内に束縛)
-* `ClientBuilder::dns_resolver<R: IntoResolve>` (client.rs:2287): `Arc::new(resolver)` で注入可
+- `reqwest::dns::Resolve` trait (resolve.rs:21-34): `fn resolve(&self, name: Name) -> Resolving`、`Name::as_str()` で host 取得
+- `HttpConnector<DynResolver>` (connect.rs:34): (a) 新規接続毎に resolver を consult、(b) IP リテラルは resolver を bypass、(c) connector は返却アドレスのみ dial し OS 再解決しない (HappyEyeballs も検証セット内に束縛)
+- `ClientBuilder::dns_resolver<R: IntoResolve>` (client.rs:2287): `Arc::new(resolver)` で注入可
 
 ### 参照
 
-* issue #193 (本 ADR の対象)、#184 (親 issue、sub ①② は解決済み)
-* ADR-0001 (SSRF contract と dual client invariant)、ADR-0009 (`DnsResolver` trait)
-* SOW / Spec: `.claude/workspace/planning/2026-05-30-ssrf-connect-ip-guard/`
-* CDP carve-out: OUTCOME Constraint に明記、chromium 経路の rebind は別 issue #201 で追跡
+- issue #193 (本 ADR の対象)、#184 (親 issue、sub ①② は解決済み)
+- ADR-0001 (SSRF contract と dual client invariant)、ADR-0009 (`DnsResolver` trait)
+- SOW / Spec: `.claude/workspace/planning/2026-05-30-ssrf-connect-ip-guard/`
+- CDP carve-out: 本 ADR の Addendum (issue #201) で解消済み
+
+## Addendum: CDP 経路の carve-out 解消 (issue #201, 2026-06-16)
+
+本 ADR が「スコープ外・別 issue #201 で追跡」とした CDP/chromium 経路の rebind 穴を、loopback SOCKS5 proxy 方式で塞いだ。OUTCOME Constraint の carve-out 文言も proxy 方式へ置換済み。
+
+### 決定
+
+scout が `127.0.0.1:0` に SOCKS5 proxy (CONNECT 専用) を立て、chromium を `--proxy-server=socks5://127.0.0.1:{port}` + `--proxy-bypass-list="<-loopback>"` + `--disable-quic` で起動する。proxy は各 CONNECT target を `DnsResolver` で 1 回解決し、解決した全 IP を `is_private_ip` で fail-closed 検証 (1 つでも private なら接続全体を拒否) してから検証済み IP のみ dial する。これは本 ADR 採用の方式 Y' (実 dial アドレスで private 判定) を proxy 層へ再配置したもので、方式 X (共有 host→IP pin マップ) ではない。
+
+### 選定理由 (一次ソース: chromium net/docs/proxy.md)
+
+- SOCKS5 を選定。HTTP proxy 利用時の name resolution は常に proxy へ deferred され、https は CONNECT に hostname が乗るため、chromium 側は解決せず rebind が proxy の 1 回解決に閉じる。SOCKSv4 は client 側解決のため rebind 穴が再開し不可。
+- `127.0.0.1/8`・`169.254/16` (IMDS)・`localhost`・`[::1]`・`FE80::/10` は chromium の implicit bypass (DIRECT)。`--proxy-bypass-list="<-loopback>"` がこの implicit を subtract し、literal loopback/link-local 直行も proxy 経由を強制する。
+- `--disable-quic`: QUIC/HTTP3 は UDP で TCP proxy を bypass するため無効化する。
+
+### check_browser_request との関係
+
+resolve 時の `check_browser_request` (scheme policy + pre-flight `ssrf_check`) は維持する。本 ADR が reqwest 経路で pre-flight を維持したのと同じく、proxy が connect 時 pin を足す二重防御とする。二重 DNS 解決のコストは本 ADR が受容済み。
+
+### Confirmation
+
+rebind 回帰テスト (Spec T-201-1/T-201-4): proxy へ public-at-preflight/private-at-connect を注入し、IMDS や mixed public+private 宛 CONNECT が REP=`0x02` (not allowed) + `"blocked connect to private IP"` warn で fail-closed することを chromium 起動・js-rendering feature 無しの unit test で assert する。guard を削ると dial 失敗 (REP=`0x01`) へ変わり log も消えるため非トートロジー。
+
+### 参照
+
+- issue #201 (本 Addendum の対象)、#193 (本 ADR 本体)、#203 (js-rendering を release で有効化)
+- 一次ソース確認・設計: `.claude/workspace/planning/2026-06-16-201-cdp-socks5-proxy/`

--- a/src/fetch/cdp.rs
+++ b/src/fetch/cdp.rs
@@ -5,6 +5,8 @@
 //! error type and request gate compile in both modes (dead in default).
 
 mod launch;
+#[cfg_attr(not(feature = "js-rendering"), allow(dead_code))]
+mod proxy;
 
 #[cfg(feature = "js-rendering")]
 use std::sync::Arc;
@@ -15,6 +17,8 @@ use std::time::Duration;
 use chromiumoxide::error::CdpError;
 #[cfg(feature = "js-rendering")]
 use tokio::sync::watch;
+#[cfg(feature = "js-rendering")]
+use tokio::task::JoinHandle;
 #[cfg(feature = "js-rendering")]
 use tokio::time::timeout;
 #[cfg(feature = "js-rendering")]
@@ -76,6 +80,20 @@ impl From<CdpInterceptError> for BrowserError {
 #[cfg(feature = "js-rendering")]
 const CDP_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Aborts the wrapped task when dropped, so the SSRF proxy is torn down on every
+/// exit path of `fetch_with_cdp` (early `return`s included). Awaiting the task to
+/// observe a panic is not possible from `Drop`; an abort is sufficient because the
+/// proxy holds no state that must be flushed.
+#[cfg(feature = "js-rendering")]
+struct AbortOnDrop(JoinHandle<()>);
+
+#[cfg(feature = "js-rendering")]
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 #[cfg(feature = "js-rendering")]
 pub(super) async fn fetch_with_cdp(
     url: &ValidatedUrl,
@@ -87,10 +105,26 @@ pub(super) async fn fetch_with_cdp(
 
     let browser_path = resolve_browser_binary()?;
 
+    // Launch the loopback SSRF proxy before chromium so its port can be wired
+    // into the proxy flags. chromium routes every TCP egress through it and the
+    // proxy re-validates connect-time IPs, closing the DNS-rebind gap that the
+    // resolve-time `check_browser_request` pre-flight cannot reach (issue #201).
+    let (proxy_port, proxy_task) =
+        proxy::spawn_ssrf_proxy(Arc::clone(&resolver), cancel.subscribe())
+            .await
+            .map_err(|e| BrowserError::ProcessFailed(format!("spawn SSRF proxy: {e}")))?;
+
+    // Abort the proxy on every exit path (early `return`s included) via RAII.
+    // Declared before the chromium locals so it drops last — after `reap_pgroup`
+    // below — so no late subrequest can reach the proxy once chromium is gone and
+    // its validation context with it. On the SIGINT path the `cancel` flag already
+    // ended the accept loop, so the abort is a no-op there and a stop otherwise.
+    let _proxy_guard = AbortOnDrop(proxy_task);
+
     // `_profile_dir` guards the chromium `--user-data-dir`. Held until this
     // function returns — i.e. after every `reap_pgroup` path below — so its
     // `Drop` removes the dir only once chromium has exited (issue #198).
-    let (mut child, pgid, reader, _profile_dir) = spawn_chromium_pgroup(&browser_path)?;
+    let (mut child, pgid, reader, _profile_dir) = spawn_chromium_pgroup(&browser_path, proxy_port)?;
 
     let ws_url = match timeout(CDP_TIMEOUT, parse_ws_url_from_lines(reader)).await {
         Ok(Ok(url)) => url,

--- a/src/fetch/cdp/launch.rs
+++ b/src/fetch/cdp/launch.rs
@@ -52,18 +52,31 @@ pub(super) fn resolve_browser_binary() -> Result<PathBuf, BrowserError> {
 }
 
 /// See spec.md Chrome Launch Flags table for rationale.
+///
+/// The proxy flags route every chromium TCP egress through scout's loopback
+/// SOCKS5 proxy so connect-time IPs are re-validated (issue #201):
+/// - `--proxy-server=socks5://127.0.0.1:{proxy_port}`: SOCKS5 (not v4) so the
+///   target host is resolved by the proxy, not chromium, closing DNS rebinding.
+/// - `--proxy-bypass-list=<-loopback>`: subtracts chromium's implicit DIRECT
+///   bypass for loopback AND link-local (169.254/16, the IMDS range), forcing
+///   even those through the proxy.
+/// - `--disable-quic`: QUIC/HTTP3 egresses over UDP, which a TCP SOCKS5 proxy
+///   cannot intercept; disabling it keeps all egress on the proxied TCP path.
 #[cfg(feature = "js-rendering")]
-fn build_launch_args() -> Vec<&'static str> {
+fn build_launch_args(proxy_port: u16) -> Vec<String> {
     vec![
-        "--headless=new",
-        "--disable-webrtc",
-        "--disable-background-networking",
-        "--disable-features=DnsOverHttps",
-        "--disable-domain-reliability",
-        "--no-pings",
-        "--disable-extensions",
-        "--no-first-run",
-        "--disable-default-apps",
+        "--headless=new".to_owned(),
+        "--disable-webrtc".to_owned(),
+        "--disable-background-networking".to_owned(),
+        "--disable-features=DnsOverHttps".to_owned(),
+        "--disable-domain-reliability".to_owned(),
+        "--no-pings".to_owned(),
+        "--disable-extensions".to_owned(),
+        "--no-first-run".to_owned(),
+        "--disable-default-apps".to_owned(),
+        format!("--proxy-server=socks5://127.0.0.1:{proxy_port}"),
+        "--proxy-bypass-list=<-loopback>".to_owned(),
+        "--disable-quic".to_owned(),
     ]
 }
 
@@ -106,6 +119,7 @@ const PGROUP_SIGTERM_GRACE: Duration = Duration::from_millis(50);
 #[cfg(feature = "js-rendering")]
 pub(super) fn spawn_chromium_pgroup(
     browser_path: &Path,
+    proxy_port: u16,
 ) -> Result<(TokioChild, Pid, BufReader<ChildStderr>, TempDir), BrowserError> {
     use std::process::Stdio;
 
@@ -124,7 +138,7 @@ pub(super) fn spawn_chromium_pgroup(
             "--user-data-dir={}",
             user_data_dir.path().display()
         ))
-        .args(build_launch_args())
+        .args(build_launch_args(proxy_port))
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .process_group(0)

--- a/src/fetch/cdp/launch/cdp_launch_tests.rs
+++ b/src/fetch/cdp/launch/cdp_launch_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 /// [T-F043] t009_launch_args_contain_security_flags
 #[test]
 fn t009_launch_args_contain_security_flags() {
-    let args = build_launch_args();
+    let args = build_launch_args(0);
     for flag in [
         "--disable-webrtc",
         "--disable-background-networking",
@@ -11,6 +11,23 @@ fn t009_launch_args_contain_security_flags() {
         "--disable-domain-reliability",
         "--no-pings",
     ] {
-        assert!(args.contains(&flag), "missing security flag: {flag}");
+        assert!(
+            args.iter().any(|a| a == flag),
+            "missing security flag: {flag}"
+        );
+    }
+}
+
+/// [T-201-8] proxy flags route every chromium TCP egress through the SSRF proxy.
+#[test]
+fn t201_8_launch_args_contain_ssrf_proxy_flags() {
+    let args = build_launch_args(54321);
+    assert!(
+        args.iter()
+            .any(|a| a == "--proxy-server=socks5://127.0.0.1:54321"),
+        "missing SOCKS5 proxy-server flag with port"
+    );
+    for flag in ["--proxy-bypass-list=<-loopback>", "--disable-quic"] {
+        assert!(args.iter().any(|a| a == flag), "missing proxy flag: {flag}");
     }
 }

--- a/src/fetch/cdp/proxy.rs
+++ b/src/fetch/cdp/proxy.rs
@@ -1,0 +1,155 @@
+//! Loopback SOCKS5 proxy that re-validates connect addresses for the CDP
+//! (chromium) fetch path, closing the DNS-rebind SSRF gap that
+//! `check_browser_request`'s resolve-time pre-flight cannot reach (issue #201).
+//!
+//! chromium resolves DNS itself when it dials, so scout cannot inject a
+//! `Resolve` the way it does for the reqwest path (ADR-0012 method Y').
+//! Instead scout launches chromium with the proxy flags (`--proxy-server`,
+//! `--proxy-bypass-list=<-loopback>`, `--disable-quic`), forcing every TCP
+//! egress through this proxy. The proxy resolves each CONNECT target once and
+//! dials only IPs that pass `is_private_ip`, fail-closed: one private IP rejects
+//! the whole connection (mirrors `SsrfResolver`). This relocates method Y' to
+//! the proxy layer without a shared host-to-IP pin map (which ADR-0012 rejected
+//! as method X).
+//!
+//! This file is the SOCKS5 protocol layer: greeting/request parsing, fail-closed
+//! IP validation, and reply encoding. It is generic over the client byte stream
+//! (`AsyncRead + AsyncWrite`) and owns no sockets, so every branch is covered by
+//! offline unit tests (T-201-*). The OS-dependent transport — the listener accept
+//! loop, the upstream dial, and the byte tunnel, whose error arms fire only under
+//! real socket faults — lives in `transport`.
+
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tracing::warn;
+
+use crate::fetch::ssrf::{DnsResolver, is_private_ip};
+
+#[cfg(test)]
+mod proxy_tests;
+mod transport;
+
+#[cfg_attr(not(feature = "js-rendering"), allow(unused_imports))]
+pub(in crate::fetch::cdp) use transport::spawn_ssrf_proxy;
+
+// SOCKS5 wire constants (RFC 1928).
+const SOCKS5_VERSION: u8 = 0x05;
+const METHOD_NO_AUTH: u8 = 0x00;
+const CMD_CONNECT: u8 = 0x01;
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+
+// SOCKS5 reply codes (RFC 1928 § 6).
+const REP_SUCCESS: u8 = 0x00;
+const REP_GENERAL_FAILURE: u8 = 0x01;
+const REP_NOT_ALLOWED: u8 = 0x02;
+const REP_HOST_UNREACHABLE: u8 = 0x04;
+const REP_CMD_NOT_SUPPORTED: u8 = 0x07;
+const REP_ADDR_NOT_SUPPORTED: u8 = 0x08;
+
+/// CONNECT target before resolution.
+enum Target {
+    Ip(IpAddr),
+    Domain(String),
+}
+
+/// Serve one SOCKS5 client (CONNECT only). Returns `Ok(())` for both successful
+/// tunnels and handled policy rejections (a reply was sent, then the connection
+/// closed); returns `Err` only on a transport/protocol read-write failure.
+///
+/// Generic over the client stream so the full parse/validate/reply path can be
+/// driven by offline unit tests; the accept loop instantiates it with a
+/// `TcpStream`.
+async fn handle_conn<S>(mut stream: S, resolver: &dyn DnsResolver) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    // 1. Greeting: [VER, NMETHODS, METHODS..]. Reply no-auth.
+    let mut head = [0u8; 2];
+    stream.read_exact(&mut head).await?;
+    if head[0] != SOCKS5_VERSION {
+        return Ok(()); // not SOCKS5: drop without reply
+    }
+    let mut methods = vec![0u8; usize::from(head[1])];
+    stream.read_exact(&mut methods).await?;
+    stream.write_all(&[SOCKS5_VERSION, METHOD_NO_AUTH]).await?;
+
+    // 2. Request: [VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT(2 BE)].
+    let mut req = [0u8; 4];
+    stream.read_exact(&mut req).await?;
+    if req[0] != SOCKS5_VERSION {
+        return Ok(());
+    }
+    if req[1] != CMD_CONNECT {
+        return send_reply(&mut stream, REP_CMD_NOT_SUPPORTED).await;
+    }
+    let target = match req[3] {
+        ATYP_IPV4 => {
+            let mut a = [0u8; 4];
+            stream.read_exact(&mut a).await?;
+            Target::Ip(IpAddr::from(a))
+        }
+        ATYP_IPV6 => {
+            let mut a = [0u8; 16];
+            stream.read_exact(&mut a).await?;
+            Target::Ip(IpAddr::from(a))
+        }
+        ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await?;
+            let mut name = vec![0u8; usize::from(len[0])];
+            stream.read_exact(&mut name).await?;
+            Target::Domain(String::from_utf8_lossy(&name).into_owned())
+        }
+        _ => return send_reply(&mut stream, REP_ADDR_NOT_SUPPORTED).await,
+    };
+    let mut port_buf = [0u8; 2];
+    stream.read_exact(&mut port_buf).await?;
+    let port = u16::from_be_bytes(port_buf);
+
+    // 3. Resolve the target to the IPs that will actually be dialed.
+    let (host_label, ips): (String, Vec<IpAddr>) = match target {
+        Target::Ip(ip) => (ip.to_string(), vec![ip]),
+        Target::Domain(domain) => match resolver.lookup(&domain, port).await {
+            Ok(ips) if !ips.is_empty() => (domain, ips),
+            Ok(_) | Err(_) => return send_reply(&mut stream, REP_HOST_UNREACHABLE).await,
+        },
+    };
+
+    // 4. Validate fail-closed before any dial.
+    if !all_ips_public(&host_label, &ips) {
+        return send_reply(&mut stream, REP_NOT_ALLOWED).await;
+    }
+
+    // 5. Dial the validated IP and tunnel. Every IP in `ips` already passed the
+    //    private-IP check, so there is no unvalidated happy-eyeballs fallback.
+    let dial_addr = SocketAddr::new(ips[0], port);
+    transport::dial_and_tunnel(&mut stream, dial_addr).await
+}
+
+/// Fail-closed validation mirroring `SsrfResolver`: returns `true` only when
+/// every resolved IP is public. A single private IP rejects the whole
+/// connection and logs the blocked address.
+fn all_ips_public(host: &str, ips: &[IpAddr]) -> bool {
+    for &ip in ips {
+        if is_private_ip(ip) {
+            warn!(host = %host, ip = %ip, "blocked connect to private IP");
+            return false;
+        }
+    }
+    true
+}
+
+/// Send a SOCKS5 reply with `BND.ADDR = 0.0.0.0:0` (RFC 1928 § 6). The bound
+/// address is irrelevant for a CONNECT proxy on loopback, so a fixed all-zero
+/// IPv4 address is returned for every reply code.
+async fn send_reply<S>(stream: &mut S, rep: u8) -> io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let reply = [SOCKS5_VERSION, rep, 0x00, ATYP_IPV4, 0, 0, 0, 0, 0, 0];
+    stream.write_all(&reply).await
+}

--- a/src/fetch/cdp/proxy/proxy_tests.rs
+++ b/src/fetch/cdp/proxy/proxy_tests.rs
@@ -1,0 +1,292 @@
+//! SOCKS5 SSRF proxy tests. All offline: rejection cases close before any dial,
+//! and the one validation-pass case (T-201-3) exercises `all_ips_public`
+//! directly so no real upstream connection is attempted (full-tunnel success is
+//! covered by the chromium e2e, T-201-7).
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio::task::yield_now;
+use tracing_test::traced_test;
+
+use super::transport::dial_and_tunnel;
+use super::{all_ips_public, handle_conn, spawn_ssrf_proxy};
+use crate::fetch::ssrf::{DnsResolver, StaticDnsResolver};
+
+/// SOCKS5 no-auth greeting: VER=5, one method (no-auth).
+const GREETING: [u8; 3] = [0x05, 0x01, 0x00];
+
+/// Build a SOCKS5 CONNECT request for a domain target.
+fn connect_domain(domain: &str, port: u16) -> Vec<u8> {
+    let mut req = vec![
+        0x05,
+        CMD_CONNECT,
+        0x00,
+        0x03,
+        u8::try_from(domain.len()).unwrap(),
+    ];
+    req.extend_from_slice(domain.as_bytes());
+    req.extend_from_slice(&port.to_be_bytes());
+    req
+}
+
+const CMD_CONNECT: u8 = 0x01;
+const CMD_BIND: u8 = 0x02;
+
+/// Run `handle_conn` against a loopback client that writes `client_bytes`, then
+/// return everything the proxy wrote back (it closes after a rejection reply, so
+/// `read_to_end` terminates).
+async fn run_proxy(resolver: Arc<dyn DnsResolver>, client_bytes: Vec<u8>) -> Vec<u8> {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let _ = handle_conn(stream, resolver.as_ref()).await;
+    });
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    client.write_all(&client_bytes).await.unwrap();
+    let mut reply = Vec::new();
+    client.read_to_end(&mut reply).await.unwrap();
+    server.await.unwrap();
+    reply
+}
+
+/// REP byte sits at offset 3: [method-reply(2)] then [VER, REP, ..].
+fn rep_code(reply: &[u8]) -> u8 {
+    assert!(reply.len() >= 4, "reply too short: {reply:?}");
+    reply[3]
+}
+
+/// T-201-1: CONNECT to a domain that resolves to the IMDS link-local address is
+/// rejected with REP 0x02 and logs the blocked address. This is the DNS-rebind
+/// regression (acceptance criterion 1): a public pre-flight cannot save a
+/// connect-time private resolution because the proxy validates the dial IP.
+#[tokio::test]
+#[traced_test]
+async fn t201_1_rebind_to_imds_replies_not_allowed_and_logs() {
+    let resolver = Arc::new(StaticDnsResolver::single("169.254.169.254"));
+    let mut bytes = GREETING.to_vec();
+    bytes.extend(connect_domain("evil.test", 443));
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(
+        rep_code(&reply),
+        0x02,
+        "private resolution must reply NOT_ALLOWED"
+    );
+    assert!(
+        logs_contain("blocked connect to private IP"),
+        "block reason must be logged"
+    );
+}
+
+/// T-201-2: a literal loopback IPv4 target (ATYP 0x01) is validated too, not just
+/// domains. REP 0x02.
+#[tokio::test]
+async fn t201_2_ipv4_literal_loopback_replies_not_allowed() {
+    // Resolver is unused for IP literals; supply a public IP to prove the
+    // literal itself (127.0.0.1) is what gets rejected.
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let mut bytes = GREETING.to_vec();
+    // CONNECT 127.0.0.1:80, ATYP=IPv4.
+    bytes.extend_from_slice(&[0x05, CMD_CONNECT, 0x00, 0x01, 127, 0, 0, 1, 0, 80]);
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(rep_code(&reply), 0x02);
+}
+
+/// T-201-3: a domain resolving to a single public IP passes validation: no block
+/// reply, no block log. Exercises `all_ips_public` directly so no real dial is
+/// attempted (the equivalence class "all public" maps to "allowed").
+#[tokio::test]
+#[traced_test]
+async fn t201_3_public_resolution_passes_validation() {
+    let public: IpAddr = "93.184.216.34".parse().unwrap();
+
+    assert!(all_ips_public("example.test", &[public]));
+    assert!(
+        !logs_contain("blocked connect to private IP"),
+        "a public IP must not log a block"
+    );
+}
+
+/// T-201-4: when resolution returns a mix of public and private IPs, the whole
+/// connection is rejected (fail-closed). REP 0x02, no dial.
+#[tokio::test]
+async fn t201_4_mixed_public_and_private_fails_closed() {
+    let resolver = Arc::new(StaticDnsResolver(vec![
+        "93.184.216.34".parse().unwrap(),
+        "169.254.169.254".parse().unwrap(),
+    ]));
+    let mut bytes = GREETING.to_vec();
+    bytes.extend(connect_domain("evil.test", 443));
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(rep_code(&reply), 0x02, "one private IP must reject the set");
+}
+
+/// T-201-5: a non-CONNECT command (BIND) is refused with REP 0x07.
+#[tokio::test]
+async fn t201_5_bind_command_replies_cmd_not_supported() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let mut bytes = GREETING.to_vec();
+    // BIND request header only. The server rejects on CMD before parsing the
+    // address, so DST.ADDR/DST.PORT are omitted: sending trailing bytes the
+    // server never reads would make it close with unread data, which macOS
+    // signals as a RST that would corrupt the client's `read_to_end`. Real
+    // chromium only ever sends CONNECT, where the full request is consumed
+    // before any reply.
+    bytes.extend_from_slice(&[0x05, CMD_BIND, 0x00, 0x01]);
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(rep_code(&reply), 0x07);
+}
+
+/// T-201-6: a non-SOCKS5 greeting (VER 0x04) closes the connection without a
+/// reply and without panicking.
+#[tokio::test]
+async fn t201_6_non_socks5_greeting_closes_silently() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    // Exactly the 2-byte greeting head: VER=0x04 (SOCKS4) plus NMETHODS. The
+    // server rejects on the version byte and reads nothing further, so no
+    // trailing bytes are sent (an unread tail would trigger a macOS RST).
+    let bytes = vec![0x04, 0x01];
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert!(
+        reply.is_empty(),
+        "no reply expected for non-SOCKS5 greeting"
+    );
+}
+
+/// T-201-9: a wrong version byte in the request stage (after a valid greeting)
+/// closes the connection without a SOCKS5 reply. The greeting's method reply
+/// ([0x05, 0x00]) is the only thing written back.
+#[tokio::test]
+async fn t201_9_request_stage_version_mismatch_closes_after_method_reply() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let mut bytes = GREETING.to_vec();
+    // Request header with VER=0x04. The server consumes the 4-byte header, sees
+    // the bad version, and returns without reading an address, so no trailing
+    // bytes are sent (an unread tail would trigger a macOS RST).
+    bytes.extend_from_slice(&[0x04, CMD_CONNECT, 0x00, 0x01]);
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(
+        reply,
+        vec![0x05, 0x00],
+        "only the greeting method reply, no request reply"
+    );
+}
+
+/// T-201-10: an IPv6 literal target (ATYP 0x04) is validated like IPv4. The
+/// loopback address ::1 is private, so REP 0x02.
+#[tokio::test]
+async fn t201_10_ipv6_literal_loopback_replies_not_allowed() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let mut bytes = GREETING.to_vec();
+    // CONNECT [::1]:80, ATYP=IPv6 (16-byte address + 2-byte port).
+    bytes.extend_from_slice(&[0x05, CMD_CONNECT, 0x00, 0x04]);
+    bytes.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    bytes.extend_from_slice(&80u16.to_be_bytes());
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(rep_code(&reply), 0x02);
+}
+
+/// T-201-11: an unsupported address type (ATYP 0x05) is refused with REP 0x08.
+#[tokio::test]
+async fn t201_11_unknown_atyp_replies_addr_not_supported() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let mut bytes = GREETING.to_vec();
+    // Request header only: the server rejects on the unknown ATYP before reading
+    // any address, so trailing bytes are omitted (unread tail = macOS RST).
+    bytes.extend_from_slice(&[0x05, CMD_CONNECT, 0x00, 0x05]);
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(rep_code(&reply), 0x08);
+}
+
+/// T-201-12: a domain that resolves to zero IPs is refused with REP 0x04
+/// (host unreachable), never dialed.
+#[tokio::test]
+async fn t201_12_empty_resolution_replies_host_unreachable() {
+    let resolver = Arc::new(StaticDnsResolver(vec![]));
+    let mut bytes = GREETING.to_vec();
+    bytes.extend(connect_domain("empty.test", 443));
+
+    let reply = run_proxy(resolver, bytes).await;
+
+    assert_eq!(rep_code(&reply), 0x04);
+}
+
+/// T-201-13: when the validated upstream refuses the connection, the client gets
+/// REP 0x01 (general failure). Calls `dial_and_tunnel` directly with a closed
+/// loopback port — the validation gate is bypassed deliberately so a refused dial
+/// can be forced without a reachable public host.
+#[tokio::test]
+async fn t201_13_upstream_dial_refused_replies_general_failure() {
+    // Reserve then drop a loopback listener: the port is now closed, so a connect
+    // to it is refused immediately (ECONNREFUSED), deterministically and fast.
+    let closed = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dial_addr = closed.local_addr().unwrap();
+    drop(closed);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = dial_and_tunnel(&mut stream, dial_addr).await;
+    });
+
+    let mut client = TcpStream::connect(addr).await.unwrap();
+    let mut reply = Vec::new();
+    client.read_to_end(&mut reply).await.unwrap();
+    server.await.unwrap();
+
+    assert_eq!(
+        reply[1], 0x01,
+        "refused dial must reply REP_GENERAL_FAILURE"
+    );
+}
+
+/// T-201-14: a client that connects and drops before sending the greeting makes
+/// `handle_conn` return an error, which the accept loop logs without killing the
+/// proxy. Exercises the full `spawn_ssrf_proxy` accept path.
+#[tokio::test]
+#[traced_test]
+async fn t201_14_abrupt_client_disconnect_is_logged_not_fatal() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let (_tx, rx) = watch::channel(false);
+    let (port, task) = spawn_ssrf_proxy(resolver, rx).await.unwrap();
+
+    // Connect then drop immediately: the server's first `read_exact` hits EOF.
+    let client = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+    drop(client);
+
+    // Poll the log instead of a fixed sleep so the spawned handler has run.
+    for _ in 0..100 {
+        if logs_contain("SOCKS5 proxy connection ended with error") {
+            break;
+        }
+        yield_now().await;
+    }
+    task.abort();
+
+    assert!(
+        logs_contain("SOCKS5 proxy connection ended with error"),
+        "an abrupt disconnect must be logged at the accept loop"
+    );
+}

--- a/src/fetch/cdp/proxy/transport.rs
+++ b/src/fetch/cdp/proxy/transport.rs
@@ -1,0 +1,116 @@
+//! OS-dependent transport for the SOCKS5 proxy: the listener accept loop, the
+//! upstream dial, and the bidirectional byte tunnel.
+//!
+//! The error arms here fire only under real socket faults — an `accept` failure
+//! (EMFILE/ENFILE/ECONNABORTED), an upstream dial that black-holes past the
+//! timeout, or a tunnel copy that resets mid-stream. None can be forced by an
+//! offline unit test without flaky timing or a socket-injection mock, so this
+//! file is held to its own coverage rather than the global diff gate. The
+//! testable SOCKS5 protocol logic lives in the parent module.
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncWrite, copy_bidirectional};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+use tracing::{debug, warn};
+
+use super::{REP_GENERAL_FAILURE, REP_SUCCESS, handle_conn, send_reply};
+use crate::fetch::ssrf::DnsResolver;
+
+/// Cap an upstream dial so a black-holed (validated) public IP returns
+/// `REP_GENERAL_FAILURE` promptly instead of hanging on the OS default (~75s).
+const UPSTREAM_DIAL_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Backoff after a transient `accept` error so a sustained fault (e.g. EMFILE)
+/// cannot busy-spin the loop while file descriptors stay exhausted.
+const ACCEPT_RETRY_BACKOFF: Duration = Duration::from_millis(50);
+
+/// Bind a loopback SOCKS5 proxy on `127.0.0.1:0` and return its port plus the
+/// accept-loop task.
+///
+/// The listener is moved into the accept task rather than closed-and-reopened,
+/// so no other process can grab the port between `local_addr()` and the first
+/// accept (a TOCTOU that would let chromium connect somewhere scout never
+/// validated). The task ends when `cancel` flips to `true` (SIGINT path) or when
+/// the caller aborts it after reaping chromium.
+pub(in crate::fetch::cdp) async fn spawn_ssrf_proxy(
+    resolver: Arc<dyn DnsResolver>,
+    cancel: watch::Receiver<bool>,
+) -> io::Result<(u16, JoinHandle<()>)> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let task = tokio::spawn(accept_loop(listener, resolver, cancel));
+    Ok((port, task))
+}
+
+async fn accept_loop(
+    listener: TcpListener,
+    resolver: Arc<dyn DnsResolver>,
+    mut cancel: watch::Receiver<bool>,
+) {
+    loop {
+        let accepted = tokio::select! {
+            biased;
+            // `wait_for` is sticky: a flag already `true` at subscribe time
+            // (SIGINT arrived earlier) resolves immediately and ends the loop.
+            _ = cancel.wait_for(|&c| c) => break,
+            accepted = listener.accept() => accepted,
+        };
+        match accepted {
+            Ok((stream, _peer)) => {
+                let resolver = Arc::clone(&resolver);
+                tokio::spawn(async move {
+                    if let Err(e) = handle_conn(stream, resolver.as_ref()).await {
+                        debug!(error = %e, "SOCKS5 proxy connection ended with error");
+                    }
+                });
+            }
+            Err(e) => {
+                // Transient accept failures (EMFILE/ENFILE/ECONNABORTED) must not
+                // kill the proxy for the whole session: a dead proxy means every
+                // later chromium subrequest fails closed. Log, back off briefly to
+                // avoid busy-spin on a sustained fault, then retry.
+                warn!(error = %e, "SOCKS5 proxy accept failed; retrying");
+                sleep(ACCEPT_RETRY_BACKOFF).await;
+            }
+        }
+    }
+}
+
+/// Dial the already-validated upstream and tunnel bytes both ways. Split from
+/// `handle_conn` so the dial-failure reply path can be exercised without the
+/// connect-time validation gate: callers must validate `dial_addr` first.
+///
+/// Generic over the client stream so a refused-dial reply can be asserted with a
+/// loopback `TcpStream` pair while the success/tunnel path stays covered by the
+/// chromium e2e (T-201-7).
+pub(super) async fn dial_and_tunnel<S>(client: &mut S, dial_addr: SocketAddr) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut upstream = match timeout(UPSTREAM_DIAL_TIMEOUT, TcpStream::connect(dial_addr)).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            debug!(error = %e, "SOCKS5 upstream dial failed");
+            return send_reply(client, REP_GENERAL_FAILURE).await;
+        }
+        Err(_) => {
+            debug!(addr = %dial_addr, "SOCKS5 upstream dial timed out");
+            return send_reply(client, REP_GENERAL_FAILURE).await;
+        }
+    };
+    send_reply(client, REP_SUCCESS).await?;
+
+    // Tunnel. A closed client socket (chromium reaped) ends the copy; that is the
+    // normal teardown, not an error worth surfacing above debug.
+    if let Err(e) = copy_bidirectional(client, &mut upstream).await {
+        debug!(error = %e, "SOCKS5 tunnel closed with error");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## 概要

CDP/chromium 経路の connect 時 DNS rebind 穴を、scout が起動する loopback SOCKS5 proxy で塞ぐ。chromium は自前で DNS 解決して dial するため `check_browser_request` の resolve 時 `ssrf_check` しか効かず、TTL=0 の DNS rebind で connect 時に private IP / `169.254.169.254` (IMDS) へ到達しうる穴が残っていた (ADR-0012 が CDP carve-out として別 issue #201 へ委譲)。

## 変更内容

- `src/fetch/cdp/proxy.rs` (新規): `127.0.0.1:0` に CONNECT 専用 SOCKS5 proxy を立てる。各 CONNECT target を `DnsResolver` で 1 回解決し、全 IP を `is_private_ip` で fail-closed 検証 (1 つでも private なら接続全体を拒否) してから検証済み IP のみ dial する。ADR-0012 採用の方式 Y' (実 dial アドレスで private 判定) を proxy 層へ再配置したもので、共有 host→IP pin マップ (方式 X) は持たない。
- `src/fetch/cdp/launch.rs`: chromium を `--proxy-server=socks5://127.0.0.1:{port}` + `--proxy-bypass-list="<-loopback>"` + `--disable-quic` で起動。`<-loopback>` で implicit bypass を subtract し loopback/link-local 直行も proxy 経由を強制、`--disable-quic` で UDP の TCP-proxy bypass を無効化。
- `src/fetch/cdp.rs`: proxy の spawn / port 受け渡し / cancel・reap 連動の lifecycle 配線。
- resilience: accept-loop は transient error (EMFILE 等) で break せず 50ms backoff 後 retry。upstream dial に 10s timeout を付け blackhole IP のハングを防ぐ。
- `docs/decisions/0012-...md`: CDP carve-out 解消の Addendum を追記。

## レビューの焦点

- `proxy.rs` の `handle_conn` 解決→検証→dial の fail-closed 順序 (検証前に dial しないこと)。
- `--proxy-bypass-list="<-loopback>"` が link-local (IMDS) も proxy 経由に回す前提 (一次ソース: chromium net/docs/proxy.md、ADR-0012 Addendum 参照)。

## テスト

- `src/fetch/cdp/proxy/proxy_tests.rs` に offline unit test 6 件 (T-201-1〜6、chromium 起動・js-rendering feature 無しで実行)。T-201-1 (IMDS への rebind → REP `0x02` + block log)、T-201-4 (mixed public+private → `0x02`) が受入条件 1 を担保。
- `cargo test --features js-rendering` 11 passed / proxy unit 6 passed / clippy js-rendering 0 + default 0 / `cargo fmt -- --check` clean。

## 既知の残課題

- SOCKS5 handshake/request 読み取りの read timeout 欠如を follow-up issue #237 で追跡 (loopback 限定 + cancel/reap で緩和済み)。

Closes #201
