### PR TITLE
fetch: deflate codec の回帰テスト追加と解凍後バイト cap の明文化 (#202 フォローアップ)

### DIFF
--- a/src/fetch/download/download_tests.rs
+++ b/src/fetch/download/download_tests.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use flate2::Compression;
-use flate2::write::GzEncoder;
+use flate2::write::{GzEncoder, ZlibEncoder};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, ResponseTemplate};
 
@@ -11,6 +11,14 @@ use crate::test_support::{no_redirect_client, try_spawn_mock_server};
 
 fn gzip(bytes: &[u8]) -> Vec<u8> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+/// reqwest's `deflate` Content-Encoding expects zlib-wrapped data (not raw
+/// DEFLATE), which is what `ZlibEncoder` produces.
+fn zlib_deflate(bytes: &[u8]) -> Vec<u8> {
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
     encoder.write_all(bytes).unwrap();
     encoder.finish().unwrap()
 }
@@ -325,5 +333,42 @@ async fn download_transparently_decodes_gzip_response() {
     assert!(
         body.contains("hello"),
         "gzip body should be transparently decompressed, got: {body:?}"
+    );
+}
+
+/// [T-F059] download_transparently_decodes_deflate_response (issue #202): pins a
+/// second enabled codec beyond gzip. `Content-Encoding: deflate` carries
+/// zlib-wrapped data; reqwest's `deflate` feature must transparently decompress
+/// it rather than hand the raw bytes to the charset decoder.
+#[tokio::test]
+async fn download_transparently_decodes_deflate_response() {
+    let Some(server) = try_spawn_mock_server("fetch::download").await else {
+        return;
+    };
+    let html = "<html><body><p>hello</p></body></html>";
+    Mock::given(method("GET"))
+        .and(path("/df"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html; charset=utf-8")
+                .insert_header("content-encoding", "deflate")
+                .set_body_bytes(zlib_deflate(html.as_bytes())),
+        )
+        .mount(&server)
+        .await;
+
+    let client = no_redirect_client();
+    let (_final_url, body) = download(
+        &client,
+        &validated(&format!("{}/df", server.uri())),
+        MAX_REDIRECTS,
+        &public_resolver(),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        body.contains("hello"),
+        "deflate body should be transparently decompressed, got: {body:?}"
     );
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -48,6 +48,13 @@ pub(crate) const MAX_GITHUB_RESPONSE_BYTES: usize = 10_000_000;
 /// matches their backend's legitimate payload size (`MAX_API_RESPONSE_BYTES` for
 /// Brave/Slack, `MAX_GITHUB_RESPONSE_BYTES` for GitHub, `MAX_RESPONSE_BYTES` for
 /// `fetch`'s HTML downloads).
+///
+/// `cap` applies to *decoded* bytes: with reqwest's compression features enabled,
+/// `chunk()` yields already-decompressed data and `content_length()` returns
+/// `None` for compressed responses (so the pre-check goes inert and the chunk
+/// loop is the live guard). This bounds peak memory to `cap + one chunk` even
+/// against a decompression bomb, at the cost of rejecting a legitimately large
+/// page whose decompressed size exceeds the cap.
 pub(crate) async fn read_body_capped<E>(
     response: reqwest::Response,
     cap: usize,


### PR DESCRIPTION
## 概要と背景

#202 (PR #239, マージ済み) で reqwest の圧縮 features に gzip/brotli/deflate/zstd を有効化したが、回帰テストは gzip 1 種のみで、有効化した残り 3 codec の透過解凍経路が未検証だった。challenge レビューで deflate の zlib-vs-raw 曖昧性が hazard として指摘されたため、第2 codec 経路を pin する。

## 変更点

- `[T-F059]` 回帰テスト追加: `Content-Encoding: deflate` (zlib-wrapped, flate2 ZlibEncoder 生成) が透過解凍されることを検証。reqwest の deflate=zlib 期待を pin。
- `read_body_capped` の doc 注記追加: 圧縮 features 有効時、cap は解凍後バイトに適用される。圧縮応答では `content_length()` が None を返し早期 precheck が inert 化、chunk ループが live guard となりピークメモリを cap + 1 chunk に有界化 (decompression bomb 耐性)。

## 対象範囲

- **含まないもの**: brotli/zstd の scout 側テスト (reqwest デコーダに委譲、リスク low)。fail-silent decode の非ゼロ exit 化 (別 issue 相当)。

## 設計判断

- 第2 codec に deflate を選択: challenge で zlib-vs-raw 曖昧性が指摘された経路を優先 pin。flate2 ZlibEncoder で新規依存なしに生成可能。

## テスト方法

1. `cargo test --lib download_transparently_decodes` → gzip/deflate 2 テスト pass
2. `cargo test` → 全テスト pass、`cargo clippy --all-targets` / `cargo fmt -- --check` クリーン

## 関連

- Refs #202
- Follow-up of #239