### PR TITLE
fetch: gzip を無条件返却するサイトでレスポンスが文字化けする (reqwest 圧縮 features 欠如)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,33 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -75,6 +96,18 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -168,6 +201,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -372,6 +426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -646,6 +729,16 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1290,6 +1383,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1596,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1879,6 +1988,7 @@ dependencies = [
  "encoding_rs",
  "fast_html2md",
  "fastrand",
+ "flate2",
  "futures",
  "globset",
  "httpdate",
@@ -2051,6 +2161,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -2339,12 +2455,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3022,3 +3143,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/thkt/scout"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", features = ["json", "gzip", "brotli", "deflate", "zstd"] }
 dom_smoothie = "0.18"
 fast_html2md = "0.0.62"
 tokio = { version = "1", features = ["full"] }
@@ -38,6 +38,7 @@ js-rendering = ["chromiumoxide", "nix", "tempfile"]
 tokio = { version = "1", features = ["test-util"] }
 tracing-test = "0.2"
 wiremock = "0.6"
+flate2 = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/fetch/download/download_tests.rs
+++ b/src/fetch/download/download_tests.rs
@@ -1,8 +1,19 @@
+use std::io::Write;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
 use super::*;
 use crate::fetch::{MAX_REDIRECTS, ssrf};
 use crate::test_support::{no_redirect_client, try_spawn_mock_server};
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, ResponseTemplate};
+
+fn gzip(bytes: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(bytes).unwrap();
+    encoder.finish().unwrap()
+}
 
 fn validated(url: &str) -> ValidatedUrl {
     ValidatedUrl::for_test(url)
@@ -276,5 +287,43 @@ async fn redirect_missing_location_header_returns_error() {
     assert!(
         matches!(result, Err(FetchError::RedirectMissingLocation)),
         "missing Location header should error, got: {result:?}"
+    );
+}
+
+/// [T-F058] download_transparently_decodes_gzip_response (issue #202): a server
+/// that returns `Content-Encoding: gzip` even without an `Accept-Encoding`
+/// request header must be transparently decompressed, not handed to the charset
+/// decoder as raw gzip bytes (which yields mojibake). Requires reqwest's `gzip`
+/// feature so its default `Accepts` advertises and auto-decodes the encoding.
+#[tokio::test]
+async fn download_transparently_decodes_gzip_response() {
+    let Some(server) = try_spawn_mock_server("fetch::download").await else {
+        return;
+    };
+    let html = "<html><body><p>hello</p></body></html>";
+    Mock::given(method("GET"))
+        .and(path("/gz"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .insert_header("content-encoding", "gzip")
+                .set_body_bytes(gzip(html.as_bytes())),
+        )
+        .mount(&server)
+        .await;
+
+    let client = no_redirect_client();
+    let (_final_url, body) = download(
+        &client,
+        &validated(&format!("{}/gz", server.uri())),
+        MAX_REDIRECTS,
+        &public_resolver(),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        body.contains("hello"),
+        "gzip body should be transparently decompressed, got: {body:?}"
     );
 }


### PR DESCRIPTION
## 概要と背景

Accept-Encoding を送らなくても `Content-Encoding: gzip` を返すサイト (例: antigravity.google) が、生 gzip バイトのまま charset デコーダに渡され文字化けを返していた。reqwest は圧縮 feature を有効にした分しか Accept-Encoding を advertise せず透過解凍もしないため、`["json"]` のみの構成では解凍されなかった。エラーにならず文字化けを返すため利用者が失敗に気づきにくい。

## 変更点

- `Cargo.toml`: reqwest features に `gzip` / `brotli` / `deflate` / `zstd` を追加。reqwest の default `Accepts` がこれらを advertise し透過解凍する。client は `ClientBuilder` default 構築のため `download.rs` の変更は不要。
- `[T-F058]` 回帰テスト追加: `Content-Encoding: gzip` を返す wiremock に対し解凍後の本文を検証。テスト用 gzip 生成のため flate2 を dev-dependency に追加。

## 対象範囲

- **含まないもの**: `download.rs` のロジック変更はなし。透過解凍は reqwest に委譲。

## 設計判断

- gzip 単体でも #202 は再現解消するが、Accept-Encoding 無しで br/zstd を返す他サイトの将来再発を避けるため4種をまとめて有効化。バイナリは微増。
- テストの gzip バイト生成は precomputed バイト列より flate2 が可読なため dev-dep を追加。

## テスト方法

1. `cargo test --lib download_transparently_decodes_gzip_response` → pass (修正前は文字化けで fail する Red を確認済み)
2. `cargo test` → 全513テスト pass、`cargo clippy --all-targets` / `cargo fmt -- --check` クリーン

## 関連

- Closes #202