### PR TITLE
feat(fetch): SOCKS5 ハンドシェイク読み取りに timeout を追加 (#237)

### DIFF
--- a/src/fetch/cdp/proxy.rs
+++ b/src/fetch/cdp/proxy.rs
@@ -21,9 +21,11 @@
 
 use std::io;
 use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tracing::warn;
+use tokio::time::timeout;
+use tracing::{debug, warn};
 
 use crate::fetch::ssrf::{DnsResolver, is_private_ip};
 
@@ -33,6 +35,13 @@ mod transport;
 
 #[cfg_attr(not(feature = "js-rendering"), allow(unused_imports))]
 pub(in crate::fetch::cdp) use transport::spawn_ssrf_proxy;
+
+/// Cap the SOCKS5 handshake/request read so a client that connects but stalls
+/// mid-greeting (sends nothing, or only part of the request) cannot pin its
+/// handler task on `read_exact` indefinitely. chromium completes the handshake
+/// in microseconds; this only bounds a misbehaving same-host peer (the proxy
+/// listens on `127.0.0.1`). Mirrors `UPSTREAM_DIAL_TIMEOUT`'s 10s.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 // SOCKS5 wire constants (RFC 1928).
 const SOCKS5_VERSION: u8 = 0x05;
@@ -67,48 +76,21 @@ async fn handle_conn<S>(mut stream: S, resolver: &dyn DnsResolver) -> io::Result
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    // 1. Greeting: [VER, NMETHODS, METHODS..]. Reply no-auth.
-    let mut head = [0u8; 2];
-    stream.read_exact(&mut head).await?;
-    if head[0] != SOCKS5_VERSION {
-        return Ok(()); // not SOCKS5: drop without reply
-    }
-    let mut methods = vec![0u8; usize::from(head[1])];
-    stream.read_exact(&mut methods).await?;
-    stream.write_all(&[SOCKS5_VERSION, METHOD_NO_AUTH]).await?;
-
-    // 2. Request: [VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT(2 BE)].
-    let mut req = [0u8; 4];
-    stream.read_exact(&mut req).await?;
-    if req[0] != SOCKS5_VERSION {
-        return Ok(());
-    }
-    if req[1] != CMD_CONNECT {
-        return send_reply(&mut stream, REP_CMD_NOT_SUPPORTED).await;
-    }
-    let target = match req[3] {
-        ATYP_IPV4 => {
-            let mut a = [0u8; 4];
-            stream.read_exact(&mut a).await?;
-            Target::Ip(IpAddr::from(a))
+    // 1-2. Read and parse the greeting + CONNECT request under a single deadline.
+    //      Every `read_exact` here reads client bytes, so a peer that connects but
+    //      stalls cannot pin the task; on timeout the future drops (freeing the
+    //      borrow of `stream`) and the connection closes with no reply. The dial
+    //      and tunnel that follow have their own bounds and legitimately run long,
+    //      so they stay outside this timeout.
+    let (target, port) = match timeout(HANDSHAKE_TIMEOUT, read_request(&mut stream)).await {
+        Ok(Ok(Some(parsed))) => parsed,
+        Ok(Ok(None)) => return Ok(()), // dropped or replied mid-parse
+        Ok(Err(e)) => return Err(e),
+        Err(_elapsed) => {
+            debug!("SOCKS5 handshake timed out");
+            return Ok(());
         }
-        ATYP_IPV6 => {
-            let mut a = [0u8; 16];
-            stream.read_exact(&mut a).await?;
-            Target::Ip(IpAddr::from(a))
-        }
-        ATYP_DOMAIN => {
-            let mut len = [0u8; 1];
-            stream.read_exact(&mut len).await?;
-            let mut name = vec![0u8; usize::from(len[0])];
-            stream.read_exact(&mut name).await?;
-            Target::Domain(String::from_utf8_lossy(&name).into_owned())
-        }
-        _ => return send_reply(&mut stream, REP_ADDR_NOT_SUPPORTED).await,
     };
-    let mut port_buf = [0u8; 2];
-    stream.read_exact(&mut port_buf).await?;
-    let port = u16::from_be_bytes(port_buf);
 
     // 3. Resolve the target to the IPs that will actually be dialed.
     let (host_label, ips): (String, Vec<IpAddr>) = match target {
@@ -128,6 +110,64 @@ where
     //    private-IP check, so there is no unvalidated happy-eyeballs fallback.
     let dial_addr = SocketAddr::new(ips[0], port);
     transport::dial_and_tunnel(&mut stream, dial_addr).await
+}
+
+/// Read the SOCKS5 greeting and CONNECT request, returning the parsed target and
+/// port. `Ok(None)` means the handshake was terminated in-band (a non-SOCKS5
+/// version dropped without reply, or a mid-parse rejection reply was sent), so
+/// the caller has nothing further to do. Split out of `handle_conn` so the whole
+/// client-read span sits behind one `HANDSHAKE_TIMEOUT`.
+async fn read_request<S>(stream: &mut S) -> io::Result<Option<(Target, u16)>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    // Greeting: [VER, NMETHODS, METHODS..]. Reply no-auth.
+    let mut head = [0u8; 2];
+    stream.read_exact(&mut head).await?;
+    if head[0] != SOCKS5_VERSION {
+        return Ok(None); // not SOCKS5: drop without reply
+    }
+    let mut methods = vec![0u8; usize::from(head[1])];
+    stream.read_exact(&mut methods).await?;
+    stream.write_all(&[SOCKS5_VERSION, METHOD_NO_AUTH]).await?;
+
+    // Request: [VER, CMD, RSV, ATYP, DST.ADDR, DST.PORT(2 BE)].
+    let mut req = [0u8; 4];
+    stream.read_exact(&mut req).await?;
+    if req[0] != SOCKS5_VERSION {
+        return Ok(None);
+    }
+    if req[1] != CMD_CONNECT {
+        send_reply(stream, REP_CMD_NOT_SUPPORTED).await?;
+        return Ok(None);
+    }
+    let target = match req[3] {
+        ATYP_IPV4 => {
+            let mut a = [0u8; 4];
+            stream.read_exact(&mut a).await?;
+            Target::Ip(IpAddr::from(a))
+        }
+        ATYP_IPV6 => {
+            let mut a = [0u8; 16];
+            stream.read_exact(&mut a).await?;
+            Target::Ip(IpAddr::from(a))
+        }
+        ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await?;
+            let mut name = vec![0u8; usize::from(len[0])];
+            stream.read_exact(&mut name).await?;
+            Target::Domain(String::from_utf8_lossy(&name).into_owned())
+        }
+        _ => {
+            send_reply(stream, REP_ADDR_NOT_SUPPORTED).await?;
+            return Ok(None);
+        }
+    };
+    let mut port_buf = [0u8; 2];
+    stream.read_exact(&mut port_buf).await?;
+    let port = u16::from_be_bytes(port_buf);
+    Ok(Some((target, port)))
 }
 
 /// Fail-closed validation mirroring `SsrfResolver`: returns `true` only when

--- a/src/fetch/cdp/proxy/proxy_tests.rs
+++ b/src/fetch/cdp/proxy/proxy_tests.rs
@@ -6,7 +6,7 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 use tokio::task::yield_now;
@@ -288,5 +288,60 @@ async fn t201_14_abrupt_client_disconnect_is_logged_not_fatal() {
     assert!(
         logs_contain("SOCKS5 proxy connection ended with error"),
         "an abrupt disconnect must be logged at the accept loop"
+    );
+}
+
+/// T-201-15: a client that connects but sends no SOCKS5 bytes is closed after
+/// `HANDSHAKE_TIMEOUT` with no reply, rather than pinning its handler on the
+/// first `read_exact` forever. Driven over an in-memory `duplex` under a paused
+/// clock so the timeout fires in virtual time with no real wait and no socket
+/// reactor I/O (the module is generic over the stream precisely for this).
+#[tokio::test(start_paused = true)]
+#[traced_test]
+async fn t201_15_no_handshake_bytes_times_out_and_closes() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let (mut client, server) = duplex(64);
+
+    // Send nothing: handle_conn hangs on the greeting read until the deadline.
+    let result = handle_conn(server, resolver.as_ref()).await;
+
+    assert!(
+        result.is_ok(),
+        "handshake timeout closes cleanly, not as Err"
+    );
+    assert!(
+        logs_contain("SOCKS5 handshake timed out"),
+        "the timeout path must log its reason"
+    );
+    let mut reply = Vec::new();
+    client.read_to_end(&mut reply).await.unwrap();
+    assert!(reply.is_empty(), "no reply on handshake timeout");
+}
+
+/// T-201-16: a client that sends only the greeting and then stalls before the
+/// request is closed after `HANDSHAKE_TIMEOUT`. The deadline spans both read
+/// stages, so the stall on the request `read_exact` (a different hang point than
+/// T-201-15) is bounded too; only the greeting's method reply was written back.
+#[tokio::test(start_paused = true)]
+#[traced_test]
+async fn t201_16_partial_handshake_times_out_after_method_reply() {
+    let resolver = Arc::new(StaticDnsResolver::single("93.184.216.34"));
+    let (mut client, server) = duplex(64);
+
+    // Greeting only: handle_conn replies no-auth, then hangs on the request read.
+    client.write_all(&GREETING).await.unwrap();
+    let result = handle_conn(server, resolver.as_ref()).await;
+
+    assert!(
+        result.is_ok(),
+        "handshake timeout closes cleanly, not as Err"
+    );
+    assert!(logs_contain("SOCKS5 handshake timed out"));
+    let mut reply = Vec::new();
+    client.read_to_end(&mut reply).await.unwrap();
+    assert_eq!(
+        reply,
+        vec![0x05, 0x00],
+        "only the greeting method reply precedes the timeout"
     );
 }


### PR DESCRIPTION
## 概要

SOCKS5 proxy の greeting/request 読み取り (`handle_conn` の `read_exact` 連鎖) に read timeout がなく、`127.0.0.1` のループバック proxy へ接続したまま SOCKS5 バイトを送らない/部分的にしか送らない同一ホスト peer が、spawn されたハンドラタスクを `read_exact` で無限に占有できた。本 PR はこの穴を塞ぐ (#201 follow-up)。

## 変更

- `HANDSHAKE_TIMEOUT` (10s) を追加し、greeting + CONNECT request の読み取り span 全体を `tokio::time::timeout` で囲んだ。timeout 時は応答せず drop して接続を閉じる。
- client-read span を `read_request` に抽出 (挙動保存)。これにより parse 全体を 1 つの deadline 下に置ける。
- dial/tunnel は独自の境界 (`UPSTREAM_DIAL_TIMEOUT`) を持ち正当に長く走るため、この timeout の外に残した。

## 受け入れ基準

- AC1: stall した client が一定時間後に閉じることを確認する offline unit test を追加。
  - T-201-15: handshake バイトを一切送らない → timeout で clean close、応答なし。
  - T-201-16: greeting のみ送り request を送らない → method reply (`0x05 0x00`) 後に timeout。
  - 仮想時間 (`#[tokio::test(start_paused = true)]` + `tokio::io::duplex`) で実時間待ち・socket reactor flakiness なく検証。chromium 不要・js-rendering feature 無し。
- AC2: 既存 proxy 6 テストを含む全 proxy テストが pass。

## 検証

- 全 lib テスト (527) + proxy テスト (14) pass
- `cargo fmt -- --check` / `cargo clippy` clean
- js-rendering feature compile 確認
- diff-cover gate: `src/fetch/cdp/proxy.rs` 100%

Closes #237