### PR TITLE
Slack スレッド切り詰め時の not-found が exit 64 に誤分類される

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -54,10 +54,20 @@ impl SlackError {
             Self::InsecureUrl => Classification::new(ErrorCode::DataError),
             Self::Api { error } => match error.as_str() {
                 // Priority 3: NOT_FOUND. Underscore forms are Slack-native error
-                // codes; "message not found" (space) is scout's own string from
-                // `fetch_message` when the resolved messages list is empty.
-                "channel_not_found" | "message_not_found" | "thread_not_found"
-                | "message not found" => Classification::new(ErrorCode::NotFound),
+                // codes; the space forms are scout's own strings from
+                // `fetch_message`: bare "message not found" (resolved list empty)
+                // and "message {ts} not found in thread" (target absent or in a
+                // truncated page). The latter interpolates `{ts}`, so it can't be
+                // exact-matched — the `starts_with`/`contains` guard catches the
+                // whole "message … not found …" family (issue #224). Slack-native
+                // codes are snake_case and never start with "message " (space),
+                // so they fall through to their own arms below.
+                "channel_not_found" | "message_not_found" | "thread_not_found" => {
+                    Classification::new(ErrorCode::NotFound)
+                }
+                s if s.starts_with("message ") && s.contains("not found") => {
+                    Classification::new(ErrorCode::NotFound)
+                }
                 // Priority 4: TEMP_FAILURE
                 "internal_error" | "service_unavailable" | "fatal_error" => {
                     Classification::transient_retry()

--- a/src/slack/classify_tests.rs
+++ b/src/slack/classify_tests.rs
@@ -45,6 +45,21 @@ fn api_not_found_codes_classify_as_not_found() {
     }
 }
 
+/// [T-SLC010] scout's ts-bearing "message {ts} not found in thread" string
+/// (built at client.rs when `extract_target` misses — target absent or in a
+/// truncated page) classifies as NotFound, same as the bare "message not found"
+/// form. Guards issue #224: the interpolated `{ts}` made the old exact-match arm
+/// miss this string, dropping it to UsageError (exit 64) instead of NotFound
+/// (exit 66).
+#[test]
+fn api_not_found_in_thread_with_ts_classifies_as_not_found() {
+    let c = SlackError::Api {
+        error: "message 1700000000.123456 not found in thread".to_owned(),
+    }
+    .classify();
+    assert_eq!(c.kind, ErrorCode::NotFound);
+}
+
 /// [T-SLC004] Slack TEMP_FAILURE error codes classify as TempFailure
 /// (ADR-0003 — internal_error must not be misclassified as UsageError).
 #[test]


### PR DESCRIPTION
## 概要と理由

Slack スレッドが `conversations.replies` のページ上限（`SLACK_MAX_REPLY_PAGES`）で切り詰められ、対象 `ts` が切り詰められたページにある場合（または単純に不在の場合）、`fetch_message` が exit 64 (UsageError) を返していた。実態は「対象が見つからない／切り詰め」なので exit 66 (NotFound) が正しい。

根本は `classify()` が Slack の `Api { error }` 文字列を**完全一致**で分類していた点。`extract_target` ミス時に生成される `"message {ts} not found in thread"` は `{ts}` を補間するため完全一致アームに構造上ヒットせず、`_` → UsageError に落ちていた。

## 変更点

- `src/slack.rs` — `classify()` の NOT_FOUND アームを完全一致から `starts_with("message ") && contains("not found")` guard に変更。ts 付き `"message {ts} not found in thread"`（client.rs:466）と bare `"message not found"`（client.rs:414）の両 scout 文字列を捕捉。Slack ネイティブの snake_case コード（`message_not_found` 等）はスペース始まりでないため別アームへ素通り。
- `src/slack/classify_tests.rs` — `[T-SLC010]` 追加。ts 付き文字列 → NotFound を pin（既存 T-SLC003 は bare 形のみカバーで本ケースが抜けていた）。

## 設計判断

- issue の修正候補 A（文字列を bare に寄せる）/ B（接頭辞マッチ）/ C（専用 variant）から **B** を採用。A は最小だが `{ts}` 診断が消え、補間 not-found を将来書くと同じバグが再発する根本臭が残る。C は taxonomy 変更でコード量増。B は完全一致という根本の脆さを直接修正しつつ ts 診断を保持し、ADR-0011（priority mapping を pin、variant 集合は対象外）も変更不要。
- guard の誤爆リスクは Slack ネイティブコードが snake_case でスペース始まりが無い性質で排除（既存コメントが依拠する不変条件と同一）。

## テスト手順

1. `cargo test --lib slack::` → 64 件 pass（`[T-SLC010]` 含む）
2. `cargo test --lib` → 522 件 pass
3. `cargo fmt -- --check` / `cargo clippy --lib` → clean

## 関連

- Closes #224