### PR TITLE
テスト容易性: browser_binary_path を fetch_with_cdp に注入し OnceLock を除去 (#191 分割)

### DIFF
--- a/src/fetch/cdp.rs
+++ b/src/fetch/cdp.rs
@@ -9,6 +9,8 @@ mod launch;
 mod proxy;
 
 #[cfg(feature = "js-rendering")]
+use std::path::Path;
+#[cfg(feature = "js-rendering")]
 use std::sync::Arc;
 #[cfg(feature = "js-rendering")]
 use std::time::Duration;
@@ -94,16 +96,36 @@ impl Drop for AbortOnDrop {
     }
 }
 
+/// Resolve the browser binary, then render via CDP. Production entry: thin
+/// wrapper over `fetch_with_cdp_with`. Binary discovery runs per call (no
+/// process-global cache) so the path stays injectable for tests (issue #227,
+/// the #191 DI seam pattern). The discovery cost (a few `which` probes, ~1-5 ms)
+/// is negligible against the ~2 s chromium render that follows.
 #[cfg(feature = "js-rendering")]
 pub(super) async fn fetch_with_cdp(
     url: &ValidatedUrl,
     resolver: Arc<dyn ssrf::DnsResolver>,
     cancel: &watch::Sender<bool>,
 ) -> Result<String, BrowserError> {
+    let browser_path = resolve_browser_binary()?;
+    fetch_with_cdp_with(url, &browser_path, resolver, cancel).await
+}
+
+/// Render `url` with headless chromium at `browser_path` via CDP.
+///
+/// Seam for testing: the browser binary path is injected, so a test can drive
+/// the launch path with a bogus path (asserting `ProcessFailed`) without a real
+/// Chrome on the host. `fetch_with_cdp` is the production caller that resolves
+/// the path first.
+#[cfg(feature = "js-rendering")]
+pub(super) async fn fetch_with_cdp_with(
+    url: &ValidatedUrl,
+    browser_path: &Path,
+    resolver: Arc<dyn ssrf::DnsResolver>,
+    cancel: &watch::Sender<bool>,
+) -> Result<String, BrowserError> {
     use chromiumoxide::Browser;
     use futures::StreamExt;
-
-    let browser_path = resolve_browser_binary()?;
 
     // Launch the loopback SSRF proxy before chromium so its port can be wired
     // into the proxy flags. chromium routes every TCP egress through it and the
@@ -124,7 +146,7 @@ pub(super) async fn fetch_with_cdp(
     // `_profile_dir` guards the chromium `--user-data-dir`. Held until this
     // function returns — i.e. after every `reap_pgroup` path below — so its
     // `Drop` removes the dir only once chromium has exited (issue #198).
-    let (mut child, pgid, reader, _profile_dir) = spawn_chromium_pgroup(&browser_path, proxy_port)?;
+    let (mut child, pgid, reader, _profile_dir) = spawn_chromium_pgroup(browser_path, proxy_port)?;
 
     let ws_url = match timeout(CDP_TIMEOUT, parse_ws_url_from_lines(reader)).await {
         Ok(Ok(url)) => url,

--- a/src/fetch/cdp/cdp_integration_tests.rs
+++ b/src/fetch/cdp/cdp_integration_tests.rs
@@ -3,7 +3,7 @@ use crate::fetch::TokioDnsResolver;
 use std::collections::HashSet;
 use std::env::temp_dir;
 use std::fs::read_dir;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn chrome_available() -> bool {
     resolve_browser_binary().is_ok()
@@ -23,6 +23,38 @@ fn chromium_profile_dirs() -> HashSet<PathBuf> {
                 .is_some_and(|n| n.starts_with("scout-chromium-"))
         })
         .collect()
+}
+
+/// [T-F060] `fetch_with_cdp_with` honors the injected browser binary path.
+///
+/// Guards issue #227: the binary path is now an explicit parameter (no
+/// process-global `OnceLock` cache), so a test can drive the launch path
+/// without a real Chrome on the host. Injecting a path that is not an
+/// executable makes `spawn_chromium_pgroup` fail at spawn time, surfacing
+/// `BrowserError::ProcessFailed`. This exercises the seam (#191 DI pattern)
+/// host-independently — no Chrome required, unlike the Chrome-gated test below.
+#[tokio::test]
+async fn t007_fetch_with_cdp_with_injects_browser_path() {
+    let (cancel, _) = watch::channel(false);
+    let bogus = Path::new("/nonexistent/scout-test-no-such-chromium");
+    let err = fetch_with_cdp_with(
+        &ValidatedUrl::for_test("https://example.com"),
+        bogus,
+        Arc::new(TokioDnsResolver),
+        &cancel,
+    )
+    .await
+    .expect_err("spawning a nonexistent browser binary must fail");
+    // Pin the failure to the chromium spawn (launch.rs), not the SSRF proxy or
+    // profile-dir setup that also surface as `ProcessFailed` — otherwise the
+    // test could pass without the injected path being the cause.
+    let BrowserError::ProcessFailed(msg) = &err else {
+        panic!("expected ProcessFailed for a nonexistent binary, got {err:?}");
+    };
+    assert!(
+        msg.contains("spawn chromium"),
+        "failure must come from spawning the injected binary, got {msg:?}"
+    );
 }
 
 /// [T-F051] cdp renders public url + [T-F057] cdp removes profile dir after fetch

--- a/src/fetch/cdp/launch.rs
+++ b/src/fetch/cdp/launch.rs
@@ -6,8 +6,6 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 #[cfg(feature = "js-rendering")]
-use std::sync::OnceLock;
-#[cfg(feature = "js-rendering")]
 use std::time::Duration;
 #[cfg(feature = "js-rendering")]
 use tempfile::{Builder, TempDir};
@@ -22,33 +20,32 @@ use tracing::warn;
 use super::BrowserError;
 use crate::fetch::ssrf::{self, RedactedLogUrl};
 
+/// Discover the chromium/Chrome binary by probing `PATH` then known install
+/// locations. Called once per `--js` fetch (issue #227 removed the prior
+/// process-global `OnceLock` cache, which broke test isolation and pinned the
+/// first result for the process lifetime); the few `which` probes cost ~1-5 ms,
+/// negligible against the ~2 s chromium render that follows.
 #[cfg(feature = "js-rendering")]
 pub(super) fn resolve_browser_binary() -> Result<PathBuf, BrowserError> {
-    static CACHE: OnceLock<Result<PathBuf, String>> = OnceLock::new();
-
-    let cached = CACHE.get_or_init(|| {
-        let path_commands: &[&str] = if cfg!(target_os = "macos") {
-            &["chromium"]
-        } else {
-            &[
-                "google-chrome-stable",
-                "google-chrome",
-                "chromium-browser",
-                "chromium",
-            ]
-        };
-        let known_paths: &[&Path] = if cfg!(target_os = "macos") {
-            &[
-                Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
-                Path::new("/Applications/Chromium.app/Contents/MacOS/Chromium"),
-            ]
-        } else {
-            &[]
-        };
-        resolve_browser_binary_from(path_commands, known_paths).map_err(|e| e.to_string())
-    });
-
-    cached.clone().map_err(|_| BrowserError::NotFound)
+    let path_commands: &[&str] = if cfg!(target_os = "macos") {
+        &["chromium"]
+    } else {
+        &[
+            "google-chrome-stable",
+            "google-chrome",
+            "chromium-browser",
+            "chromium",
+        ]
+    };
+    let known_paths: &[&Path] = if cfg!(target_os = "macos") {
+        &[
+            Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+            Path::new("/Applications/Chromium.app/Contents/MacOS/Chromium"),
+        ]
+    } else {
+        &[]
+    };
+    resolve_browser_binary_from(path_commands, known_paths)
 }
 
 /// See spec.md Chrome Launch Flags table for rationale.

--- a/src/fetch/cdp/launch.rs
+++ b/src/fetch/cdp/launch.rs
@@ -27,24 +27,29 @@ use crate::fetch::ssrf::{self, RedactedLogUrl};
 /// negligible against the ~2 s chromium render that follows.
 #[cfg(feature = "js-rendering")]
 pub(super) fn resolve_browser_binary() -> Result<PathBuf, BrowserError> {
-    let path_commands: &[&str] = if cfg!(target_os = "macos") {
-        &["chromium"]
-    } else {
-        &[
-            "google-chrome-stable",
-            "google-chrome",
-            "chromium-browser",
-            "chromium",
-        ]
-    };
-    let known_paths: &[&Path] = if cfg!(target_os = "macos") {
-        &[
-            Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
-            Path::new("/Applications/Chromium.app/Contents/MacOS/Chromium"),
-        ]
-    } else {
-        &[]
-    };
+    // Compile-time `#[cfg]` (not runtime `cfg!`) so each platform's table is the
+    // only one compiled: the other OS's lines never enter `cargo llvm-cov`, so
+    // the diff-coverage gate does not flag the macOS table as uncovered on the
+    // Linux CI runner (where it is unreachable). Mirrors transport.rs's exclusion
+    // of OS-I/O that the offline suite cannot exercise.
+    #[cfg(target_os = "macos")]
+    let path_commands: &[&str] = &["chromium"];
+    #[cfg(not(target_os = "macos"))]
+    let path_commands: &[&str] = &[
+        "google-chrome-stable",
+        "google-chrome",
+        "chromium-browser",
+        "chromium",
+    ];
+
+    #[cfg(target_os = "macos")]
+    let known_paths: &[&Path] = &[
+        Path::new("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+        Path::new("/Applications/Chromium.app/Contents/MacOS/Chromium"),
+    ];
+    #[cfg(not(target_os = "macos"))]
+    let known_paths: &[&Path] = &[];
+
     resolve_browser_binary_from(path_commands, known_paths)
 }
 


### PR DESCRIPTION
## 概要と理由

`resolve_browser_binary()` の `OnceLock` プロセスグローバルキャッシュが、最初の解決結果をプロセス寿命の間 pin してしまい、テスト分離を壊していた。ブラウザバイナリパスを注入可能にし、キャッシュを除去する (#191 の DI seam 横展開)。

## 変更点

- `fetch_with_cdp_with(url, browser_path, resolver, cancel)` を新設し、レンダリング本体を保持
- `fetch_with_cdp` はバイナリを per-call で解決して委譲する薄いラッパーに
- `resolve_browser_binary()` から `OnceLock` キャッシュを除去 (`which` 探索は ~1-5ms、~2s の chromium レンダリングに対し無視できる)
- `[T-F060]` 追加: bogus パス注入で seam を host-independent に検証

## 設計判断

- **Design D を採用**: `fetch_page` 上流からパスを通す案 (Design C) は、js-rendering 非依存の汎用エントリに CDP の関心を漏らす (leaky-abstraction) ため却下。seam で本体を保持し、production ラッパーが解決を担う構成にした
- **`OnceLock` 除去の代償**: per-call `which` 解決が増えるが、レンダリングコストに対し無視できるためキャッシュは復活させない

## テスト手順

```
cargo test --features js-rendering --offline cdp   # 29 passed
cargo clippy --features js-rendering --offline      # clean
cargo clippy --offline                              # clean (default build)
cargo fmt -- --check                                # clean
```

`[T-F060]` は失敗源を `"spawn chromium"` メッセージで pin し、proxy-spawn の `ProcessFailed` で誤って green にならないことを保証。

## 関連

Closes #227 (#191 分割)