### PR TITLE
drive() seam 抽出で signal→exit code 経路を unit test 可能にする (#228)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use clap::Parser;
 use envelope::{CommandOutput, ErrorCode, ErrorEnvelope, ErrorPayload, to_json_line};
 use signals::{InterruptSignal, wait_for_signal};
+use tokio::sync::watch;
 use tokio::time::timeout;
 use tools::{Command, Scout, ScoutError};
 
@@ -115,6 +116,40 @@ fn init_tracing() {
         .try_init();
 }
 
+/// Race the in-flight command against signal arrival, returning the resulting
+/// `Outcome`. On interrupt, notify the cancel handle so `fetch_with_cdp` can run
+/// `browser.close()` (issue #121), then await the command for a bounded window
+/// before returning the interrupt outcome.
+///
+/// Extracted from `run` with the signal source injected so the
+/// signal-vs-command wiring (select → cancel notify → drain → `Interrupted`) is
+/// unit-testable without spawning the real OS signal handlers (issue #228).
+async fn drive<C, S>(
+    cmd_fut: C,
+    signal_fut: S,
+    cancel: &watch::Sender<bool>,
+) -> Outcome<Result<CommandOutput, ScoutError>>
+where
+    C: Future<Output = Result<CommandOutput, ScoutError>>,
+    S: Future<Output = InterruptSignal>,
+{
+    tokio::pin!(cmd_fut);
+    tokio::select! {
+        res = &mut cmd_fut => Outcome::Completed(res),
+        sig = signal_fut => {
+            tracing::info!(signal = %sig, "interrupted, draining for graceful close");
+            let _ = cancel.send(true);
+            if timeout(SHUTDOWN_DRAIN_TIMEOUT, &mut cmd_fut).await.is_err() {
+                tracing::warn!(
+                    timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
+                    "drain timed out; in-flight command was dropped before completion"
+                );
+            }
+            Outcome::Interrupted(sig)
+        }
+    }
+}
+
 pub async fn run() -> ExitCode {
     init_tracing();
 
@@ -133,28 +168,7 @@ pub async fn run() -> ExitCode {
         Err(e) => return emit_error(&e, json_mode),
     };
     let cancel = scout.cancel_handle();
-
-    let cmd_fut = scout.run(cli.command);
-    tokio::pin!(cmd_fut);
-
-    // Race the in-flight command against signal arrival. On interrupt,
-    // notify the cancel handle so fetch_with_cdp can run `browser.close()`
-    // (issue #121) and then await the command for a bounded window before
-    // returning the interrupt exit code.
-    let outcome: Outcome<Result<CommandOutput, ScoutError>> = tokio::select! {
-        res = &mut cmd_fut => Outcome::Completed(res),
-        sig = wait_for_signal() => {
-            tracing::info!(signal = %sig, "interrupted, draining for graceful close");
-            let _ = cancel.send(true);
-            if timeout(SHUTDOWN_DRAIN_TIMEOUT, &mut cmd_fut).await.is_err() {
-                tracing::warn!(
-                    timeout_secs = SHUTDOWN_DRAIN_TIMEOUT.as_secs(),
-                    "drain timed out; in-flight command was dropped before completion"
-                );
-            }
-            Outcome::Interrupted(sig)
-        }
-    };
+    let outcome = drive(scout.run(cli.command), wait_for_signal(), &cancel).await;
     match outcome {
         Outcome::Completed(Ok(output)) => {
             let rendered = if json_mode {
@@ -245,11 +259,74 @@ fn emit_error(err: &ScoutError, json_mode: bool) -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::future::{pending, ready};
     use std::io::{self, Write};
 
     use clap::CommandFactory;
+    use tokio::sync::watch;
 
-    use super::{CommandOutput, init_tracing, render_json_success, write_output};
+    use super::{
+        CommandOutput, InterruptSignal, Outcome, ScoutError, drive, init_tracing,
+        render_json_success, write_output,
+    };
+
+    /// [T-DRV001] drive returns `Interrupted` carrying the firing signal, and that
+    /// signal maps to its POSIX exit code, when the signal future resolves before
+    /// the command. This is the issue #228 acceptance criterion: the
+    /// signal → exit code wiring is exercised without the real OS signal handler.
+    /// `start_paused` auto-advances the 7s drain timer so the pending command does
+    /// not block for wall-clock time.
+    #[tokio::test(start_paused = true)]
+    async fn drive_interrupt_yields_signal_exit_code() {
+        let (cancel, _rx) = watch::channel(false);
+        let outcome = drive(
+            pending::<Result<CommandOutput, ScoutError>>(),
+            ready(InterruptSignal::Sigint),
+            &cancel,
+        )
+        .await;
+        let code = match outcome {
+            Outcome::Interrupted(sig) => sig.exit_code(),
+            Outcome::Completed(_) => panic!("expected interrupt, command never completes"),
+        };
+        assert_eq!(code, 130);
+    }
+
+    /// [T-DRV002] On interrupt, drive notifies the cancel handle so `fetch_with_cdp`
+    /// can run `browser.close()` for graceful shutdown (issue #121).
+    #[tokio::test(start_paused = true)]
+    async fn drive_interrupt_notifies_cancel_handle() {
+        let (cancel, rx) = watch::channel(false);
+        let _ = drive(
+            pending::<Result<CommandOutput, ScoutError>>(),
+            ready(InterruptSignal::Sigint),
+            &cancel,
+        )
+        .await;
+        assert!(
+            *rx.borrow(),
+            "cancel handle must be notified so CDP can close gracefully"
+        );
+    }
+
+    /// [T-DRV003] When the command completes before any signal, drive returns
+    /// `Completed` and leaves the cancel handle untouched (no spurious shutdown).
+    #[tokio::test]
+    async fn drive_command_completion_wins_over_pending_signal() {
+        let (cancel, rx) = watch::channel(false);
+        let output = CommandOutput::ok(String::from("hi"), serde_json::json!({"markdown": "hi"}));
+        let outcome = drive(
+            ready(Ok::<_, ScoutError>(output)),
+            pending::<InterruptSignal>(),
+            &cancel,
+        )
+        .await;
+        assert!(matches!(outcome, Outcome::Completed(Ok(_))));
+        assert!(
+            !*rx.borrow(),
+            "cancel must not fire when the command completes normally"
+        );
+    }
 
     /// [T-RJS001] render_json_success serializes a `CommandOutput` as a one-line
     /// success envelope per ADR-0010: `data` payload preserved, `degraded:false`,


### PR DESCRIPTION
## 背景

signal 受信 → `Outcome::Interrupted` → exit code の経路は integration test でしか検証できず、unit 被覆ゼロだった (#228)。`run()` が `wait_for_signal()` を直接参照しゼロパラメタだったのが原因。

## 変更

`run()` の `tokio::select!` + drain ブロックを内部ヘルパ `drive(cmd_fut, signal_fut, cancel)` に抽出し、signal source を引数で注入可能にした。ロジックは元と同一(挙動保存)。`run()` はゼロ引数公開シグネチャを維持するため `main.rs` は無改修。

注入範囲は受入条件が要求する signal 経路のみ。args/output 注入は対応する受入条件が無いため YAGNI で除外(/build 中に確認)。

## テスト

| ID | 検証 |
| --- | --- |
| T-DRV001 | interrupt → signal の exit code (SIGINT=130)。#228 受入条件「signal → exit code 経路の unit test」 |
| T-DRV002 | interrupt → cancel handle 通知 (#121 graceful close) |
| T-DRV003 | command 完了が pending signal に優先 |

`start_paused` で 7s drain タイマを自動進行させ wall-clock ブロックを回避。

## 検証

- `cargo test`: lib 525 + integration 11 + 新規 3 すべて緑
- `cargo clippy --all-targets` / `cargo fmt -- --check`: clean

## レビュー観点

`drive()` は元の select ブロックと論理同一の extract-function。`wait_for_signal()` を引数に置換した点と、3 テストが両 select arm + drain + cancel を踏んでいるかを確認してほしい。

## 補足

SIGTERM(143) の drive 直接テストは追加していない。`drive()` は signal 変種で分岐せず `sig` を透過するため、Sigterm 版は tautological で増分被覆ゼロ(/challenge で NO-GO 判定)。SIGTERM の exit code は既存 T-S002 が立証済み。

Closes #228