### PR TITLE
test(retry): read_body_capped の chunk ループ経路(Content-Length 欠落)をカバーする

### DIFF
--- a/src/retry/tests.rs
+++ b/src/retry/tests.rs
@@ -7,7 +7,9 @@ use wiremock::{Mock, ResponseTemplate};
 use super::*;
 use crate::clock::FixedClock;
 use crate::rng::{FastrandRng, SeededRng};
-use crate::test_support::{spawn_mid_stream_drop_server, try_spawn_mock_server};
+use crate::test_support::{
+    spawn_close_delimited_body_server, spawn_mid_stream_drop_server, try_spawn_mock_server,
+};
 
 /// Test-only error type. `RateLimited` carries the server-supplied
 /// `Retry-After` (seconds); `Other` represents a non-rate-limit transient
@@ -343,4 +345,46 @@ fn parse_retry_after_returns_none_for_garbage() {
 fn parse_retry_after_returns_none_when_header_absent() {
     let headers = HeaderMap::new();
     assert_eq!(parse_retry_after(&headers, &FixedClock(0)), None);
+}
+
+// T-R013: read_body_capped_rejects_close_delimited_oversized_body
+// Issue #219: every existing `too_large` test drives wiremock's
+// `set_body_bytes`, which always emits an honest Content-Length, so they
+// exercise only the pre-check path (retry.rs:64-69). The chunk loop
+// (retry.rs:75-79) is the defense-in-depth guard for upstreams that omit
+// Content-Length (compression → `content_length() == None`, chunked or
+// close-delimited transfer); before this test it had zero coverage. A
+// close-delimited response (no Content-Length, EOF-terminated body) forces
+// `content_length() == None`, so the chunk loop — not the pre-check — must
+// be what rejects the oversized body. CAP is tiny to keep the transfer
+// cheap; the branch under test is identical regardless of cap size.
+#[tokio::test]
+async fn read_body_capped_rejects_close_delimited_oversized_body() {
+    const CAP: usize = 16;
+    let Some((url, handle)) = spawn_close_delimited_body_server(CAP + 1) else {
+        return; // loopback bind unavailable — skip
+    };
+    let resp = reqwest::Client::new().get(&url).send().await.expect("send");
+
+    // Pin the chunk-loop path: a present Content-Length would route through
+    // the pre-check instead, silently re-covering the existing gap.
+    assert!(
+        resp.content_length().is_none(),
+        "close-delimited response must have no Content-Length so the chunk \
+         loop, not the pre-check, is the cap guard under test"
+    );
+
+    // Distinct sentinels so a transport/framing fault surfaces as `network`
+    // rather than masquerading as the `too_large` we want to assert.
+    let result: Result<Vec<u8>, &str> =
+        read_body_capped(resp, CAP, || "too_large", |_e| "network").await;
+
+    assert_eq!(
+        result,
+        Err("too_large"),
+        "body exceeding cap with absent Content-Length must be rejected by \
+         the chunk loop"
+    );
+
+    let _ = handle.join();
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -100,9 +100,10 @@ pub fn spawn_close_delimited_body_server(body_size: usize) -> Option<(String, Jo
     let listener = TcpListener::bind("127.0.0.1:0").ok()?;
     let addr = listener.local_addr().ok()?;
     let handle = thread::spawn(move || {
-        let Ok((mut stream, _)) = listener.accept() else {
-            return;
-        };
+        // Single-shot: the test makes exactly one connection, so a failed
+        // accept is a test-environment fault — panic loudly rather than
+        // hang the joining test on a silent return.
+        let (mut stream, _) = listener.accept().expect("accept loopback connection");
         // Drain the request so the write below is the response, not racing
         // an unread request buffer.
         let mut buf = [0u8; 4096];

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -85,6 +85,35 @@ pub fn spawn_mid_stream_drop_server(
     Some((format!("http://{addr}"), counter, handle))
 }
 
+/// One-shot server that accepts one connection and replies with a
+/// close-delimited HTTP/1.1 response: no `Content-Length`, no
+/// `Transfer-Encoding`, `Connection: close`, then `body_size` body bytes
+/// before dropping the socket (EOF delimits the body). reqwest sees
+/// `content_length() == None`, so `read_body_capped`'s pre-check goes inert
+/// and the chunk loop becomes the live cap guard — the path a compressed or
+/// Content-Length-absent upstream drives (issue #219).
+///
+/// Returns `None` when loopback bind is unavailable so callers can
+/// early-return in restricted environments, matching
+/// `spawn_mid_stream_drop_server`.
+pub fn spawn_close_delimited_body_server(body_size: usize) -> Option<(String, JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").ok()?;
+    let addr = listener.local_addr().ok()?;
+    let handle = thread::spawn(move || {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        // Drain the request so the write below is the response, not racing
+        // an unread request buffer.
+        let mut buf = [0u8; 4096];
+        let _ = stream.read(&mut buf);
+        let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
+        let _ = stream.write_all(&vec![b'x'; body_size]);
+        // stream drops here → socket close is the body's EOF delimiter.
+    });
+    Some((format!("http://{addr}"), handle))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## 概要

`read_body_capped`(`src/retry.rs`)の chunk ループ経路(`retry.rs:75-79`)が3バックエンド全体でカバレッジゼロだった。既存の `too_large` テストはすべて wiremock の `set_body_bytes`(正直な Content-Length を付与)を使い pre-check 経路しか叩いていない。Content-Length を省く upstream(圧縮で `content_length() == None`)に対する OOM 防御の本丸をテストで固定する。

## 変更点

- `src/test_support.rs`: `spawn_close_delimited_body_server` 追加。Content-Length なし・`Connection: close`・EOF 終端の raw TCP レスポンスで `content_length() == None` を生成
- `src/retry/tests.rs`: T-R013 追加。`content_length().is_none()` を assert して chunk ループ経路を pin し、cap 超ボディが `too_large` で弾かれることを検証

## 設計判断

- **Content-Length 詐称(過小申告)は対象外**: reqwest/hyper は宣言境界で読み止めるため、過小申告では chunk ループが cap 超を観測できず到達不能。有効なトリガーは Content-Length 欠落のみ
- **chunked 手書きでなく close-delimited**: フレーミング(hex長/CRLF)誤りを避けられる。sentinel を `too_large`/`network` で分離し、transport 障害が `too_large` に化けず loud に落ちるようにした
- **cap=16**: 1 MiB 転送を回避。検証対象の分岐は cap サイズ非依存

## テスト手順

1. `cargo test --lib read_body_capped_rejects_close_delimited_oversized_body` → pass
2. `cargo test --lib retry`(22 件)・`test_support`(3 件)全 green、`cargo fmt --check` / `cargo clippy --lib --tests` クリーン

## 関連

- Closes #219