### PR TITLE
feat(slack): fetch の cap/truncate を ADR-0003 degradation channel に接続 (#222)

### DIFF
--- a/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
+++ b/docs/decisions/0003-error-classification-contract-for-sysexits-and-json-output.md
@@ -17,15 +17,15 @@ ADR-0002 の table は exit code 値のみで domain mapping を扱わず、JSON
 
 ## Decision Drivers
 
-* exit code + JSON `--json` mode は CLI script / agent のメタ判断 source of truth
-* Slack 5xx / GitHub 5xx の retryability は CLI script の retry/fail-fast 判断に直結
-* partial failure (`repo_overview` で readme は取れたが issues は失敗等) を programmatic 通知できないと自動化価値が下がる
+- exit code + JSON `--json` mode は CLI script / agent のメタ判断 source of truth
+- Slack 5xx / GitHub 5xx の retryability は CLI script の retry/fail-fast 判断に直結
+- partial failure (`repo_overview` で readme は取れたが issues は失敗等) を programmatic 通知できないと自動化価値が下がる
 
 ## Considered Options
 
-* Option A: HTTP status → ErrorCode の uniform mapping rule + partial failure に `degraded` flag
-* Option B: per-error-source ad-hoc mapping (現状)
-* Option C: 全 error type をリッチに展開し、JSON output に full error union を expose
+- Option A: HTTP status → ErrorCode の uniform mapping rule + partial failure に `degraded` flag
+- Option B: per-error-source ad-hoc mapping (現状)
+- Option C: 全 error type をリッチに展開し、JSON output に full error union を expose
 
 ## Decision Outcome
 
@@ -33,13 +33,13 @@ Chosen option: Option A, because public CLI contract として一貫した class
 
 ### HTTP status → ErrorCode mapping
 
-| HTTP status         | ErrorCode    | sysexits    | Retryable? |
-| ------------------- | ------------ | ----------- | ---------- |
-| 5xx (500-599)       | TempFailure  | 75 EX_TEMPFAIL | Yes |
-| 408, 429            | TempFailure  | 75 EX_TEMPFAIL | Yes |
-| 404                 | NotFound     | 66 EX_NOINPUT | No |
-| 401, 403            | UsageError   | 64 EX_USAGE | No (auth misconfig) |
-| 4xx (other)         | DataError    | 65 EX_DATAERR | No |
+| HTTP status   | ErrorCode   | sysexits       | Retryable?          |
+| ------------- | ----------- | -------------- | ------------------- |
+| 5xx (500-599) | TempFailure | 75 EX_TEMPFAIL | Yes                 |
+| 408, 429      | TempFailure | 75 EX_TEMPFAIL | Yes                 |
+| 404           | NotFound    | 66 EX_NOINPUT  | No                  |
+| 401, 403      | UsageError  | 64 EX_USAGE    | No (auth misconfig) |
+| 4xx (other)   | DataError   | 65 EX_DATAERR  | No                  |
 
 例外: API-specific な再分類が必要な場合 (例: Slack 4xx の中で transient なものがあれば) は doc コメントで明示する。
 
@@ -47,10 +47,10 @@ Chosen option: Option A, because public CLI contract として一貫した class
 
 `repo_overview` 等の multi-fetch 経路で部分失敗が発生した場合:
 
-* 結果 struct に `degraded: bool` と `reason: Option<DegradedReason>` フィールドを追加
-* `--json` 出力にも expose
-* `DegradedReason` は `ReadmeMissing`, `IssuesFetchFailed`, `PullsFetchFailed`, `ReleasesFetchFailed` 等 enum で typed
-* silent log-only fallback (`unwrap_or_note` 系) は廃止
+- 結果 struct に `degraded: bool` と `reason: Option<DegradedReason>` フィールドを追加
+- `--json` 出力にも expose
+- `DegradedReason` は `ReadmeMissing`, `IssuesFetchFailed`, `PullsFetchFailed`, `ReleasesFetchFailed` 等 enum で typed
+- silent log-only fallback (`unwrap_or_note` 系) は廃止
 
 > **Note (2026-05-13, post-implementation audit)**: `degraded: bool` field は本 ADR 起票前から `src/envelope.rs` に既存。本 ADR は既存 behavior を canonical contract として formalize し、残り (`DegradedReason` typed enum + `unwrap_or_note` → `unwrap_or_degraded` refactor + JSON schema 拡張) を follow-up scope として明示する。
 >
@@ -58,65 +58,67 @@ Chosen option: Option A, because public CLI contract として一貫した class
 >
 > **Note (2026-05-19, post-ADR-0005 update)**: ADR-0005 (Brave Search switch, 2026-05-15) に伴い `BraveSearchFailed` variant 追加で **計 9 variants**。`unwrap_or_degraded` 経由で meaningful label を持つのは `*FetchFailed` の 3 つに加えて `BraveSearchFailed` の合計 4 variants。命名規約 (`*FetchFailed`) の例外として `BraveSearchFailed` は Brave API endpoint 機能名 (search) に倣う。発見元 audit: `docs/audit/2026-05-19-undocumented-decisions.md` E-06。
 >
+> **Note (2026-06-17, post-issue-#222 update)**: `fetch_slack` の cap/truncate を degradation channel に接続するため Slack 用 3 variant 追加 (`SlackThreadTruncated`, `SlackUsersCapped`, `SlackOutputTruncated`) で **計 12 variants**。この 3 つは `fetch_slack` が callsite で note text を直接構築するため `unwrap_or_degraded` を経由せず、`label()` は exhaustive match 用の placeholder。よって `unwrap_or_degraded` 経由で meaningful label を持つのは引き続き 4 variants で不変。追加は serde additive (新 variant は `degraded_reasons` の skip-if-empty で feature-detect 可能) のため既存 JSON consumer に無影響。発見元: issue #222 実装時の docs drift 確認。
+>
 > **README 404 silent の意図的選択**: 「README が存在しない repo」は scout として degraded ではない (overview は他フィールドだけで成立)。404 を silent にすることで `degraded` flag を「abnormal なときだけ立てる」契約に保つ。代わりに JSON consumer は `data.readme` が null か否かで「README の有無」を直接判別可能 (404 と fetch error の区別は `degraded_reasons` の `ReadmeFetchFailed` の有無で行う)。403 等の non-404 4xx は `ReadmeFetchFailed` で集約しており、status code 別の細分は当面 scope 外。
 
 ### Consequences
 
-* Good, because CLI script が exit code で retry/fail-fast 判断可能、ADR-0002 contract が enforced される
-* Good, because `--json` caller が partial failure を programmatic 検出可能、agent が次アクションを自動判断できる
-* Bad, because 既存 code (`SlackError::Api`, `unwrap_or_note`) の refactoring が必要 (本 ADR 後の別 PR で実装)
-* Bad, because `degraded` flag 導入で JSON schema 変更 (semver bump 検討)
+- Good, because CLI script が exit code で retry/fail-fast 判断可能、ADR-0002 contract が enforced される
+- Good, because `--json` caller が partial failure を programmatic 検出可能、agent が次アクションを自動判断できる
+- Bad, because 既存 code (`SlackError::Api`, `unwrap_or_note`) の refactoring が必要 (本 ADR 後の別 PR で実装)
+- Bad, because `degraded` flag 導入で JSON schema 変更 (semver bump 検討)
 
 ### Confirmation
 
-* 各 error source (Slack / GitHub / Fetch / Gemini) で HTTP status → ErrorCode mapping unit test
-* `repo_overview` partial failure path で `--json` 出力に `degraded` フィールドが含まれることの integration test
-* T-ER001a/b/c, T-ER002, T-ER003 は ADR-0002 (exit code values) と本 ADR (mapping rule) の両方で binding。両 ADR ref を doc コメントに記載
+- 各 error source (Slack / GitHub / Fetch / Gemini) で HTTP status → ErrorCode mapping unit test
+- `repo_overview` partial failure path で `--json` 出力に `degraded` フィールドが含まれることの integration test
+- T-ER001a/b/c, T-ER002, T-ER003 は ADR-0002 (exit code values) と本 ADR (mapping rule) の両方で binding。両 ADR ref を doc コメントに記載
 
 ## Pros and Cons of the Options
 
 ### Option A: Uniform mapping rule + degraded flag (採用)
 
-* Good, because mapping rule が単一 table、enforce が test 一本化可能
-* Good, because `degraded` flag で partial failure 検出が programmatic
-* Bad, because 既存 ad-hoc mapping (Slack, unwrap_or_note 等) refactoring 必要
-* Bad, because behavior 変更で CLI 既存 caller (exit code を hardcode していた script) が break する可能性
+- Good, because mapping rule が単一 table、enforce が test 一本化可能
+- Good, because `degraded` flag で partial failure 検出が programmatic
+- Bad, because 既存 ad-hoc mapping (Slack, unwrap_or_note 等) refactoring 必要
+- Bad, because behavior 変更で CLI 既存 caller (exit code を hardcode していた script) が break する可能性
 
 ### Option B: per-error-source ad-hoc mapping (現状)
 
-* Good, because 現コードを変えなくて済む
-* Bad, because ADR-0002 contract 違反が散発、契約として機能しない
-* Bad, because reviewer が mapping rule を都度判断、code review 負荷大
+- Good, because 現コードを変えなくて済む
+- Bad, because ADR-0002 contract 違反が散発、契約として機能しない
+- Bad, because reviewer が mapping rule を都度判断、code review 負荷大
 
 ### Option C: 全 error type を JSON union で expose
 
-* Good, because 完全な error type 情報を caller に提供
-* Bad, because JSON schema が複雑化、agent / script の処理コスト増
-* Bad, because internal error type のリーク (encapsulation 違反)
+- Good, because 完全な error type 情報を caller に提供
+- Bad, because JSON schema が複雑化、agent / script の処理コスト増
+- Bad, because internal error type のリーク (encapsulation 違反)
 
 ## More Information
 
 ### Implementation Guidelines
 
-* 各 `ErrorCode` バリアントの construction site で本 ADR の mapping table を参照
-* `unwrap_or_note` を `unwrap_or_degraded` に rename 済み (`src/tools/errors.rs` `unwrap_or_degraded`)。`DegradedReason` を受け取り、`Degradation::push` 経由で `(notes[i], reasons[i])` の pair invariant を保ったまま統一的に蓄積する形に refactor 済み
-* `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (実装後 9 variants、上記 Note 2026-05-19 post-ADR-0005 update を参照)
-* ADR-0011 §Classification Priority Table の 5 段ルール (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN 退避) を各 `From<...>` 実装の match arm 順序と `// Priority N` コメントで明示する。`*Error::Api { code }` の 4xx は priority 2 (DataError) に集約する。Priority 5 (INTERNAL) 以下は 3 つの sibling constructor に分離する: `internal_bug()` は scout-side invariant violation (例: deserialize 想定外 schema) を `ErrorCode::Internal` (exit 70 EX_SOFTWARE) で表し、`io_error()` は scout の不変条件外にある external tool / IO failure (例: headless browser CDP error) を `ErrorCode::IoError` (exit 74 EX_IOERR) で表し、`unknown()` は priority 1-5 のどれにも該当しない unclassifiable failure を `ErrorCode::Unknown` (exit 104 PJ extension) で退避する。3 つの分離により caller script / agent は scout 側 bug (70) と外部要因 (74) と分類欠落 (104) を programmatic 判別できる
+- 各 `ErrorCode` バリアントの construction site で本 ADR の mapping table を参照
+- `unwrap_or_note` を `unwrap_or_degraded` に rename 済み (`src/tools/errors.rs` `unwrap_or_degraded`)。`DegradedReason` を受け取り、`Degradation::push` 経由で `(notes[i], reasons[i])` の pair invariant を保ったまま統一的に蓄積する形に refactor 済み
+- `DegradedReason` の variants は `repo_overview` 等の現実の failure mode を反映 (実装後 12 variants、上記 Note 2026-06-17 post-issue-#222 update を参照)
+- ADR-0011 §Classification Priority Table の 5 段ルール (USAGE → DATA → NOT_FOUND → TEMP_FAILURE → INTERNAL → UNKNOWN 退避) を各 `From<...>` 実装の match arm 順序と `// Priority N` コメントで明示する。`*Error::Api { code }` の 4xx は priority 2 (DataError) に集約する。Priority 5 (INTERNAL) 以下は 3 つの sibling constructor に分離する: `internal_bug()` は scout-side invariant violation (例: deserialize 想定外 schema) を `ErrorCode::Internal` (exit 70 EX_SOFTWARE) で表し、`io_error()` は scout の不変条件外にある external tool / IO failure (例: headless browser CDP error) を `ErrorCode::IoError` (exit 74 EX_IOERR) で表し、`unknown()` は priority 1-5 のどれにも該当しない unclassifiable failure を `ErrorCode::Unknown` (exit 104 PJ extension) で退避する。3 つの分離により caller script / agent は scout 側 bug (70) と外部要因 (74) と分類欠落 (104) を programmatic 判別できる
 
 ### Reassessment Triggers
 
-| Trigger                                                          | アクション                            |
-| ---------------------------------------------------------------- | ------------------------------------- |
-| 5xx の中で 501/505 等 permanent な status が一般化               | mapping table の 5xx 全 retryable 規則を再評価 |
-| GitHub / Slack / Gemini が新規 4xx status を導入                 | mapping table に row 追加              |
-| `degraded` flag が caller 側で無視される傾向が広まる             | flag 設計の usability 再評価          |
+| Trigger                                              | アクション                                     |
+| ---------------------------------------------------- | ---------------------------------------------- |
+| 5xx の中で 501/505 等 permanent な status が一般化   | mapping table の 5xx 全 retryable 規則を再評価 |
+| GitHub / Slack / Gemini が新規 4xx status を導入     | mapping table に row 追加                      |
+| `degraded` flag が caller 側で無視される傾向が広まる | flag 設計の usability 再評価                   |
 
 ### 参照
 
-* `docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md` (exit code 値の source)
-* `docs/decisions/0010-scout-local-json-envelope-contract.md` (JSON schema portion を scout-local 化、本 ADR の Degradation field omit policy も Rule 2-3 で governed)
-* `docs/decisions/0011-scout-local-classification-priority-policy.md` (Classification Priority portion を scout-local 化、本 ADR が参照する 5 段 ranking の現行 source of truth)
-* `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (全 portion supersede 済 meta ADR、historical reference)
-* `docs/audit/2026-05-13-undocumented-decisions-part2.md` (本 ADR の根拠 audit、Candidate #7 + #8)
-* `src/tools/errors.rs` (`From<SlackError>` priority-2 集約 + `unwrap_or_degraded` 実装), `src/envelope.rs` (`Degradation` / `DegradedReason` typed enum) — implementation sites (audit 時点の違反は resolved 済み、historical record は `docs/audit/2026-05-13-undocumented-decisions-part2.md` を参照)
-* `docs/audit/2026-05-14-adr-drift.md` (PR #94 後の追従 audit)
+- `docs/decisions/0002-adopt-sysexitsh-exit-code-convention-for-cli.md` (exit code 値の source)
+- `docs/decisions/0010-scout-local-json-envelope-contract.md` (JSON schema portion を scout-local 化、本 ADR の Degradation field omit policy も Rule 2-3 で governed)
+- `docs/decisions/0011-scout-local-classification-priority-policy.md` (Classification Priority portion を scout-local 化、本 ADR が参照する 5 段 ranking の現行 source of truth)
+- `~/.claude/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md` (全 portion supersede 済 meta ADR、historical reference)
+- `docs/audit/2026-05-13-undocumented-decisions-part2.md` (本 ADR の根拠 audit、Candidate #7 + #8)
+- `src/tools/errors.rs` (`From<SlackError>` priority-2 集約 + `unwrap_or_degraded` 実装), `src/envelope.rs` (`Degradation` / `DegradedReason` typed enum) — implementation sites (audit 時点の違反は resolved 済み、historical record は `docs/audit/2026-05-13-undocumented-decisions-part2.md` を参照)
+- `docs/audit/2026-05-14-adr-drift.md` (PR #94 後の追従 audit)

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -31,24 +31,24 @@ impl DegradedReason {
     /// Human-readable label used by [`crate::tools::errors::unwrap_or_degraded`]
     /// to build the `"Could not fetch {label} ({e})"` message. The four
     /// fetch-style variants (three `*FetchFailed` plus `BraveSearchFailed`)
-    /// that flow through that helper get a meaningful label; other variants
-    /// build bespoke messages at their callsite. The three Slack variants are
-    /// in the latter group: `fetch_slack` writes their note text directly, so
-    /// these labels are only a semantic placeholder for the exhaustive match.
+    /// that flow through that helper get a meaningful label; the rest build
+    /// their note text at their callsite and never reach `label()`, so they
+    /// share the generic `"resource"` fallback that only keeps the match
+    /// exhaustive (`ReadabilityFallback` and the three Slack cap variants).
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::IssuesFetchFailed => "issues",
             Self::PullsFetchFailed => "pull requests",
             Self::ReleasesFetchFailed => "releases",
             Self::BraveSearchFailed => "Brave search",
-            Self::SlackThreadTruncated => "Slack thread",
-            Self::SlackUsersCapped => "Slack users",
-            Self::SlackOutputTruncated => "Slack output",
             Self::ReadmeFetchFailed
             | Self::ReadmeBlobFetchFailed
             | Self::ReadmeDecodeFailed
             | Self::UrlFetchFailed
-            | Self::ReadabilityFallback => "resource",
+            | Self::ReadabilityFallback
+            | Self::SlackThreadTruncated
+            | Self::SlackUsersCapped
+            | Self::SlackOutputTruncated => "resource",
         }
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -22,6 +22,9 @@ pub(crate) enum DegradedReason {
     UrlFetchFailed,
     ReadabilityFallback,
     BraveSearchFailed,
+    SlackThreadTruncated,
+    SlackUsersCapped,
+    SlackOutputTruncated,
 }
 
 impl DegradedReason {
@@ -29,13 +32,18 @@ impl DegradedReason {
     /// to build the `"Could not fetch {label} ({e})"` message. The four
     /// fetch-style variants (three `*FetchFailed` plus `BraveSearchFailed`)
     /// that flow through that helper get a meaningful label; other variants
-    /// build bespoke messages at their callsite.
+    /// build bespoke messages at their callsite. The three Slack variants are
+    /// in the latter group: `fetch_slack` writes their note text directly, so
+    /// these labels are only a semantic placeholder for the exhaustive match.
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::IssuesFetchFailed => "issues",
             Self::PullsFetchFailed => "pull requests",
             Self::ReleasesFetchFailed => "releases",
             Self::BraveSearchFailed => "Brave search",
+            Self::SlackThreadTruncated => "Slack thread",
+            Self::SlackUsersCapped => "Slack users",
+            Self::SlackOutputTruncated => "Slack output",
             Self::ReadmeFetchFailed
             | Self::ReadmeBlobFetchFailed
             | Self::ReadmeDecodeFailed

--- a/src/slack/client.rs
+++ b/src/slack/client.rs
@@ -28,6 +28,22 @@ use super::{
 struct FetchedThread {
     messages: Vec<Message>,
     is_thread: bool,
+    /// True when `fetch_replies` stopped at `SLACK_MAX_REPLY_PAGES` with more
+    /// pages still available, so the thread is missing replies past the cap.
+    truncated: bool,
+}
+
+/// Result of resolving a Slack permalink into rendered Markdown, carrying the
+/// cap-hit signals `fetch_slack` needs to wire into the ADR-0003 degradation
+/// channel. A bare `String` return hid these, so caps were invisible to callers
+/// (issue #222).
+pub(crate) struct SlackFetchOutcome {
+    pub markdown: String,
+    /// `conversations.replies` hit the page cap; replies past it are omitted.
+    pub thread_truncated: bool,
+    /// Distinct user IDs exceeded `SLACK_MAX_USER_LOOKUPS`; the excess render
+    /// as raw `<@UID>` instead of resolved names.
+    pub users_capped: bool,
 }
 
 pub(crate) struct SlackClient {
@@ -297,7 +313,14 @@ impl SlackClient {
     /// across pages up to `SLACK_MAX_REPLY_PAGES`. Without this loop a target
     /// message past the first `SLACK_REPLIES_LIMIT` page is silently dropped and
     /// surfaces as "not found" (issue #188 claim 2).
-    async fn fetch_replies(&self, channel: &str, ts: &str) -> Result<Vec<Message>, SlackError> {
+    /// Returns the fetched replies paired with a `truncated` flag: `true` when
+    /// the loop stopped at `SLACK_MAX_REPLY_PAGES` with another page still
+    /// advertised, `false` when it ran out of pages naturally.
+    async fn fetch_replies(
+        &self,
+        channel: &str,
+        ts: &str,
+    ) -> Result<(Vec<Message>, bool), SlackError> {
         let mut messages = Vec::new();
         // conversations.replies is observed to repeat the thread parent as
         // messages[0] on each page; the official reference is silent, so dedup
@@ -328,7 +351,7 @@ impl SlackClient {
             }
             match next {
                 Some(c) => cursor = Some(c),
-                None => return Ok(messages),
+                None => return Ok((messages, false)),
             }
         }
         warn!(
@@ -337,16 +360,17 @@ impl SlackClient {
             max_pages = SLACK_MAX_REPLY_PAGES,
             "conversations.replies hit the page cap, thread truncated"
         );
-        Ok(messages)
+        Ok((messages, true))
     }
 
     async fn fetch_thread(&self, slack_url: &SlackUrl) -> Result<FetchedThread, SlackError> {
         let ch = &slack_url.channel;
         if let Some(ref thread_ts) = slack_url.thread_ts {
-            let messages = self.fetch_replies(ch, thread_ts).await?;
+            let (messages, truncated) = self.fetch_replies(ch, thread_ts).await?;
             return Ok(FetchedThread {
                 messages,
                 is_thread: true,
+                truncated,
             });
         }
 
@@ -366,20 +390,25 @@ impl SlackClient {
             .first()
             .is_some_and(|m| m.reply_count.unwrap_or(0) > 0);
         if has_replies {
-            let messages = self.fetch_replies(ch, &slack_url.ts).await?;
+            let (messages, truncated) = self.fetch_replies(ch, &slack_url.ts).await?;
             Ok(FetchedThread {
                 messages,
                 is_thread: true,
+                truncated,
             })
         } else {
             Ok(FetchedThread {
                 messages: body.messages,
                 is_thread: false,
+                truncated: false,
             })
         }
     }
 
-    pub async fn fetch_message(&self, slack_url: &SlackUrl) -> Result<String, SlackError> {
+    pub async fn fetch_message(
+        &self,
+        slack_url: &SlackUrl,
+    ) -> Result<SlackFetchOutcome, SlackError> {
         let fetched = self.fetch_thread(slack_url).await?;
         if fetched.messages.is_empty() {
             return Err(SlackError::Api {
@@ -409,7 +438,8 @@ impl SlackClient {
         }
 
         let distinct_total = authors.len() + mentions.len();
-        if distinct_total > SLACK_MAX_USER_LOOKUPS {
+        let users_capped = distinct_total > SLACK_MAX_USER_LOOKUPS;
+        if users_capped {
             warn!(
                 distinct_users = distinct_total,
                 cap = SLACK_MAX_USER_LOOKUPS,
@@ -443,7 +473,11 @@ impl SlackClient {
             replies = replies.len(),
             "slack fetch complete"
         );
-        Ok(output)
+        Ok(SlackFetchOutcome {
+            markdown: output,
+            thread_truncated: fetched.truncated,
+            users_capped,
+        })
     }
 }
 

--- a/src/slack/client/http_tests.rs
+++ b/src/slack/client/http_tests.rs
@@ -269,7 +269,8 @@ async fn fetch_replies_paginates_to_find_target_on_page_two() {
     let out = client
         .fetch_message(&url)
         .await
-        .expect("target message on page 2 is found via pagination");
+        .expect("target message on page 2 is found via pagination")
+        .markdown;
     assert!(
         out.contains("the target reply"),
         "expected the page-2 target in output, got: {out}"
@@ -319,10 +320,14 @@ async fn fetch_message_caps_users_info_lookups_on_mass_mentions() {
         thread_ts: None,
         raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
     };
-    client
+    let outcome = client
         .fetch_message(&url)
         .await
         .expect("mass-mention message resolves");
+    assert!(
+        outcome.users_capped,
+        "distinct user IDs exceed the cap, so users_capped must be set"
+    );
     // The `.expect(cap)` is verified when `server` drops at end of scope.
 }
 
@@ -392,7 +397,8 @@ async fn fetch_message_prioritizes_authors_over_mentions_when_capping() {
     let out = client
         .fetch_message(&url)
         .await
-        .expect("thread with capped lookups resolves");
+        .expect("thread with capped lookups resolves")
+        .markdown;
     assert!(
         !out.contains("UAUTHOR"),
         "every author should resolve to a name, but a raw author ID leaked: {out}"
@@ -466,10 +472,15 @@ async fn fetch_replies_dedups_parent_repeated_across_pages() {
         thread_ts: Some(parent_ts.into()),
         raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
     };
-    let out = client
+    let outcome = client
         .fetch_message(&url)
         .await
         .expect("thread spanning two pages resolves");
+    assert!(
+        !outcome.thread_truncated,
+        "a thread whose last page advertises no next cursor ends naturally and must not be flagged truncated (page-cap false-positive guard, symmetric to the user-cap boundary in T-SK055)"
+    );
+    let out = outcome.markdown;
     assert!(
         out.contains("context_messages: 2"),
         "two distinct replies expected, parent duplicate must not inflate the count: {out}"
@@ -522,10 +533,15 @@ async fn fetch_replies_stops_at_page_cap_and_warns() {
         thread_ts: Some(parent_ts.into()),
         raw_url: "https://acme.slack.com/archives/C1/p1000000001".into(),
     };
-    let out = client
+    let outcome = client
         .fetch_message(&url)
         .await
         .expect("a truncated thread still returns the pages fetched so far");
+    assert!(
+        outcome.thread_truncated,
+        "the reply page cap was hit, so thread_truncated must be set"
+    );
+    let out = outcome.markdown;
     assert!(
         out.contains("PARENT_BODY"),
         "expected the parent body in the truncated output, got: {out}"
@@ -591,7 +607,8 @@ async fn fetch_message_link_with_replies_fetches_thread() {
     let out = client
         .fetch_message(&url)
         .await
-        .expect("a permalink to a thread root resolves the full thread");
+        .expect("a permalink to a thread root resolves the full thread")
+        .markdown;
     assert!(
         out.contains("a reply"),
         "expected the probed thread's reply in output, got: {out}"
@@ -653,7 +670,8 @@ async fn fetch_message_keeps_first_occurrence_authors_when_capping() {
     let out = client
         .fetch_message(&url)
         .await
-        .expect("thread with capped author lookups resolves");
+        .expect("thread with capped author lookups resolves")
+        .markdown;
     // The first 50 authors (U000..U049) are kept, so each resolves to a name and
     // no raw ID leaks.
     for i in 0..SLACK_MAX_USER_LOOKUPS {
@@ -738,7 +756,8 @@ async fn fetch_message_keeps_dual_role_id_as_author_not_mention() {
     let out = client
         .fetch_message(&url)
         .await
-        .expect("thread with a dual-role ID resolves");
+        .expect("thread with a dual-role ID resolves")
+        .markdown;
     assert!(
         !out.contains("UDUAL"),
         "the dual-role ID must stay kept as an author, but its raw ID leaked: {out}"

--- a/src/tools/builder_tests.rs
+++ b/src/tools/builder_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::clock::FixedClock;
-use crate::envelope::ErrorCode;
+use crate::envelope::{DegradedReason, ErrorCode};
 use crate::fetch::{FailingDnsResolver, StaticDnsResolver};
 use crate::rng::SeededRng;
 use crate::test_support::try_spawn_mock_server;
@@ -194,5 +194,410 @@ async fn scout_builder_slack_endpoint_reaches_fetch_slack_via_seam() {
         output.markdown().contains("hello from wiremock"),
         "fetch output must carry the wiremock message body, got: {}",
         output.markdown()
+    );
+}
+
+/// [T-SK050] A thread whose reply pages never stop hits the page cap, so
+/// `fetch_slack` wires the truncation into the ADR-0003 channel: `degraded` is
+/// set, `degraded_reasons` carries `SLACK_THREAD_TRUNCATED`, and the Markdown
+/// body gains a cap note in the frontmatter preamble (issue #222). Before this,
+/// a truncated Slack thread returned `degraded: false` and the omission was
+/// invisible to callers. The target ts is on page 1 so the message resolves;
+/// only the reply tail past the cap is lost.
+#[tokio::test]
+async fn fetch_slack_thread_page_cap_sets_degraded_reason_and_preamble() {
+    let Some(server) = try_spawn_mock_server("tools::slack_thread_cap").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    // Every page advertises another, so the loop only ends at the page cap.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"user": "U1", "text": "parent body", "ts": parent_ts}],
+            "has_more": true,
+            "response_metadata": {"next_cursor": "MORE"}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some(
+                "https://acme.slack.com/archives/C1/p1000000001?thread_ts=1000.000001".into(),
+            ),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("a truncated thread still resolves the target on page 1");
+
+    assert!(
+        output
+            .degraded_reasons()
+            .contains(&DegradedReason::SlackThreadTruncated),
+        "page-cap truncation must surface SLACK_THREAD_TRUNCATED, got: {:?}",
+        output.degraded_reasons()
+    );
+    assert!(
+        output.markdown().contains("> Note:") && output.markdown().contains("Thread truncated"),
+        "the cap note must appear in the Markdown preamble, got: {}",
+        output.markdown()
+    );
+}
+
+/// [T-SK051] A message mentioning more distinct users than the lookup cap (50)
+/// surfaces `SLACK_USERS_CAPPED` in `degraded_reasons` and a preamble note, so a
+/// caller can tell that some `<@UID>` mentions render raw rather than resolved
+/// (issue #222).
+#[tokio::test]
+async fn fetch_slack_users_cap_sets_degraded_reason_and_preamble() {
+    let Some(server) = try_spawn_mock_server("tools::slack_users_cap").await else {
+        return;
+    };
+    // 60 distinct mentions > SLACK_MAX_USER_LOOKUPS (50), so the lookup is capped.
+    let mentions = (0..60)
+        .map(|i| format!("<@U{i}>"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"text": mentions, "ts": "1000.000001"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some("https://acme.slack.com/archives/C1/p1000000001".into()),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("a mass-mention message resolves");
+
+    assert!(
+        output
+            .degraded_reasons()
+            .contains(&DegradedReason::SlackUsersCapped),
+        "exceeding the user-lookup cap must surface SLACK_USERS_CAPPED, got: {:?}",
+        output.degraded_reasons()
+    );
+    assert!(
+        output.markdown().contains("> Note:") && output.markdown().contains("User lookups"),
+        "the user-cap note must appear in the Markdown preamble, got: {}",
+        output.markdown()
+    );
+}
+
+/// [T-SK052] A message body over `MAX_FETCH_OUTPUT_BYTES` (100KB) is truncated,
+/// and `fetch_slack` reports it via `SLACK_OUTPUT_TRUNCATED` plus the inline
+/// byte-count note that `truncate_with_note` appends at the body end (issue
+/// #222). The non-Slack `fetch` path already cut output silently for Slack.
+#[tokio::test]
+async fn fetch_slack_output_truncation_sets_degraded_reason() {
+    let Some(server) = try_spawn_mock_server("tools::slack_output_trunc").await else {
+        return;
+    };
+    let huge = "x".repeat(150_000);
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"text": huge, "ts": "1000.000001"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some("https://acme.slack.com/archives/C1/p1000000001".into()),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("an oversized message still resolves, truncated");
+
+    assert!(
+        output
+            .degraded_reasons()
+            .contains(&DegradedReason::SlackOutputTruncated),
+        "exceeding the output cap must surface SLACK_OUTPUT_TRUNCATED, got: {:?}",
+        output.degraded_reasons()
+    );
+    assert!(
+        output.markdown().contains("(truncated: showing"),
+        "the inline truncation note must remain at the body end, got len {}",
+        output.markdown().len()
+    );
+}
+
+/// [T-SK053] When a thread is page-capped AND its body exceeds the output cap,
+/// the thread note must still reach the agent. The preamble is inserted after
+/// truncation, so the 100KB cut cannot drop it (issue #222 Finding A). Both
+/// `SLACK_THREAD_TRUNCATED` and `SLACK_OUTPUT_TRUNCATED` are reported, and the
+/// thread note survives in the Markdown alongside the inline truncation note.
+#[tokio::test]
+async fn fetch_slack_thread_cap_note_survives_output_truncation() {
+    let Some(server) = try_spawn_mock_server("tools::slack_combo_cap").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    let huge = "x".repeat(150_000);
+    // Every page advertises another (page cap) and the parent body is oversized
+    // (output cap), so both degradations fire on one fetch.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"user": "U1", "text": huge, "ts": parent_ts}],
+            "has_more": true,
+            "response_metadata": {"next_cursor": "MORE"}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some(
+                "https://acme.slack.com/archives/C1/p1000000001?thread_ts=1000.000001".into(),
+            ),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("an oversized truncated thread still resolves");
+
+    let reasons = output.degraded_reasons();
+    assert!(
+        reasons.contains(&DegradedReason::SlackThreadTruncated)
+            && reasons.contains(&DegradedReason::SlackOutputTruncated),
+        "both the thread and output caps must be reported, got: {reasons:?}"
+    );
+    assert!(
+        output.markdown().contains("Thread truncated"),
+        "the thread note must survive the output truncation in the preamble, got len {}",
+        output.markdown().len()
+    );
+}
+
+/// [T-SK054] A normal thread with no caps keeps `degraded: false`: no reason is
+/// emitted and no `> Note:` preamble is injected, so the wiring does not flag
+/// healthy fetches (issue #222 negative case).
+#[tokio::test]
+async fn fetch_slack_without_caps_stays_undegraded() {
+    let Some(server) = try_spawn_mock_server("tools::slack_no_cap").await else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"text": "a short healthy message", "ts": "1000.000001"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some("https://acme.slack.com/archives/C1/p1000000001".into()),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("a healthy message resolves");
+
+    assert!(
+        output.degraded_reasons().is_empty(),
+        "a fetch with no caps must carry no degraded_reasons, got: {:?}",
+        output.degraded_reasons()
+    );
+    assert!(
+        !output.markdown().contains("> Note:"),
+        "no cap note preamble should be injected, got: {}",
+        output.markdown()
+    );
+}
+
+/// [T-SK055] Distinct user IDs exactly equal to the lookup cap (50) do NOT
+/// trigger `SLACK_USERS_CAPPED`: the condition is `> SLACK_MAX_USER_LOOKUPS`, so
+/// the boundary value resolves fully and stays undegraded (issue #222 boundary).
+#[tokio::test]
+async fn fetch_slack_users_at_cap_boundary_stays_undegraded() {
+    let Some(server) = try_spawn_mock_server("tools::slack_users_boundary").await else {
+        return;
+    };
+    // Exactly SLACK_MAX_USER_LOOKUPS (50) distinct mentions: == cap, not > cap.
+    let mentions = (0..50)
+        .map(|i| format!("<@U{i}>"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    Mock::given(method("GET"))
+        .and(path("/conversations.history"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [{"text": mentions, "ts": "1000.000001"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some("https://acme.slack.com/archives/C1/p1000000001".into()),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("a message mentioning exactly the cap resolves");
+
+    assert!(
+        !output
+            .degraded_reasons()
+            .contains(&DegradedReason::SlackUsersCapped),
+        "distinct users == cap is within budget and must not degrade, got: {:?}",
+        output.degraded_reasons()
+    );
+}
+
+/// [T-SK056] A reply-bearing thread that hits both the page cap and the
+/// user-lookup cap pins where the preamble lands and that multiple notes join
+/// into one blockquote. `insert_preamble_notes` must insert after the FIRST
+/// `---\n\n` (the frontmatter terminator) and never at a reply separator
+/// (`\n\n---\n\n`); the other cap tests dedup replies to the parent alone, so no
+/// reply separator ever appears and that placement rule goes unverified. Here a
+/// distinct reply survives, so the note must sit after the frontmatter and
+/// before the first reply separator, and the join must carry both the thread and
+/// users notes (the only path that produces a 2-note preamble) (issue #222).
+#[tokio::test]
+async fn fetch_slack_thread_and_users_caps_place_joined_preamble_after_frontmatter() {
+    let Some(server) = try_spawn_mock_server("tools::slack_thread_users_cap").await else {
+        return;
+    };
+    let parent_ts = "1000.000001";
+    // 60 distinct mentions (> SLACK_MAX_USER_LOOKUPS 50) in the parent body fire
+    // the user cap; U100.. avoids colliding with the U1/U2 authors.
+    let mentions = (100..160)
+        .map(|i| format!("<@U{i}>"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    // Every page advertises another (page cap) and carries a distinct reply that
+    // dedups to one, so the rendered thread has a reply separator to place
+    // against.
+    Mock::given(method("GET"))
+        .and(path("/conversations.replies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "messages": [
+                {"user": "U1", "text": mentions, "ts": parent_ts},
+                {"user": "U2", "text": "a surviving reply", "ts": "1000.000002"}
+            ],
+            "has_more": true,
+            "response_metadata": {"next_cursor": "MORE"}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/users.info"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ok": true,
+            "user": {"real_name": "Someone"}
+        })))
+        .mount(&server)
+        .await;
+
+    let scout = ScoutBuilder::for_test()
+        .with_slack_endpoint(&server.uri())
+        .build();
+    let output = scout
+        .fetch(FetchParams {
+            url: Some(
+                "https://acme.slack.com/archives/C1/p1000000001?thread_ts=1000.000001".into(),
+            ),
+            js: false,
+            raw: false,
+        })
+        .await
+        .expect("a capped reply-bearing thread resolves the target on page 1");
+
+    let reasons = output.degraded_reasons();
+    assert!(
+        reasons.contains(&DegradedReason::SlackThreadTruncated)
+            && reasons.contains(&DegradedReason::SlackUsersCapped),
+        "both the page cap and the user cap must be reported, got: {reasons:?}"
+    );
+
+    let md = output.markdown();
+    let note_pos = md.find("> Note:").expect("a preamble note is present");
+    let frontmatter_end = md
+        .find("---\n\n")
+        .expect("the frontmatter terminator is present");
+    let reply_sep = md
+        .find("\n\n---\n\n")
+        .expect("a reply separator is present for the surviving reply");
+    assert!(
+        note_pos > frontmatter_end,
+        "the note must sit after the frontmatter terminator, not before it: {md}"
+    );
+    assert!(
+        note_pos < reply_sep,
+        "the note must sit before the first reply separator, not at one: {md}"
+    );
+    let preamble = &md[note_pos..reply_sep];
+    assert!(
+        preamble.contains("Thread truncated") && preamble.contains("User lookups"),
+        "both cap notes must join into one preamble blockquote: {preamble}"
     );
 }

--- a/src/tools/query.rs
+++ b/src/tools/query.rs
@@ -1,5 +1,7 @@
 //! `Scout` query commands: web search, page fetch (including Slack), research.
 
+use std::borrow::Cow;
+
 use tokio::time::timeout;
 use tracing::{info, warn};
 
@@ -95,7 +97,7 @@ impl Scout {
         info!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), "fetch (slack)");
         let client = self.slack().await?;
         let slack_timeout = self.config.slack_timeout;
-        let output = timeout(slack_timeout, client.fetch_message(&slack_url))
+        let outcome = timeout(slack_timeout, client.fetch_message(&slack_url))
             .await
             .unwrap_or_else(|_| {
                 warn!(
@@ -113,12 +115,48 @@ impl Scout {
                 warn!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), error = %e, "slack fetch failed");
             })?;
         info!(workspace = %slack_url.workspace(), channel = %slack_url.channel(), "fetch (slack) complete");
-        let markdown = truncate_with_note(&output, MAX_FETCH_OUTPUT_BYTES).into_owned();
+
+        // Truncate first, then prepend the cap preamble: the preamble must
+        // survive the 100KB cut, so it is added after truncation rather than
+        // counted toward the limit (issue #222 Finding A). The inline byte-count
+        // note from `truncate_with_note` lands at the body end and covers the
+        // output-truncation case on the Markdown side, so only thread/users caps
+        // go into the preamble to avoid double-reporting truncation.
+        let truncated = truncate_with_note(&outcome.markdown, MAX_FETCH_OUTPUT_BYTES);
+        let output_truncated = matches!(truncated, Cow::Owned(_));
+
+        let mut degradation = Degradation::default();
+        let mut preamble_notes: Vec<&str> = Vec::new();
+        if outcome.thread_truncated {
+            let note = "Thread truncated: reply page cap reached, some replies are omitted.";
+            preamble_notes.push(note);
+            degradation.push(note.to_owned(), DegradedReason::SlackThreadTruncated);
+        }
+        if outcome.users_capped {
+            let note = "User lookups were capped, so some authors and mentions show raw IDs.";
+            preamble_notes.push(note);
+            degradation.push(note.to_owned(), DegradedReason::SlackUsersCapped);
+        }
+        if output_truncated {
+            degradation.push(
+                "Output truncated at the size cap; trailing content is omitted.".to_owned(),
+                DegradedReason::SlackOutputTruncated,
+            );
+        }
+
+        // `truncate_with_note` borrows `outcome.markdown` when the body is under
+        // the cap (the common case), so move it out rather than clone; only the
+        // over-cap path owns a freshly truncated copy.
+        let body = match truncated {
+            Cow::Owned(s) => s,
+            Cow::Borrowed(_) => outcome.markdown,
+        };
+        let markdown = insert_preamble_notes(body, &preamble_notes);
         let data = serde_json::json!({
             "url": slack_url.raw_url(),
             "markdown": markdown,
         });
-        Ok(CommandOutput::ok(markdown, data))
+        Ok(CommandOutput::with_degradation(markdown, data, degradation))
     }
 
     pub(super) async fn research(
@@ -208,6 +246,33 @@ pub(super) fn to_data_value<T: serde::Serialize>(
 ) -> Result<serde_json::Value, ScoutError> {
     serde_json::to_value(value)
         .map_err(|e| ScoutError::internal_bug(format!("failed to serialize {what}: {e}")))
+}
+
+/// Insert cap notes as a Markdown blockquote right after the Slack frontmatter
+/// so they reach the agent even when the body is truncated. `format_slack_output`
+/// opens with `---\n` then frontmatter then `---\n\n`, so the frontmatter
+/// terminator is the FIRST `---\n\n`; reply separators (`\n\n---\n\n`) come later
+/// in the body. Inserting after the first occurrence keeps the preamble ahead of
+/// any reply and above the truncation point. A reply-less single message has only
+/// one `---\n\n`, which is still the terminator, so this stays correct. Returns
+/// the input unchanged when there are no notes (no cap fired).
+fn insert_preamble_notes(markdown: String, notes: &[&str]) -> String {
+    const FRONTMATTER_END: &str = "---\n\n";
+    if notes.is_empty() {
+        return markdown;
+    }
+    let preamble = format!("> Note: {}\n\n", notes.join(" "));
+    match markdown.find(FRONTMATTER_END) {
+        Some(idx) => {
+            let insert_at = idx + FRONTMATTER_END.len();
+            let mut out = String::with_capacity(markdown.len() + preamble.len());
+            out.push_str(&markdown[..insert_at]);
+            out.push_str(&preamble);
+            out.push_str(&markdown[insert_at..]);
+            out
+        }
+        None => format!("{preamble}{markdown}"),
+    }
 }
 
 fn collect_research_degradations(report: &engine::ResearchReport, degradation: &mut Degradation) {

--- a/src/tools/query.rs
+++ b/src/tools/query.rs
@@ -256,7 +256,7 @@ pub(super) fn to_data_value<T: serde::Serialize>(
 /// any reply and above the truncation point. A reply-less single message has only
 /// one `---\n\n`, which is still the terminator, so this stays correct. Returns
 /// the input unchanged when there are no notes (no cap fired).
-fn insert_preamble_notes(markdown: String, notes: &[&str]) -> String {
+pub(super) fn insert_preamble_notes(markdown: String, notes: &[&str]) -> String {
     const FRONTMATTER_END: &str = "---\n\n";
     if notes.is_empty() {
         return markdown;

--- a/src/tools/query_tests.rs
+++ b/src/tools/query_tests.rs
@@ -489,3 +489,24 @@ async fn fetch_returns_ok_for_reachable_page() {
         "rendered markdown should be non-empty"
     );
 }
+
+/// [T-SK057] `insert_preamble_notes` prepends the note at the very top when the
+/// input carries no `---\n\n` frontmatter terminator. `format_slack_output`
+/// always emits that terminator, so this path is unreachable in production, but
+/// the fallback prepends rather than silently dropping the cap notes if that
+/// shape ever changes (issue #222 defensive seam).
+#[test]
+fn insert_preamble_notes_prepends_when_frontmatter_absent() {
+    let out = super::query::insert_preamble_notes(
+        "a body with no frontmatter".to_owned(),
+        &["a cap note"],
+    );
+    assert!(
+        out.starts_with("> Note: a cap note\n\n"),
+        "absent frontmatter must fall back to a top prepend, got: {out}"
+    );
+    assert!(
+        out.contains("a body with no frontmatter"),
+        "the original body must be preserved after the prepended note, got: {out}"
+    );
+}


### PR DESCRIPTION
## 概要

`fetch_slack` (Slack permalink fetch) は cap/truncate でコンテンツを落としても `CommandOutput::ok` (degraded:false) を返しており、欠落が stdout・JSON `degraded_reasons` のどちらからも不可視だった。非 Slack の `fetch` は既に typed degradation channel に接続済みで、Slack だけが未配線だった。本 PR で 3 つの cap locus を ADR-0003 degradation channel に接続する。

Closes #222

## 変更内容

| cap locus | 上限 | 追加 reason |
| --- | --- | --- |
| reply-page cap | `SLACK_MAX_REPLY_PAGES` | `SLACK_THREAD_TRUNCATED` |
| user-lookup cap | `SLACK_MAX_USER_LOOKUPS` | `SLACK_USERS_CAPPED` |
| output truncate | `MAX_FETCH_OUTPUT_BYTES` (100KB) | `SLACK_OUTPUT_TRUNCATED` |

- `fetch_replies` が page cap 到達フラグを返し、`fetch_message` は bare-String の代わりに cap フラグを持つ `SlackFetchOutcome` を返す (盲点が #222 の根本原因)。
- `fetch_slack` は truncate を先に行い、cap note を frontmatter 直後の Markdown preamble として付与。100KB cut を生き残り、stdout 経路でも agent に届く (Finding A)。
- `DegradedReason` に Slack 用 3 variant を additive 追加。serde は skip-if-empty なので既存 JSON consumer に無影響。

## スコープ外 (follow-up)

- **no-author (SF-4)**: `Message` が subtype/bot_id を持たず bot の良性 no-author と異常を区別できないため誤検知回避で見送り。
- **resolution-failure の非対称性 (Finding B)**: `resolve_channel`/`fetch_user_name` 失敗は raw ID fallback + warn のみ。既知の制約として記録。

## テスト

- 新規 integration (`builder_tests.rs`): 各 cap の reason 発火、preamble 配置 (frontmatter 直後・reply separator 前)、2-note join、output truncation を跨いだ preamble 残存、cap 未到達の非 degraded、user cap 境界値 (==50 は非 degraded)。
- `http_tests.rs`: page cap 到達 (`thread_truncated`)・自然終了 (false-positive guard)・user cap 到達を強化。
- 全体: 513 + 11 テスト pass、`cargo fmt --check`・`cargo clippy --all-targets` clean。

## ドキュメント

ADR-0003 の running variant count を前例 (Note 2026-05-19) どおり日付付き Note で 9 → 12 に同期。`unwrap_or_degraded` 経由で meaningful label を持つのは 4 variants で不変 (Slack 3 variant は callsite 構築)。

## レビュー (Phase 7)

reviewer-rust + reviewer-coverage の medium screen で critical/high のコード欠陥なし。LOW idiom 2件 (healthy path の clone 回避 / clippy `items_after_statements`) と coverage gap 2件 (preamble 配置・page-cap 境界) を本 PR で解消済み。
