### PR TITLE
brew/release 版で js-rendering が無効だが README/help は対応を謳う (齟齬)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           if [ "$TARGET" = "aarch64-unknown-linux-gnu" ]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
           fi
-          cargo build --release --target "$TARGET"
+          cargo build --release --target "$TARGET" --features js-rendering
 
       - name: Package
         env:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Override the built-in timeouts and retry budget. Invalid values fail with exit 6
 
 ### Optional: JS rendering (for SPAs)
 
-`fetch` auto-detects JS-dependent pages (React, Next.js, Vue, Nuxt) and falls back to headless Chrome via CDP. Requires Chrome or Chromium installed locally and the `js-rendering` feature:
+`fetch` auto-detects JS-dependent pages (React, Next.js, Vue, Nuxt) and falls back to headless Chrome via CDP. Chrome or Chromium must be installed locally; without it, auto-detected pages fall back to the original HTML and `--js` returns an error.
+
+Prebuilt binaries (Homebrew, GitHub Releases) ship with the `js-rendering` feature enabled. Source builds enable it per-install:
 
 ```sh
 cargo install --path . --features js-rendering


### PR DESCRIPTION
## 概要と背景

Release ビルドが `--features js-rendering` 無しで `cargo build --release` を実行していたため、Homebrew/GitHub Release のバイナリは機能 off で配布される一方、README と `fetch --help` は JS レンダリング対応を謳っていた。結果 `scout fetch --js` が BrowserNotFound (exit 64) で失敗していた (#203)。

## 変更点

- `release.yml` の Build ステップ (4ターゲット全て) に `--features js-rendering` を追加。prebuilt バイナリへ機能を同梱
- README の JS レンダリング節を修正。prebuilt は機能同梱・実行時 Chrome/Chromium 必須、ソースビルドは install 時 opt-in と明記。Chrome 欠如時の挙動も追記

## 設計判断

- approach B (release.yml で js-rendering 有効化) を採用。前提だった #201・#198 は CLOSED 済み
- js-rendering が追加するのは pure-Rust crate のみ。クロスツールチェーン要件は既存の zstd-sys (C 依存) が既に発生させており新規負担なし

## 動作確認

1. aarch64-unknown-linux-gnu クロスビルドで chromiumoxide がリンクされた実バイナリ (14M ELF) を生成 → 成功
2. `cargo nextest run --features js-rendering` → 520 tests pass
3. `ci.yml` が merge 前に `cargo check/nextest/clippy/llvm-cov --features js-rendering` を実行済み → コンパイル破損はタグ時でなく PR 時に捕捉

## 関連

- Closes #203