### PR TITLE
Slack の users.info cap が distinct author > 50 で keep 対象を非決定選択する（出力再現性の欠如）

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -241,9 +241,14 @@ fn parse_mentions(text: &str) -> Vec<MentionSpan<'_>> {
     spans
 }
 
-fn collect_mention_ids(text: &str, ids: &mut HashSet<String>) {
+/// Append mention IDs from `text` to `out` in first-occurrence order, skipping
+/// any already in `seen`. Sharing `seen` across calls (and with an author pass)
+/// dedupes a dual-role ID so it consumes a single lookup slot.
+fn collect_mention_ids_ordered(text: &str, seen: &mut HashSet<String>, out: &mut Vec<String>) {
     for span in parse_mentions(text) {
-        ids.insert(span.user_id.to_owned());
+        if seen.insert(span.user_id.to_owned()) {
+            out.push(span.user_id.to_owned());
+        }
     }
 }
 

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -22,7 +22,7 @@ use crate::rng::{FastrandRng, Rng};
 
 use super::{
     ChannelBody, Message, MessagesBody, ResolvedMessage, SlackError, SlackUrl, UserBody,
-    collect_mention_ids, extract_target, format_slack_output, resolve_messages,
+    collect_mention_ids_ordered, extract_target, format_slack_output, resolve_messages,
 };
 
 struct FetchedThread {
@@ -389,36 +389,40 @@ impl SlackClient {
 
         // Authors render on every message, so when distinct IDs exceed the
         // lookup cap they take priority over mentions: an unresolved author
-        // degrades visible output more than an unresolved mention.
-        let mut authors = HashSet::new();
-        let mut mentions = HashSet::new();
+        // degrades visible output more than an unresolved mention. The keep set
+        // is fixed to first-occurrence (thread chronological) order so which IDs
+        // resolve is reproducible across runs (issue #221). Two passes over the
+        // messages — all authors first, then mentions — share one `seen` set, so
+        // a dual-role ID is kept as an author and consumes one slot, not two.
+        let mut authors: Vec<String> = Vec::new();
+        let mut mentions: Vec<String> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
         for msg in &fetched.messages {
-            if let Some(uid) = &msg.user {
-                authors.insert(uid.clone());
+            if let Some(uid) = &msg.user
+                && seen.insert(uid.clone())
+            {
+                authors.push(uid.clone());
             }
-            collect_mention_ids(&msg.text, &mut mentions);
+        }
+        for msg in &fetched.messages {
+            collect_mention_ids_ordered(&msg.text, &mut seen, &mut mentions);
         }
 
-        let distinct_total = authors.union(&mentions).count();
-        let user_ids: HashSet<String> = if distinct_total > SLACK_MAX_USER_LOOKUPS {
+        let distinct_total = authors.len() + mentions.len();
+        if distinct_total > SLACK_MAX_USER_LOOKUPS {
             warn!(
                 distinct_users = distinct_total,
                 cap = SLACK_MAX_USER_LOOKUPS,
                 "too many distinct user IDs; capping users.info lookups, excess IDs render as raw IDs (authors kept first)"
             );
-            let mut kept: HashSet<String> =
-                authors.into_iter().take(SLACK_MAX_USER_LOOKUPS).collect();
-            for id in mentions {
-                if kept.len() >= SLACK_MAX_USER_LOOKUPS {
-                    break;
-                }
-                kept.insert(id);
-            }
-            kept
-        } else {
-            authors.extend(mentions);
-            authors
-        };
+        }
+        // `take` is a no-op under the cap, so the capped and uncapped cases
+        // collapse to one chained collect: authors first, then mention top-up.
+        let user_ids: HashSet<String> = authors
+            .into_iter()
+            .chain(mentions)
+            .take(SLACK_MAX_USER_LOOKUPS)
+            .collect();
 
         let (channel_name, users) = tokio::join!(
             self.resolve_channel(&slack_url.channel),

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -597,3 +597,154 @@ async fn fetch_message_link_with_replies_fetches_thread() {
         "expected the probed thread's reply in output, got: {out}"
     );
 }
+
+/// [T-SK048] When distinct authors exceed SLACK_MAX_USER_LOOKUPS, the keep set
+/// is fixed to first-occurrence (thread chronological) order rather than
+/// HashSet iteration order, so which authors resolve to names is reproducible
+/// across runs. A thread carrying SLACK_MAX_USER_LOOKUPS + 10 distinct authors
+/// keeps exactly the first 50 by message order; authors 50..59 are evicted and
+/// render as raw IDs. T-SK044 has only 3 authors « cap, so it never exercises
+/// this path (issue #221).
+#[tokio::test]
+async fn fetch_message_keeps_first_occurrence_authors_when_capping() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000000";
+    let total = SLACK_MAX_USER_LOOKUPS + 10; // 60 distinct authors
+    // Author i authors message i, in a fixed order. Zero-padded IDs (U000..U059)
+    // avoid the substring trap where contains("U5") would match "U50".
+    let messages = (0..total)
+        .map(|i| {
+            serde_json::json!({
+                "user": format!("U{i:03}"),
+                "text": "reply",
+                "ts": format!("1000.{i:06}"),
+            })
+        })
+        .collect::<Vec<_>>();
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": messages,
+            "has_more": false,
+            "response_metadata": {"next_cursor": ""}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: parent_ts.into(),
+        thread_ts: Some(parent_ts.into()),
+        raw_url: "https://acme.slack.com/archives/C1/p1000000000".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("thread with capped author lookups resolves");
+    // The first 50 authors (U000..U049) are kept, so each resolves to a name and
+    // no raw ID leaks.
+    for i in 0..SLACK_MAX_USER_LOOKUPS {
+        let raw = format!("U{i:03}");
+        assert!(
+            !out.contains(&raw),
+            "author {raw} is within the first 50 by order and must resolve, but its raw ID leaked: {out}"
+        );
+    }
+    // Authors 50..59 fall past the cap, so they are evicted and render raw.
+    for i in SLACK_MAX_USER_LOOKUPS..total {
+        let raw = format!("U{i:03}");
+        assert!(
+            out.contains(&raw),
+            "evicted author {raw} must render as a raw ID, but it was absent: {out}"
+        );
+    }
+}
+
+/// [T-SK049] A user mentioned in an early message who authors a later message is
+/// kept as an author, not demoted to an evictable mention. The keep set is built
+/// in two passes — all authors first, then mentions — sharing one `seen` set, so
+/// the author role wins a dual-role ID's single slot. A single interleaved pass
+/// would record the early mention first and evict the late author, shrinking
+/// effective author coverage (issue #221 implementation hazard).
+#[tokio::test]
+async fn fetch_message_keeps_dual_role_id_as_author_not_mention() {
+    let Some(server) = try_spawn_mock_server("slack::http").await else {
+        return;
+    };
+    let parent_ts = "1000.000000";
+    // The parent mentions UMENT01 then UDUAL (in-text order). UDUAL authors a
+    // later message, so under two-pass author-first priority it keeps a slot;
+    // the pure mention UMENT01 loses the (zero) remaining slots and renders raw.
+    let mut messages = vec![serde_json::json!({
+        "user": "UA00",
+        "text": "<@UMENT01> <@UDUAL>",
+        "ts": parent_ts,
+    })];
+    // UA00 plus UA01.. give SLACK_MAX_USER_LOOKUPS - 1 distinct pure authors;
+    // UDUAL as a late author makes exactly the cap, leaving no top-up slot for
+    // mentions. Derived from the cap so the boundary holds if the cap changes.
+    for i in 1..(SLACK_MAX_USER_LOOKUPS - 1) {
+        messages.push(serde_json::json!({
+            "user": format!("UA{i:02}"),
+            "text": "reply",
+            "ts": format!("1000.{i:06}"),
+        }));
+    }
+    messages.push(serde_json::json!({
+        "user": "UDUAL",
+        "text": "dual-role author",
+        "ts": "1000.000049",
+    }));
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": messages,
+            "has_more": false,
+            "response_metadata": {"next_cursor": ""}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = SlackClient::with_base_url(Client::new(), &server.uri());
+    let url = SlackUrl {
+        workspace: "acme".into(),
+        channel: "C1".into(),
+        ts: parent_ts.into(),
+        thread_ts: Some(parent_ts.into()),
+        raw_url: "https://acme.slack.com/archives/C1/p1000000000".into(),
+    };
+    let out = client
+        .fetch_message(&url)
+        .await
+        .expect("thread with a dual-role ID resolves");
+    assert!(
+        !out.contains("UDUAL"),
+        "the dual-role ID must stay kept as an author, but its raw ID leaked: {out}"
+    );
+    assert!(
+        out.contains("UMENT01"),
+        "the pure mention must be evicted past the full cap and render raw: {out}"
+    );
+}


### PR DESCRIPTION
## 何を・なぜ

distinct author が SLACK_MAX_USER_LOOKUPS(=50) を超えるとき、users.info で解決する keep 集合が `HashSet` の走査順で決まり、同一スレッドでも実行ごとに「解決名 vs raw ID」が揺れていた（#188 で導入した著者優先 cap の残存欠陥）。keep 集合を初出順（スレッド時系列）に固定し、出力を再現可能にする。

## 変更点

- `src/slack/client.rs`: cap ブロックを2-pass（全著者→mention、`seen` 共有）に変更。`authors.into_iter().chain(mentions).take(cap).collect()` で capped/uncapped を1本化。初出順で keep 集合が決定的になる。
- `src/slack.rs`: `collect_mention_ids` → `collect_mention_ids_ordered`。`Vec` へ初出順 push し、`seen` で著者と dedup（dual-role ID が1スロットのみ消費）。
- テスト: T-SK048（著者60>cap50: 先頭50解決・残り raw）、T-SK049（early-mention→late-author の dual-role が著者として keep）を追加。既存 T-SK044 は著者3≪cap でこの経路を通らず不足だった。

## 設計判断

- 初出順 = 親投稿者+初期参加者を keep。長大スレッド末尾の活発な著者は evict される（「最早50」≠「最価値50」）が、決定性と直感性を優先。
- `fetch_replies` の `Vec`+`HashSet` seen idiom を踏襲し `indexmap` 依存は追加しない。
- 2-pass は dual-role ハザード対策の要（1-pass interleaved だと early-mention が late-author を evict し著者カバレッジが縮む）。

## スコープ

- **含まないもの**: mention の「どの ID が解決されるか」の決定化は売りにしない（観測者利益が薄い）。著者 keep 集合の決定化が主眼。

## テスト方法

1. `cargo test --lib fetch_message_keeps` → T-SK048/T-SK049 が pass。
2. `cargo test` 全 pass、`cargo fmt -- --check` / `cargo clippy --all-targets` クリーン。

## 関連

- Closes #221