### PR TITLE
Slack mention の cache 未解決時に埋め込み label へフォールバックする

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -214,6 +214,10 @@ struct ResolvedMessage {
 /// A `<@UID>` or `<@UID|label>` mention span within a text.
 struct MentionSpan<'a> {
     user_id: &'a str,
+    /// Human-readable label Slack embedded as `<@UID|label>`, `None` when absent
+    /// or empty. Used as a best-effort render fallback when the user id is
+    /// unresolved; it is the send-time display name and may be stale.
+    label: Option<&'a str>,
     /// Byte range covering the entire `<@…>` token.
     start: usize,
     end: usize,
@@ -230,9 +234,13 @@ fn parse_mentions(text: &str) -> Vec<MentionSpan<'_>> {
         };
         let abs_end = after + rel_end + 1;
         let inner = &text[after..after + rel_end];
-        let user_id = inner.split('|').next().unwrap_or(inner);
+        let (user_id, label) = match inner.split_once('|') {
+            Some((id, label)) => (id, Some(label).filter(|l| !l.is_empty())),
+            None => (inner, None),
+        };
         spans.push(MentionSpan {
             user_id,
+            label,
             start: abs_start,
             end: abs_end,
         });
@@ -292,6 +300,8 @@ fn substitute_mentions(text: &str, cache: &HashMap<String, String>) -> String {
             cache
                 .get(span.user_id)
                 .map(String::as_str)
+                .filter(|name| !name.is_empty())
+                .or(span.label)
                 .unwrap_or(span.user_id),
         );
         pos = span.end;

--- a/src/slack/mention_tests.rs
+++ b/src/slack/mention_tests.rs
@@ -28,6 +28,32 @@ fn t003_pipe_label_extracts_user_id_only() {
     assert_eq!(spans[0].user_id, "U123");
 }
 
+/// [T-SK058] parse_mentions captures the embedded label from a pipe-labeled mention
+#[test]
+fn t003b_pipe_label_captured() {
+    let spans = parse_mentions("cc <@U123|alice>");
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].user_id, "U123");
+    assert_eq!(spans[0].label, Some("alice"));
+}
+
+/// [T-SK059] parse_mentions leaves label as None for a bare mention
+#[test]
+fn t003c_bare_mention_has_no_label() {
+    let spans = parse_mentions("hi <@U123>");
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].label, None);
+}
+
+/// [T-SK060] parse_mentions normalizes an empty label to None
+#[test]
+fn t003d_empty_label_normalized_to_none() {
+    let spans = parse_mentions("x <@U123|>");
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].user_id, "U123");
+    assert_eq!(spans[0].label, None);
+}
+
 /// [T-SK018] parse_mentions captures consecutive adjacent mentions
 #[test]
 fn t004_multiple_adjacent_mentions() {
@@ -102,4 +128,40 @@ fn t009b_pipe_label_substituted_with_display_name() {
     let cache: HashMap<String, String> = [("U123".into(), "Alice".into())].into_iter().collect();
     let result = substitute_mentions("cc <@U123|alice_handle>", &cache);
     assert_eq!(result, "cc @Alice");
+}
+
+/// [T-SK061] substitute_mentions falls back to embedded label when the user id
+/// is absent from the cache
+#[test]
+fn t025_cache_miss_renders_embedded_label() {
+    let cache: HashMap<String, String> = HashMap::new();
+    let result = substitute_mentions("cc <@U123|alice>", &cache);
+    assert_eq!(result, "cc @alice");
+}
+
+/// [T-SK062] substitute_mentions falls back to the raw user id when the cache
+/// misses and the embedded label is empty
+#[test]
+fn t026_cache_miss_empty_label_renders_user_id() {
+    let cache: HashMap<String, String> = HashMap::new();
+    let result = substitute_mentions("x <@U123|>", &cache);
+    assert_eq!(result, "x @U123");
+}
+
+/// [T-SK063] substitute_mentions treats an empty cache value as a miss and
+/// falls through to the embedded label
+#[test]
+fn t027_empty_cache_value_falls_through_to_label() {
+    let cache: HashMap<String, String> = [("U123".into(), String::new())].into_iter().collect();
+    let result = substitute_mentions("cc <@U123|alice>", &cache);
+    assert_eq!(result, "cc @alice");
+}
+
+/// [T-SK064] substitute_mentions prefers a resolved cache value over the
+/// embedded label
+#[test]
+fn t028_cache_hit_takes_priority_over_label() {
+    let cache: HashMap<String, String> = [("U123".into(), "Bob".into())].into_iter().collect();
+    let result = substitute_mentions("cc <@U123|alice>", &cache);
+    assert_eq!(result, "cc @Bob");
 }


### PR DESCRIPTION
## 概要と背景

Slack スレッド出力で `<@UID|label>` mention が user cache 未解決のとき、現状は raw user_id (`@UID`) を描画している。#188 の user lookup cap 導入で cache miss（raw-ID 描画）の頻度が上がり、可読性への影響が増した。Slack が payload に埋め込んだ人間可読 label へフォールバックし、cap 増加下でも可読性を保つ。label は同一トークン内に既存のため追加 fetch ゼロコスト。

## 変更点

- `MentionSpan` に `label: Option<&'a str>` を追加。`parse_mentions` が `split_once('|')` で `|` 後の label を捕捉し、空・不在は `None` に正規化。
- `substitute_mentions` のフォールバック連鎖を `cache.filter(非空) → label → user_id` に変更。cache hit を最優先し、cache miss・空 cache 値のとき label、label も無ければ raw user_id を描画。
- unit test 7件追加（T-SK058〜064）: label 捕捉・空 label 正規化・各フォールバック分岐・cache 優先。

## 対象外スコープ

- `client.rs` の `.or(real_name)` 空除外（author 経路の別問題）。空 user_id `<@|label>` ガード（pre-existing）。スレッド単位 uid→label 再利用（混在エンコード一貫性、best-effort で許容）。

## 設計判断

- 空文字正規化を parse 時に1回行い `Option<&str>` の Some を「非空 label」の型不変条件にした。cache 値の空は render-site の `.filter(非空)` で吸収し単一 chokepoint で閉じる。
- label fallback は best-effort: 送信時表示名で陳腐化しうる・同一 UID が混在エンコードで行ごとに異描画・同名 label が別 user 間で衝突しうる。権威的でないため cache hit を優先。

## テスト手順

1. `cargo test --lib slack::` → 63 passed（既存 T-SK015〜024 回帰なし + 新規 T-SK058〜064）
2. `cargo test` → 521 passed、`cargo clippy --all-targets` warning 0

## 関連

- Closes #223