### PR TITLE
chore(release): バージョンを 2.2.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scout"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "chardetng 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scout"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 rust-version = "1.95"
 description = "CLI tool for web search (Brave Search), page fetching, and GitHub repository exploration"


### PR DESCRIPTION
## 概要

v2.1.0 以降に蓄積した変更を 2.2.0 としてリリースするためのバージョン bump。

## 変更内容

- `Cargo.toml` / `Cargo.lock` の version を 2.1.0 → 2.2.0

## v2.1.0 以降の主な変更

- feat: fetch の charset 解読不能を degraded シグナル化、SOCKS5 ハンドシェイクのタイムアウト境界、Slack の degradation channel 接続と mention ラベルフォールバック、silent failure への構造化トレーシング
- fix(security 含む): SSRF DNS-rebind の connect 時 IP ガード、出力の URL スキーム/YAML マーカーエスケープ、GitHub API レスポンスのバイト上限、gzip デコード有効化、retry backoff キャップ
- refactor/chore: 過大モジュール分割、error envelope 統合、Renovate 移行、diff coverage gate 追加

## リリース手順

マージ後、main 上で `v2.2.0` タグを push するとリリースワークフローが起動する。