### PR TITLE
base64 改行除去の全コピー受容を根拠付きで記録

### DIFF
--- a/src/github/encoding.rs
+++ b/src/github/encoding.rs
@@ -36,6 +36,12 @@ pub(crate) struct DecodeResult {
 /// This is the first half of the old `decode_content`: base64 → bytes.
 /// Encoding detection is handled separately by `decode_bytes`.
 pub(super) fn decode_base64(encoded: &str) -> Result<Vec<u8>, GitHubError> {
+    // GitHub wraps base64 at 60 chars, but base64 v0.22 has no whitespace-tolerant
+    // decode (GeneralPurposeConfig exposes only padding/trailing-bit options), so the
+    // newlines must be stripped into a contiguous buffer first. This transient copy is
+    // accepted over a streaming DecoderReader: decode_base64 runs once per file fetch
+    // (network-bound, not a hot path despite the #190 lineage) and `clean` is freed
+    // immediately after decode. See #233.
     let clean: String = encoded.chars().filter(|c| !c.is_whitespace()).collect();
     STANDARD
         .decode(&clean)


### PR DESCRIPTION
## 概要

#233（研究タスク）の結論を記録。base64 デコード前の whitespace 除去で payload を `String` に全コピーしている件を調査し、コピー受容を `decode_base64` のコメントに残した。

## 調査結果

- whitespace 寛容デコード: base64 v0.22.1 では不可能。`GeneralPurposeConfig` の builder は padding 系3つのみで whitespace オプションが無い（一次ソース確認済み）
- 全コピー回避: `DecoderReader` で技術的には可能。ただし `decode_base64` は per-fetch 1回・ネットワークバウンドで、`clean` はデコード直後に解放される一過性バッファ。streaming 化の恒久的複雑性に見合わず受容

## 変更

| ファイル | 変更 |
| --- | --- |
| `src/github/encoding.rs` | 受容根拠を6行コメントで追加（ロジック変更なし） |

## テスト

`cargo test --lib github::encoding` で 15 tests pass（[T-GE013] whitespace 除去含む、緑のまま）。`cargo fmt -- --check` OK。

Closes #233